### PR TITLE
Adds --no-enable-autoupgrade to the second pool of nodes

### DIFF
--- a/installer/create-cluster-gke.sh
+++ b/installer/create-cluster-gke.sh
@@ -65,7 +65,8 @@ gcloud beta container node-pools create kafka-pool-0 \
   --cluster=$CLUSTER_NAME \
   --machine-type n1-highmem-2  \
   --node-labels=dedicated=StrimziKafka \
-  --node-taints=dedicated=StrimziKafka:NoSchedule
+  --node-taints=dedicated=StrimziKafka:NoSchedule \
+  --no-enable-autoupgrade
 
 ## Wait for clusters to come up
 echo "Waiting for cluster to become stable before continuing with the installation....."


### PR DESCRIPTION

### What changes were proposed in this pull request?

Adds `--no-enable-autoupgrade` at the creation of the second pool of nodes.

### Why are the changes needed?

Without it, the created cluster becomes unavailable shortly after creation, while the nodes are being upgraded

### Does this PR introduce any user-facing change?


### How was this patch tested?
Running `installer/create-cluster-gke.sh` manually