### PR TITLE
Configuration parameters are sometimes split incorrectly when deploying.

### DIFF
--- a/kubectl-cloudflow/deploy/deploy.go
+++ b/kubectl-cloudflow/deploy/deploy.go
@@ -130,7 +130,7 @@ func AppendExistingValuesNotConfigured(client *kubernetes.Clientset, spec domain
 			for _, configValue := range secret.Data {
 				lines := strings.Split(string(configValue), "\r\n")
 				for _, line := range lines {
-					cleaned := strings.TrimPrefix(strings.TrimSpace(line), "pipelines.streamlets.")
+					cleaned := strings.TrimPrefix(strings.TrimSpace(line), "cloudflow.streamlets.")
 					if len(cleaned) != 0 {
 						keyValueArray, err := splitOnFirstCharacter(cleaned, '=')
 						if err != nil {

--- a/kubectl-cloudflow/deploy/deploy.go
+++ b/kubectl-cloudflow/deploy/deploy.go
@@ -96,15 +96,28 @@ func GetCloudflowApplicationDescriptorFromDockerImage(dockerRegistryURL string, 
 	return spec, *pulledImage
 }
 
+func splitOnFirstCharacter(str string, char byte) ([]string, error) {
+	var arr []string
+	if idx := strings.IndexByte(str, char); idx >= 0 {
+		arr = append(arr, str[:idx])
+		arr = append(arr, strings.Trim(str[idx+1:], "\""))
+		return arr, nil
+	}
+	return arr, fmt.Errorf("The configuration parameters must be formated as space delimited '[streamlet-name[.[property]=[value]' pairs")
+}
+
 // SplitConfigurationParameters maps string representations of a key/value pair into a map
 func SplitConfigurationParameters(configurationParameters []string) map[string]string {
 	configurationKeyValues := make(map[string]string)
+
 	for _, v := range configurationParameters {
-		keyValueArray := strings.Split(v, "=")
-		if len(keyValueArray) != 2 {
-			util.LogAndExit("The configuration parameters must be formated as space delimited '[streamlet-name[.[property]=[value]' pairs.")
+		keyValueArray, err := splitOnFirstCharacter(v, '=')
+		if err != nil {
+			util.LogAndExit(err.Error())
+		} else {
+			configurationKeyValues[keyValueArray[0]] = keyValueArray[1]
+
 		}
-		configurationKeyValues[keyValueArray[0]] = strings.Trim(keyValueArray[1], "\"")
 	}
 	return configurationKeyValues
 }
@@ -117,13 +130,14 @@ func AppendExistingValuesNotConfigured(client *kubernetes.Clientset, spec domain
 			for _, configValue := range secret.Data {
 				lines := strings.Split(string(configValue), "\r\n")
 				for _, line := range lines {
-					cleaned := strings.TrimPrefix(strings.TrimSpace(line), "cloudflow.streamlets.")
+					cleaned := strings.TrimPrefix(strings.TrimSpace(line), "pipelines.streamlets.")
 					if len(cleaned) != 0 {
-						keyValueArray := strings.Split(cleaned, "=")
-						if len(keyValueArray) != 2 {
-							util.LogAndExit("Configuration for streamlet %s in secret %s is corrupted.", deployment.StreamletName, secret.Name)
+						keyValueArray, err := splitOnFirstCharacter(cleaned, '=')
+						if err != nil {
+							util.LogAndExit("Configuration for streamlet %s in secret %s is corrupted. %s", deployment.StreamletName, secret.Name, err.Error())
+						} else {
+							existingConfigurationKeyValues[keyValueArray[0]] = keyValueArray[1]
 						}
-						existingConfigurationKeyValues[keyValueArray[0]] = strings.Trim(keyValueArray[1], "\"")
 					}
 				}
 			}

--- a/kubectl-cloudflow/deploy/deploy_test.go
+++ b/kubectl-cloudflow/deploy/deploy_test.go
@@ -29,13 +29,21 @@ func commandLineForConfiguration() []string {
 }
 
 func Test_SplitConfigurationParameters(t *testing.T) {
-
-	result := SplitConfigurationParameters([]string{`a="b"`, "key=ddd", `some.key="some, value"`})
+	result := SplitConfigurationParameters([]string{
+		`a="b"`,
+		"key=ddd",
+		`some.key="some, value"`,
+		`some.key2=c29tZSBzdHJpbmc9PQ==`,
+		`some.key3="some text passed to a streamlet"`,
+		`some.key4=post Cobra processed, unquoted string`})
 
 	assert.NotEmpty(t, result)
-	assert.Equal(t, result["a"], `b`)
+	assert.Equal(t, result["a"], "b")
 	assert.Equal(t, result["key"], "ddd")
-	assert.Equal(t, result["some.key"], `some, value`)
+	assert.Equal(t, result["some.key"], "some, value")
+	assert.Equal(t, result["some.key2"], "c29tZSBzdHJpbmc9PQ==")
+	assert.Equal(t, result["some.key3"], "some text passed to a streamlet")
+	assert.Equal(t, result["some.key4"], "post Cobra processed, unquoted string")
 
 	empty := SplitConfigurationParameters([]string{})
 	assert.Empty(t, empty)


### PR DESCRIPTION
Fixes splitting of configuration parameters key/value pairs when the key contains equals sign, for example, padding in a base64 encoded string.