### PR TITLE
Use the open sourced helm charts 

### DIFF
--- a/installer/common/install-operators.sh
+++ b/installer/common/install-operators.sh
@@ -42,7 +42,7 @@ if [ "$installFlinkOperator" = true ]; then
     --set serviceAccounts.flink.name=cloudflow-app-serviceaccount \
     https://github.com/lightbend/flink-operator/releases/download/v${flinkOperatorChartVersion}/flink-operator-${flinkOperatorChartVersion}.tgz)
 
-    if [ $? -ne 0 ]; then 
+    if [ $? -ne 0 ]; then
         print_error_message "$result"
         print_error_message "installation failed"
         exit 1
@@ -52,7 +52,7 @@ if [ "$installFlinkOperator" = true ]; then
     kubectl label deployment -n "$flinkOperatorNamespace" cloudflow-flink-flink-operator installed-by=cloudflow --overwrite
 fi
 
-# Strimzi 
+# Strimzi
 if [ "$installStrimzi" = true ]; then
     echo "Installing Strimzi"
     result=$(helm upgrade "$strimziReleaseName" \
@@ -61,7 +61,7 @@ if [ "$installStrimzi" = true ]; then
     --version "$strimziVersion" \
     strimzi/strimzi-kafka-operator)
 
-    if [ $? -ne 0 ]; then 
+    if [ $? -ne 0 ]; then
         print_error_message "$result"
         print_error_message "installation failed"
         exit 1
@@ -81,9 +81,9 @@ if [ "$installSparkOperator" = true ]; then
     --version "$sparkOperatorChartVersion" \
     --set sparkJobNamespace="" \
     --set operatorVersion="$sparkOperatorImageVersion" \
-    lightbend-helm-charts/fdp-sparkoperator)
+    https://github.com/lightbend/fdp-sparkoperator/releases/download/v${sparkOperatorChartVersion}/fdp-sparkoperator-${sparkOperatorChartVersion}.tgz)
 
-    if [ $? -ne 0 ]; then 
+    if [ $? -ne 0 ]; then
         print_error_message "$result"
         print_error_message "installation failed"
         exit 1

--- a/installer/common/shared.sh
+++ b/installer/common/shared.sh
@@ -205,8 +205,9 @@ export limitsCpu="2"
 # Installs an NFS server: $1: namespace, $2: boolean onOpenShift
 NFS_SERVER_NAME=cloudflow-nfs
 NFS_CHART_NAME=fdp-nfs
+NFS_CHART_VERSION=0.3.0
 install_nfs_server() {
-helm upgrade $NFS_SERVER_NAME lightbend-helm-charts/$NFS_CHART_NAME \
+helm upgrade $NFS_SERVER_NAME https://github.com/lightbend/${NFS_CHART_NAME}/releases/download/v${NFS_CHART_VERSION}/${NFS_CHART_NAME}-${NFS_CHART_VERSION}.tgz \
 --install \
 --namespace "$1" \
 --timeout $HELM_TIMEOUT \
@@ -214,8 +215,7 @@ helm upgrade $NFS_SERVER_NAME lightbend-helm-charts/$NFS_CHART_NAME \
 --set serviceAccount.create=false \
 --set serviceAccount.name=cloudflow-operator \
 --set onOpenShift="$2" \
---set storageClassName=nfs-client \
---version 0.2.0
+--set storageClassName=nfs-client
 }
 
 EFS_SERVER_NAME=cloudflow-efs


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use the open source OSS charts (Spark and NFS). 
Previously we were using the internal ones published at the lightbend-helm-charts repo.
TODO: @yuchaoran2011 is working on the Flink one.
Helm chart github repos names will change so this is WIP.

### Why are the changes needed?
Use directly the individual published charts.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Manually tested, running a Cloudflow app on GKE and tried a Spark job on EKS.
