### PR TITLE
override getContext in SparkStreamletLogic

### DIFF
--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -230,6 +230,8 @@ trait SparkStreamlet extends Streamlet with Serializable {
  */
 abstract class SparkStreamletLogic(implicit val context: SparkStreamletContext) extends StreamletLogic[SparkStreamletContext] {
 
+  override def getContext(): SparkStreamletContext = super.getContext()
+
   implicit class StreamingQueryExtensions(val query: StreamingQuery) {
     def toQueryExecution: StreamletQueryExecution = StreamletQueryExecution(query)
   }


### PR DESCRIPTION
follow up the previous one ,sorry for missing out an override