### PR TITLE
Fix cloudflow operator tag

### DIFF
--- a/installer/common/shared.sh
+++ b/installer/common/shared.sh
@@ -57,7 +57,7 @@ echo "The tiller namespace is '$TILLER_NAMESPACE'"
 
 # Cloudflow operator version
 export operatorImageName="lightbend/cloudflow-operator"
-export operatorImageTag="1.3.0"
+export operatorImageTag="89-f8a4ddc"
 export operatorImage="$operatorImageName:$operatorImageTag"
 
 
@@ -199,7 +199,7 @@ elif [ "${KAFKA}" = "External" ]; then
 else
     print_error_message "Invalid Kafka installation mode defined: '${KAFKA}'."
     print_error_message ""
-    
+
     exit 1
 fi
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fixes https://github.com/lightbend/cloudflow/issues/105.
### Why are the changes needed?
A new Cloudflow operator image was pushed from latest master.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Manually by running Cloudflow on an EKS cluster and checking if the operator starts as usual.
```$ kubectl get pods -n cloudflow
NAME                                                         READY   STATUS     RESTARTS   AGE
cloudflow-efs-efs-provisioner-575d8f8567-g9555               0/1     Init:0/1   0          4m8s
cloudflow-flink-flink-operator-76865f984-fxc2f               1/1     Running    0          3m59s
cloudflow-operator-7c86ffbfbb-h6szd                          1/1     Running    0          3m43s
cloudflow-sparkoperator-fdp-sparkoperator-6c9bbf5ccf-2wfm9   1/1     Running    0          3m48s
cloudflow-strimzi-entity-operator-5c5d6f948-vnbcd            2/2     Running    0          2m10s
cloudflow-strimzi-kafka-0                                    2/2     Running    0          2m57s
cloudflow-strimzi-kafka-1                                    2/2     Running    0          2m57s
cloudflow-strimzi-kafka-2                                    2/2     Running    0          2m57s
cloudflow-strimzi-zookeeper-0                                2/2     Running    0          3m40s
cloudflow-strimzi-zookeeper-1                                2/2     Running    0          3m40s
cloudflow-strimzi-zookeeper-2                                2/2     Running    0          3m40s
strimzi-cluster-operator-5d7d946c6d-k6vvl                    1/1     Running    0          3m53s
````
Operator log:
```
$ kubectl  logs cloudflow-operator-7c86ffbfbb-h6szd  -n cloudflow
01:11:19,940 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
01:11:19,940 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.groovy]
....
Release version : 1.2.0
    
      
2020-01-15 01:11:21,455 INFO  [ActorSystemImpl] - Bound to /0.0.0.0:5001.
2020-01-15 01:11:21,644 INFO  [ActorSystemImpl] - Connected to Kubernetes cluster: https://10.100.0.1:443

```
Pod image:
```
$ kubectl get pods cloudflow-operator-7c86ffbfbb-h6szd  -n cloudflow -o json | jq  '.spec.containers | .[].image'
"lightbend/cloudflow-operator:89-f8a4ddc"

```
