### PR TITLE
Verify that a compute region and zone are set in the gcloud config

### DIFF
--- a/installer/create-cluster-gke.sh
+++ b/installer/create-cluster-gke.sh
@@ -23,6 +23,22 @@ if [ $# -eq 0 ]
     exit 1
 fi
 
+gcloudZone=$(gcloud config get-value compute/zone)
+if [ "$gcloudZone" == "" ]
+  then
+    echo "No compute/zone set in your GCloud configuration"
+    echo "Please set a compute zone by running: gcloud config set compute/zone VALUE [optional flags]"
+    exit 1
+fi
+
+gcloudRegion=$(gcloud config get-value compute/region)
+if [ "$gcloudRegion" == "" ]
+  then
+    echo "No compute/region set in your GCloud configuration"
+    echo "Please set a compute region by running: gcloud config set compute/region VALUE [optional flags]"
+    exit 1
+fi
+
 CLUSTER_NAME=$1
 
 # Create cluster


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check if the compute/zone and compute/region properties are set in the Gcloud configuration as mentioned in #51 

### Why are the changes needed?
Make the installation more user-friendly by telling the user what to do instead of confronting them with a gcloud error

### Does this PR introduce any user-facing change?
Yes, additional error messages that are possibly displayed during the creation of a GCP cluster

### How was this patch tested?
Verified the functionality by unsetting the gcloud config values.
