### PR TITLE
Made ctx volatile.

### DIFF
--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
@@ -36,7 +36,7 @@ abstract class AkkaStreamlet extends Streamlet {
   final override val runtime = AkkaStreamletRuntime
 
   // ctx is always first set by runner through `init` so this is safe.
-  private var ctx: AkkaStreamletContext = null
+  @volatile private var ctx: AkkaStreamletContext = null
 
   /**
    * Returns the [[StreamletContext]] in which this streamlet is run. It can only be accessed when the streamlet is run.

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -75,7 +75,7 @@ abstract class FlinkStreamlet extends Streamlet with Serializable {
   final override val runtime = FlinkStreamletRuntime
 
   // ctx is always first set by runner through `init` so this is safe.
-  private var ctx: FlinkStreamletContext = null
+  @volatile private var ctx: FlinkStreamletContext = null
 
   private val readyPromise = Promise[Dun]()
   private val completionPromise = Promise[Dun]()

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -69,7 +69,7 @@ trait SparkStreamlet extends Streamlet with Serializable {
   final override val runtime = SparkStreamletRuntime
 
   // ctx is always first set by runner through `init` so this is safe.
-  private var ctx: SparkStreamletContext = null
+  @volatile private var ctx: SparkStreamletContext = null
 
   private val readyPromise = Promise[Dun]()
   private val completionPromise = Promise[Dun]()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Minor fix, making `ctx` volatile in `AkkaStreamlet`. Thanks to @hepin1989 for the suggestion.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It is a (minor) improvement (it's more safe).


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Compiled.