### PR TITLE
Use the open-source ligthbend flink-operator

### DIFF
--- a/installer/common/install-operators.sh
+++ b/installer/common/install-operators.sh
@@ -40,7 +40,7 @@ if [ "$installFlinkOperator" = true ]; then
     --version "$flinkOperatorChartVersion" \
     --set serviceAccounts.flink.create=false \
     --set serviceAccounts.flink.name=cloudflow-app-serviceaccount \
-    lightbend-helm-charts/flink-operator)
+    https://github.com/lightbend/flink-operator/releases/download/v${flinkOperatorChartVersion}/flink-operator-${flinkOperatorChartVersion}.tgz)
 
     if [ $? -ne 0 ]; then 
         print_error_message "$result"

--- a/installer/common/shared.sh
+++ b/installer/common/shared.sh
@@ -66,7 +66,7 @@ export KAFKA="${KAFKA:-CloudflowManaged}"
 
 # Flink
 export flinkReleaseName="cloudflow-flink"
-export flinkOperatorChartVersion="0.6.0"
+export flinkOperatorChartVersion="0.7.0"
 export flinkOperatorNamespace=""
 export installFlinkOperator=false
 


### PR DESCRIPTION
# What changes were proposed in this pull request?
Use the open-sourced Lightbend flink-operator. This is related to #87 and blocking #63

### Why are the changes needed?
The flink-operator has recently been open-sourced and the installer needs to be updated accordingly

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
I've tested the installation with the GKE installer