### PR TITLE
Fix for uninitialized streamlet context.

### DIFF
--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -84,8 +84,6 @@ trait AkkaStreamletContext extends StreamletContext {
   private[akkastream] def metricTags(): Map[String, String]
 }
 
-final class AkkaStreamletContextException() extends StreamletContextException("The AkkaStreamletContext can only be accessed from within the streamlet logic.")
-
 /**
  * The position to initially start reading from, when using `plainSource`.
  *

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -83,26 +83,12 @@ trait SparkStreamlet extends Streamlet[SparkStreamletContext] {
       }.get
   }
 
-  /**
-   * This method is used to inject a `SparkStreamletContext` directly instead of through the
-   * `Config`. This is used mainly by the testkit to inject the test context
-   */
-  private[cloudflow] def setContext(streamletContext: SparkStreamletContext): SparkStreamlet = {
-    ctx = streamletContext
-    this
-  }
-
-  final class SparkStreamletContextException() extends StreamletContextException("The SparkStreamletContext can only be accessed from within the streamlet logic.")
-
   protected def createLogic(): SparkStreamletLogic
 
-  override final def run(config: Config): StreamletExecution = {
-    // create a context only when it is not set
-    val ctx = getOrCreateContext(config)
-
+  override final def run(context: SparkStreamletContext): StreamletExecution = {
     val InitialDelay = 2 seconds
     val MonitorFrequency = 5 seconds
-    implicit val system: ActorSystem = ActorSystem("spark_streamlet", ctx.config)
+    implicit val system: ActorSystem = ActorSystem("spark_streamlet", context.config)
 
     readyPromise.trySuccess(Dun)
     val streamletQueryExecution = createLogic.buildStreamingQueries

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/Streamlet.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/Streamlet.scala
@@ -26,8 +26,7 @@ import cloudflow.streamlets.descriptors.StreamletDescriptor
 abstract class Streamlet[Context <: StreamletContext] {
   @transient protected lazy val log = LoggerFactory.getLogger(getClass.getName)
 
-  // ctx is always first set by runner through `init` so this is safe.
-  @volatile protected var ctx: Context = _
+  @volatile private var ctx: Context = _
 
   /**
    * Returns the [[StreamletContext]] in which this streamlet is run. It can only be accessed when the streamlet is run.
@@ -48,7 +47,7 @@ abstract class Streamlet[Context <: StreamletContext] {
    * This method is used to inject a `StreamletContext` directly instead of through the
    * `Config`. This is used mainly by the testkit to inject the test context.
    */
-  private def setContext(context: Context): Streamlet[Context] = {
+  private[cloudflow] def setContext(context: Context): Streamlet[Context] = {
     ctx = context
     this
   }
@@ -98,17 +97,22 @@ abstract class Streamlet[Context <: StreamletContext] {
   def defineCustomAttributes(): Array[StreamletAttribute] = Array[StreamletAttribute]()
 
   /**
-   * Run the streamlet
+   * Runs the streamlet. Called by the cloudflow.runner.Runner.
    */
-  def run(config: Config): StreamletExecution
-
-  protected def getOrCreateContext(config: Config): Context = {
-    if (ctx ne null) ctx else this.synchronized {
-      if (ctx ne null) ctx else createContext(config)
+  private[cloudflow] final def run(config: Config): StreamletExecution = {
+    this.synchronized {
+      if (ctx == null) ctx = createContext(config)
     }
+    run(ctx)
   }
+
   /**
-   * Create a `StreamletContext` for the appropriate runtime
+   * Runs the streamlet.
+   */
+  def run(context: Context): StreamletExecution
+
+  /**
+   * Creates a `StreamletContext` for the appropriate runtime
    */
   protected def createContext(config: Config): Context
 
@@ -136,7 +140,7 @@ abstract class Streamlet[Context <: StreamletContext] {
  * a streamlet, e.g. "akka", "spark", etc.
  *
  * Implementations will usually be provided by a runtime support library
- * such as cloudflow-akkastream or cloudflow-spark.
+ * such as cloudflow-akka, cloudflow-spark and cloudflow-flink.
  */
 trait StreamletRuntime {
   def name: String

--- a/core/cloudflow-streamlets/src/test/scala/cloudflow/streamlets/descriptors/TestStreamlets.scala
+++ b/core/cloudflow-streamlets/src/test/scala/cloudflow/streamlets/descriptors/TestStreamlets.scala
@@ -43,7 +43,7 @@ trait TestStreamlet extends Streamlet[StreamletContext] {
   override def runtime: StreamletRuntime = TestRuntime
   def logStartRunnerMessage(buildInfo: String): Unit = ???
   override protected def createContext(config: Config): StreamletContext = ???
-  override def run(config: Config): StreamletExecution = ???
+  override def run(context: StreamletContext): StreamletExecution = ???
 
 }
 

--- a/core/sbt-cloudflow/src/test/scala/cloudflow/sbt/TestStreamlets.scala
+++ b/core/sbt-cloudflow/src/test/scala/cloudflow/sbt/TestStreamlets.scala
@@ -64,7 +64,7 @@ case object TestRuntime extends StreamletRuntime {
 
 trait TestStreamlet extends Streamlet[StreamletContext] {
   override def createContext(config: Config): StreamletContext = ???
-  override def run(config: Config): StreamletExecution = ???
+  override def run(context: StreamletContext): StreamletExecution = ???
   override def runtime: StreamletRuntime = TestRuntime
   def logStartRunnerMessage(buildInfo: String): Unit = ???
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
- the streamlet ctx is never set, which fails any streamlet on a cluster with:
```
Exception in thread "main" cloudflow.streamlets.StreamletContextException: StreamletContext can only be accessed from the `createLogic()` method.
	at cloudflow.streamlets.Streamlet.context(Streamlet.scala:36)
	at cloudflow.akkastream.AkkaStreamlet.run(AkkaStreamlet.scala:71)
	at cloudflow.runner.Runner$.run(Runner.scala:68)
	at cloudflow.runner.Runner$.main(Runner.scala:46)
	at cloudflow.runner.Runner.main(Runner.scala)
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This fixes a problem that prevents any cloudflow app from running.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
yes, implementors of streamlets don't have to create or set the context anymore, this is now automatically done in `Streamlet`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested by running examples (with runLocal).