### PR TITLE
Simplified steps to push data to the application

### DIFF
--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
@@ -33,6 +33,24 @@ import net.ceedubs.ficus.Ficus._
 abstract class AkkaStreamlet extends Streamlet[AkkaStreamletContext] {
   final override val runtime = AkkaStreamletRuntime
 
+  // ctx is always first set by runner through `init` so this is safe.
+  @volatile private var ctx: AkkaStreamletContext = null
+
+  /**
+   * Returns the [[StreamletContext]] in which this streamlet is run. It can only be accessed when the streamlet is run.
+   */
+  protected final implicit def context: AkkaStreamletContext = {
+    if (ctx == null) throw new StreamletContextException()
+    ctx
+  }
+
+  /**
+   * Java API
+   *
+   * Returns the [[StreamletContext]] in which this streamlet is run. It can only be accessed when the streamlet is run.
+   */
+  protected final def getStreamletContext(): AkkaStreamletContext = context
+
   /**
    * Initialize the streamlet from the config. In some cases (e.g. the tests) we may pass a context
    * directly to be used instead of building it from the config.

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -71,7 +71,10 @@ import cloudflow.streamlets._
 abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Serializable {
   final override val runtime = FlinkStreamletRuntime
 
-  private val readyPromise      = Promise[Dun]()
+  // ctx is always first set by runner through `init` so this is safe.
+  @volatile private var ctx: FlinkStreamletContext = null
+
+  private val readyPromise = Promise[Dun]()
   private val completionPromise = Promise[Dun]()
   private val completionFuture  = completionPromise.future
 

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -37,13 +37,13 @@ import cloudflow.streamlets._
  * `writeStream` returns a `StreamingQuery` that pushes the input `Dataset[Out]` to
  *              a `MemorySink`.
  */
-private[testkit] class TestSparkStreamletContext(override val streamletRef: String,
-                                                 session: SparkSession,
-                                                 inletTaps: Seq[SparkInletTap[_]],
-                                                 outletTaps: Seq[SparkOutletTap[_]],
-                                                 override val config: Config = ConfigFactory.empty)
-    extends SparkStreamletContext(StreamletDefinition("appId", "appVersion", streamletRef, "streamletClass", List(), List(), config),
-                                  session) {
+private[testkit] class TestSparkStreamletContext(
+    override val streamletRef: String,
+    session: SparkSession,
+    inletTaps: Seq[SparkInletTap[_]],
+    outletTaps: Seq[SparkOutletTap[_]],
+    override val config: Config = ConfigFactory.empty)
+  extends SparkStreamletContext(StreamletDefinition("appId", "appVersion", streamletRef, "streamletClass", List(), List(), config), session) {
 
   override def readStream[In](inPort: CodecInlet[In])(implicit encoder: Encoder[In], typeTag: TypeTag[In]): Dataset[In] =
     inletTaps

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -66,7 +66,10 @@ import cloudflow.streamlets._
 trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable {
   final override val runtime = SparkStreamletRuntime
 
-  private val readyPromise      = Promise[Dun]()
+  // ctx is always first set by runner through `init` so this is safe.
+  @volatile private var ctx: SparkStreamletContext = null
+
+  private val readyPromise = Promise[Dun]()
   private val completionPromise = Promise[Dun]()
   private val completionFuture  = completionPromise.future
 

--- a/core/project/plugins.sbt
+++ b/core/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.24")
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 // to generate one complete scaladoc site and one complete javadoc site
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")

--- a/installer/README.md
+++ b/installer/README.md
@@ -18,16 +18,11 @@ Testing on other major cloud providers is in the roadmap.
 
 ## Prerequisites
 
-### K8s CLI's
-You need the command line tool for your particular Kubernetes cluster:
+To use the Cloudflow GKE installer, you need to have the following packages installed on your local machine:
+
 * [Google Cloud SDK](https://cloud.google.com/sdk/)
-* [Amazon CLI for EKS](https://eksctl.io/)
-
-Note: Make sure you have the latest `aws-cli` version.
-
-### Utilities
 * [jq](https://stedolan.github.io/jq/)
-* [Helm](https://helm.sh/) *note: Cloudflow installer is currently compatible with both v2 and v3*
+* [Helm v2](https://helm.sh/) *note: Cloudflow installer is currently not compatible with Helm v3*
 
 ## Installation Procedure
 
@@ -58,6 +53,10 @@ Replace above `<cluster-name>` with the preferred name for your EKS cluster.
 Some extra considerations are needed when integrating EFS with EKS. Please make sure the user launching the cluster
 satisfies the security groups requirements explained
 [here](https://docs.aws.amazon.com/efs/latest/ug/accessing-fs-create-security-groups.html).
+
+## Uninstall Procedure
+
+In case of a failed installation, or if you simply want to uninstall entirely, run `./uninstall-cloudflow.sh`.
 
 ## Uninstall Procedure
 

--- a/installer/common/shared.sh
+++ b/installer/common/shared.sh
@@ -37,7 +37,7 @@ set +x
 
 # Cloudflow operator version
 export operatorImageName="lightbend/cloudflow-operator"
-export operatorImageTag="89-f8a4ddc"
+export operatorImageTag="24-4a50b57"
 export operatorImage="$operatorImageName:$operatorImageTag"
 
 # Kafka installation mode CloudflowManaged|ExternalStrimzi|External

--- a/installer/uninstall-cloudflow.sh
+++ b/installer/uninstall-cloudflow.sh
@@ -29,9 +29,6 @@ fi
 # shellcheck source=common/detect.sh
 . common/detect.sh
 
-# Utility functions for interacting with Helm
-. common/helm.sh
-
 echo "This script will remove all Cloudflow related objects from the Kubernetes cluster currently logged in to"
 read -p "Do you want to continue ? (y/n) " -n 1 -r
 echo ""


### PR DESCRIPTION
This gets rid of some obsolete steps when pushing data to the application. 

1. Just using the provided bash script with the provided test-data is sufficient
2. Use a one-liner for the port-forwarding to remove the need for looking up and copying the pod id