### PR TITLE
Updated Flink operator to the release that's compatible with both Hel…

### DIFF
--- a/installer/common/shared.sh
+++ b/installer/common/shared.sh
@@ -66,7 +66,7 @@ export KAFKA="${KAFKA:-CloudflowManaged}"
 
 # Flink
 export flinkReleaseName="cloudflow-flink"
-export flinkOperatorChartVersion="0.7.0"
+export flinkOperatorChartVersion="0.7.1"
 export flinkOperatorNamespace=""
 export installFlinkOperator=false
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make Cloudflow use a Helm-2 and Helm-3 compatible Flink operator chart.

### Why are the changes needed?
Fix #102 

### Does this PR introduce any user-facing change?
Yes, the user should no longer see the bug.

### How was this patch tested?
Manually tested.
