### PR TITLE
Fix the detect.sh path in the GKE uninstaller

### DIFF
--- a/installer/uninstall-cloudflow.sh
+++ b/installer/uninstall-cloudflow.sh
@@ -25,7 +25,7 @@ fi
 
 
 # shellcheck source=common/detect.sh
-. common/utils.sh
+. common/detect.sh
 
 echo "This script will remove all Cloudflow related objects from the Kubernetes cluster currently logged in to"
 read -p "Do you want to continue ? (y/n) " -n 1 -r

--- a/installer/uninstall-cloudflow.sh
+++ b/installer/uninstall-cloudflow.sh
@@ -25,7 +25,7 @@ fi
 
 
 # shellcheck source=common/detect.sh
-source "$currentDirectory"/detect.sh
+. common/utils.sh
 
 echo "This script will remove all Cloudflow related objects from the Kubernetes cluster currently logged in to"
 read -p "Do you want to continue ? (y/n) " -n 1 -r


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update the path to `detect.sh`

### Why are the changes needed?
When using the Cloudflow GKE uninstaller, an error was thrown because of an incorrect path to the `detect.sh` file:

```./uninstall-cloudflow.sh: line 28: ./detect.sh: No such file or directory```