### PR TITLE
adds docker plugin to getting started guide

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -86,7 +86,17 @@ lazy val sensorData =  (project in file("."))
   )
 ```
 
-Cloudflow offers several sbt plugins that abstract quite a bit of boilerplates necessary to build a complete application. In this example we use the plugin `CloudflowAkkaStreamsApplicationPlugin` that provides you all building blocks of developing an Akka Streams based Cloudflow application.
+Cloudflow offers several sbt plugins that abstract quite a bit of boilerplates necessary to build a complete application. In this example we use the plugin `CloudflowAkkaStreamsApplicationPlugin` that provides you all building blocks of developing an Akka Streams based Cloudflow application. Create `project/cloudflow-plugins.sbt` with the following content so sbt can resolve that plugin: 
+
+**cloudflow-plugins.sbt**
+
+```
+// Resolver for the cloudflow-sbt plugin
+//
+resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
+
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.0-M1")
+```
 
 > **Note:** You can use multiple plugins to develop an application that uses multiple runtimes (Akka, Spark, Flink etc.). For simplicity of this example we will be using only one.
 
@@ -201,6 +211,11 @@ Let's start building the avro schema for the domain objects that we need for the
 
 > **Note:** The above schema files are processed during the build process through the infrastructure of the Cloudflow plugin system. For each of these schema files, Cloudflow will generate Scala case classes that can be directly used from within the application.
 
+Launch a first compilation to generate those scala case classes: 
+
+```
+sbt compile
+```
 
 ### Let's build some streamlets
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Following the Getting Started guide currently leads to an error when running sbt tasks since the `CloudflowAkkaStreamsApplicationPlugin` plugin cannot be found. 

Also, when creating the scala Streamlets, partial compilation in the IDE fails (files marked as red) since the avro schemas have not yet been converted into case classes. 

### Why are the changes needed?

* documents the creation of `project/cloudflow-plugins.sbt` 
* instruct the user to execute `sbt compile` after the creation of the avro schemas

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes: the documentation


### How was this patch tested?

manually: executing `sbt compile` at the moment specified above no longer fails due to the "plugin not found" error. 