### PR TITLE
Update to alpakka 2.0.1. Added support for Committable context, instead of requiring CommittableOffset.

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -115,6 +115,7 @@ lazy val akkastreamTestkit =
         AkkaStreamContrib,
         Ficus,
         Logback % Test,
+        AkkaStreamKafkaTestkit,
         AkkaStreamTestkit,
         AkkaTestkit,
         ScalaTest,

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -87,7 +87,7 @@ lazy val akkastream =
 lazy val akkastreamUtil =
   cloudflowModule("cloudflow-akka-util")
     .enablePlugins(GenJavadocPlugin)
-    .dependsOn(akkastream, akkastreamTestkit)
+    .dependsOn(akkastream, akkastreamTestkit % Test)
     .settings(
       libraryDependencies ++= Vector(
         AkkaHttp,
@@ -130,7 +130,7 @@ lazy val akkastreamTestkit =
 
 lazy val akkastreamTests =
   cloudflowModule("cloudflow-akka-tests")
-    .dependsOn(akkastream, akkastreamTestkit)
+    .dependsOn(akkastream, akkastreamTestkit % Test)
     .settings(
       libraryDependencies ++= Vector(
         AkkaHttpTestkit,

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
@@ -98,7 +98,7 @@ private[testkit] case class TestContext(
   def sinkWithOffsetContext[T](outlet: CodecOutlet[T], committerSettings: CommitterSettings): Sink[(T, CommittableOffset), NotUsed] =
     flowWithCommittableContext[T](outlet).asFlow.toMat(Sink.ignore)(Keep.left)
 
-  def plainSource[T](inlet: CodecInlet[T], resetPosition: ResetPosition): Source[T, NotUsed] = sourceWithOffsetContext[T](inlet).asSource.map(_._1)
+  def plainSource[T](inlet: CodecInlet[T], resetPosition: ResetPosition): Source[T, NotUsed] = sourceWithOffsetContext[T](inlet).asSource.map(_._1).mapMaterializedValue(_ ⇒ NotUsed)
   def plainSink[T](outlet: CodecOutlet[T]): Sink[T, NotUsed] = sinkRef[T](outlet).sink.contramap { el ⇒ (el, TestCommittableOffset()) }
   def sinkRef[T](outlet: CodecOutlet[T]): WritableSinkRef[T] = {
     new WritableSinkRef[T] {

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
@@ -64,7 +64,7 @@ private[testkit] case class TestContext(
       )
       .getOrElse(throw TestContextException(inlet.name, s"Bad test context, could not find source for inlet ${inlet.name}"))
 
-  def flowWithCommittableContext[T](outlet: CodecOutlet[T]): cloudflow.akkastream.scaladsl.FlowWithCommittableContext[T, T] = {
+  private def flowWithCommittableContext[T](outlet: CodecOutlet[T]): cloudflow.akkastream.scaladsl.FlowWithCommittableContext[T, T] = {
     val flow = Flow[T]
 
     outletTaps

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/InletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/InletTap.scala
@@ -26,7 +26,7 @@ import cloudflow.akkastream.testkit._
 
 // The use of Tuple here is OK since the creation of the tuple is handled
 // internally by the AkkaStreamletTestKit when creating instances of this class
-case class SourceInletTap[T] private[testkit] (inlet: CodecInlet[T], src: akka.stream.javadsl.Source[(T, CommittableOffset), NotUsed]) extends InletTap[T] {
+case class SourceInletTap[T] private[testkit] (inlet: CodecInlet[T], src: akka.stream.javadsl.Source[(T, Committable), NotUsed]) extends InletTap[T] {
   val portName = inlet.name
 
   private[testkit] val source = src.asScala

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/package.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/package.scala
@@ -27,7 +27,7 @@ package testkit {
     def portName: String
 
     // This is for internal usage so using a scaladsl Source and a Tuple is no problem
-    private[testkit] def source: Source[(T, CommittableOffset), NotUsed]
+    private[testkit] def source: Source[(T, Committable), NotUsed]
   }
 
   trait OutletTap[T] {

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/InletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/InletTap.scala
@@ -24,7 +24,7 @@ import akka.stream.scaladsl._
 import cloudflow.streamlets._
 import cloudflow.akkastream.testkit._
 
-case class SourceInletTap[T](inlet: CodecInlet[T], source: Source[(T, CommittableOffset), NotUsed]) extends InletTap[T] {
+case class SourceInletTap[T](inlet: CodecInlet[T], source: Source[(T, Committable), NotUsed]) extends InletTap[T] {
   def portName = inlet.name
 }
 

--- a/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
+++ b/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
@@ -20,6 +20,7 @@ import scala.concurrent.duration.Duration;
 
 import akka.actor.ActorSystem;
 import akka.japi.Pair;
+import akka.kafka.ConsumerMessage.Committable;
 import akka.kafka.ConsumerMessage.CommittableOffset;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletSpec.scala
@@ -91,7 +91,7 @@ class AkkaStreamletSpec extends WordSpec with MustMatchers with BeforeAndAfterAl
           // The test
           streamletConfig mustBe empty
 
-          def runnableGraph = sourceWithOffsetContext(in).to(sinkWithOffsetContext(out))
+          def runnableGraph = sourceWithOffsetContext(in).to(committableSink(out))
         }
       }
 

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/MergeLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/MergeLogic.scala
@@ -25,12 +25,28 @@ import cloudflow._
 import cloudflow.akkastream._
 import cloudflow.streamlets._
 
+/**
+ * Java API
+ * Merges two or more sources, or inlets, of the same type, into one source.
+ */
 object Merger {
+  /**
+   * Java API
+   * Merges two or more sources into one Source.
+   * Elements from all inlets will be processed with at-least-once semantics. The elements will be processed
+   * in semi-random order and with equal priority for all sources.
+   */
   def source[T](
       sources: java.util.List[akka.stream.javadsl.SourceWithContext[T, Committable, _]]
   ): akka.stream.javadsl.SourceWithContext[T, Committable, _] =
     cloudflow.akkastream.util.scaladsl.Merger.source(sources.asScala.map(_.asScala)).asJava
 
+  /**
+   * Java API
+   * Merges two or more inlets into one Source.
+   * Elements from all inlets will be processed with at-least-once semantics. The elements will be processed
+   * in semi-random order and with equal priority for all inlets.
+   */
   def source[T](
       inlets: java.util.List[CodecInlet[T]],
       context: AkkaStreamletContext
@@ -39,6 +55,7 @@ object Merger {
 }
 
 /**
+ * Java API
  * A `MergeLogic` merges two or more inlets into one outlet.
  * Elements from all inlets will be processed with at-least-once semantics. The elements will be processed
  * in semi-random order and with equal priority for all inlets.

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/MergeLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/MergeLogic.scala
@@ -16,10 +16,8 @@
 
 package cloudflow.akkastream.util.javadsl
 
+import scala.annotation.varargs
 import scala.collection.JavaConverters._
-import akka.NotUsed
-import akka.japi.Pair
-import akka.stream._
 import akka.kafka.ConsumerMessage._
 import cloudflow._
 import cloudflow.akkastream._
@@ -48,10 +46,18 @@ object Merger {
    * in semi-random order and with equal priority for all inlets.
    */
   def source[T](
-      inlets: java.util.List[CodecInlet[T]],
-      context: AkkaStreamletContext
+      context: AkkaStreamletContext,
+      inlets: java.util.List[CodecInlet[T]]
   ): akka.stream.javadsl.SourceWithContext[T, Committable, _] =
     cloudflow.akkastream.util.scaladsl.Merger.source(inlets.asScala)(context).asJava
+
+  @varargs
+  def source[T](
+      context: AkkaStreamletContext,
+      inlet: CodecInlet[T],
+      inlets: CodecInlet[T]*
+  ): akka.stream.javadsl.SourceWithContext[T, Committable, _] =
+    cloudflow.akkastream.util.scaladsl.Merger.source(inlet +: inlets)(context).asJava
 }
 
 /**

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/MergeLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/MergeLogic.scala
@@ -16,16 +16,34 @@
 
 package cloudflow.akkastream.util.javadsl
 
+import scala.collection.JavaConverters._
+import akka.NotUsed
+import akka.japi.Pair
+import akka.stream._
+import akka.kafka.ConsumerMessage._
 import cloudflow._
 import cloudflow.akkastream._
 import cloudflow.streamlets._
-import scala.collection.JavaConverters._
+
+object Merger {
+  def source[T](
+      sources: java.util.List[cloudflow.akkastream.javadsl.SourceWithOffsetContext[T]]
+  ): cloudflow.akkastream.javadsl.SourceWithOffsetContext[T] =
+    cloudflow.akkastream.util.scaladsl.Merger.source(sources.asScala.map(_.asScala)).asJava
+
+  def source[T](
+      inlets: java.util.List[CodecInlet[T]],
+      context: AkkaStreamletContext
+  ): cloudflow.akkastream.javadsl.SourceWithOffsetContext[T] =
+    cloudflow.akkastream.util.scaladsl.Merger.source(inlets.asScala)(context).asJava
+}
 
 /**
  * A `MergeLogic` merges two or more inlets into one outlet.
  * Elements from all inlets will be processed with at-least-once semantics. The elements will be processed
  * in semi-random order and with equal priority for all inlets.
  */
+@deprecated("Use `Merger.source` instead.", "1.3.1")
 final class MergeLogic[T](
     inletPorts: java.util.List[CodecInlet[T]],
     outlet: CodecOutlet[T],

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/MergeLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/MergeLogic.scala
@@ -27,14 +27,14 @@ import cloudflow.streamlets._
 
 object Merger {
   def source[T](
-      sources: java.util.List[cloudflow.akkastream.javadsl.SourceWithOffsetContext[T]]
-  ): cloudflow.akkastream.javadsl.SourceWithOffsetContext[T] =
+      sources: java.util.List[akka.stream.javadsl.SourceWithContext[T, Committable, _]]
+  ): akka.stream.javadsl.SourceWithContext[T, Committable, _] =
     cloudflow.akkastream.util.scaladsl.Merger.source(sources.asScala.map(_.asScala)).asJava
 
   def source[T](
       inlets: java.util.List[CodecInlet[T]],
       context: AkkaStreamletContext
-  ): cloudflow.akkastream.javadsl.SourceWithOffsetContext[T] =
+  ): akka.stream.javadsl.SourceWithContext[T, Committable, _] =
     cloudflow.akkastream.util.scaladsl.Merger.source(inlets.asScala)(context).asJava
 }
 

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/MergeLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/MergeLogic.scala
@@ -32,7 +32,7 @@ import cloudflow.streamlets._
 object Merger {
   /**
    * Java API
-   * Merges two or more sources into one Source.
+   * Merges two or more sources into one source.
    * Elements from all inlets will be processed with at-least-once semantics. The elements will be processed
    * in semi-random order and with equal priority for all sources.
    */
@@ -43,7 +43,7 @@ object Merger {
 
   /**
    * Java API
-   * Merges two or more inlets into one Source.
+   * Merges two or more inlets into one source.
    * Elements from all inlets will be processed with at-least-once semantics. The elements will be processed
    * in semi-random order and with equal priority for all inlets.
    */

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/SplitterLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/SplitterLogic.scala
@@ -35,7 +35,7 @@ import cloudflow.streamlets._
 object Splitter {
   /**
    * Java API
-   * A Graph that splits elements based on a flow of type `FlowWithOffsetContext[I, Either[L, R]]`.
+   * Creates a graph that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
   def graph[I, L, R](
@@ -50,7 +50,7 @@ object Splitter {
     )
   /**
    * Java API
-   * A Sink that splits elements based on a flow of type `FlowWithOffsetContext[I, Either[L, R]]`.
+   * A Sink that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
   def sink[I, L, R](
@@ -66,7 +66,7 @@ object Splitter {
 
   /**
    * Java API
-   * A Sink that splits elements based on a flow of type `FlowWithOffsetContext[I, Either[L, R]]`.
+   * A Sink that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
   def sink[I, L, R](
@@ -85,7 +85,7 @@ object Splitter {
 
   /**
    * Java API
-   * A Sink that splits elements based on a flow of type `FlowWithOffsetContext[I, Either[L, R]]`.
+   * A Sink that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
   def sink[I, L, R](

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/SplitterLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/SplitterLogic.scala
@@ -16,12 +16,31 @@
 
 package cloudflow.akkastream.util.javadsl
 
+import akka.NotUsed
+import akka.stream._
+import akka.stream.javadsl._
+import akka.kafka.ConsumerMessage._
 import cloudflow._
 import cloudflow.akkastream._
 import cloudflow.akkastream.javadsl._
 import cloudflow.akkastream.javadsl.util.{ Either ⇒ JEither }
 import cloudflow.streamlets._
 
+object Splitter {
+  def graph[I, L, R](
+      flow: FlowWithCommittableContext[I, Either[L, R]],
+      left: Sink[(L, Committable), NotUsed],
+      right: Sink[(R, Committable), NotUsed]
+  ): Graph[akka.stream.SinkShape[(I, Committable)], NotUsed] = akkastream.util.scaladsl.Splitter.graph[I, L, R](flow.asScala, left.asScala, right.asScala)
+
+  def sink[I, L, R](
+      flow: FlowWithCommittableContext[I, Either[L, R]],
+      left: Sink[(L, Committable), NotUsed],
+      right: Sink[(R, Committable), NotUsed]
+  ): Sink[(I, Committable), NotUsed] = akkastream.util.scaladsl.Splitter.sink[I, L, R](flow.asScala, left.asScala, right.asScala).asJava
+}
+
+@deprecated("Use `Splitter.sink` instead.", "1.3.1")
 abstract class SplitterLogic[I, L, R](
     in: CodecInlet[I],
     left: CodecOutlet[L],
@@ -30,7 +49,7 @@ abstract class SplitterLogic[I, L, R](
 ) extends akkastream.util.scaladsl.SplitterLogic(in, left, right)(context) {
 
   def createFlow(): FlowWithOffsetContext[I, JEither[L, R]]
-  def flow: scaladsl.FlowWithOffsetContext[I, Either[L, R]] = {
+  def flow: cloudflow.akkastream.scaladsl.FlowWithOffsetContext[I, Either[L, R]] = {
     createFlow().map(jEither ⇒ if (jEither.isRight) Right(jEither.get()) else Left(jEither.getLeft())).asScala
   }
   final def createFlowWithOffsetContext() = FlowWithOffsetContext.create[I]()

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/MergeLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/MergeLogic.scala
@@ -45,7 +45,7 @@ class MergeLogic[T](
   override def runnableGraph() = {
 
     val inlets = inletPorts.map(inlet ⇒ sourceWithOffsetContext[T](inlet)).toList
-    val out = sinkWithOffsetContext[T](outlet)
+    val out = committableSink[T](outlet)
 
     RunnableGraph.fromGraph(GraphDSL.create() { implicit builder: GraphDSL.Builder[NotUsed] ⇒
       import GraphDSL.Implicits._

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/MergeLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/MergeLogic.scala
@@ -34,7 +34,7 @@ import akka.kafka.ConsumerMessage._
  */
 object Merger {
   /**
-   * Creates Source Graph to merge two or more sources into one source.
+   * Creates a graph to merge two or more sources into one source.
    * Elements from all sources will be processed with at-least-once semantics. The elements will be processed
    * in semi-random order and with equal priority for all sources.
    */
@@ -49,7 +49,7 @@ object Merger {
     }
 
   /**
-   * Merges two or more sources into one Source.
+   * Merges two or more sources into one source.
    * Elements from all inlets will be processed with at-least-once semantics. The elements will be processed
    * in semi-random order and with equal priority for all sources.
    */
@@ -60,7 +60,7 @@ object Merger {
   }
 
   /**
-   * Merges two or more inlets into one Source.
+   * Merges two or more inlets into one source.
    * Elements from all inlets will be processed with at-least-once semantics. The elements will be processed
    * in semi-random order and with equal priority for all inlets.
    */

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/MergeLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/MergeLogic.scala
@@ -69,6 +69,11 @@ object Merger {
   )(implicit context: AkkaStreamletContext): SourceWithContext[T, Committable, _] = {
     Source.fromGraph(graph(inlets.map(context.sourceWithOffsetContext(_)))).asSourceWithContext { case (_, offset) ⇒ offset }.map { case (t, _) ⇒ t }
   }
+  def source[T](
+      inlet: CodecInlet[T], inlets: CodecInlet[T]*
+  )(implicit context: AkkaStreamletContext): SourceWithContext[T, Committable, _] = {
+    Source.fromGraph(graph((inlet +: inlets.toList).map(context.sourceWithOffsetContext(_)))).asSourceWithContext { case (_, offset) ⇒ offset }.map { case (t, _) ⇒ t }
+  }
 }
 
 /**

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/SplitterLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/SplitterLogic.scala
@@ -47,15 +47,15 @@ abstract class SplitterLogic[I, L, R](
    */
   override def runnableGraph() = {
     val in = sourceWithOffsetContext[I](inlet)
-    val left = sinkWithOffsetContext[L](leftOutlet)
-    val right = sinkWithOffsetContext[R](rightOutlet)
+    val left = committableSink[L](leftOutlet)
+    val right = committableSink[R](rightOutlet)
 
     val splitterGraph = RunnableGraph.fromGraph(
       GraphDSL.create(left, right)(Keep.left) { implicit builder: GraphDSL.Builder[NotUsed] ⇒ (il, ir) ⇒
         import GraphDSL.Implicits._
 
         val toEitherFlow = builder.add(flow.asFlow)
-        val partitionWith = PartitionWith[(Either[L, R], CommittableOffset), (L, CommittableOffset), (R, CommittableOffset)] {
+        val partitionWith = PartitionWith[(Either[L, R], Committable), (L, Committable), (R, Committable)] {
           case (Left(e), offset)  ⇒ Left((e, offset))
           case (Right(e), offset) ⇒ Right((e, offset))
         }

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/SplitterLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/SplitterLogic.scala
@@ -50,8 +50,8 @@ object Splitter {
 
         // format: OFF
         toEitherFlow ~> partitioner.in
-                              partitioner.out0 ~> il
-                              partitioner.out1 ~> ir
+                        partitioner.out0 ~> il
+                        partitioner.out1 ~> ir
       // format: ON
 
       SinkShape(toEitherFlow.in)

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/SplitterLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/SplitterLogic.scala
@@ -31,7 +31,7 @@ import cloudflow.akkastream.scaladsl._
  */
 object Splitter {
   /**
-   * A Graph that splits elements based on a flow of type `FlowWithOffsetContext[I, Either[L, R]]`.
+   * A Graph that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    */
   def graph[I, L, R](
       flow: FlowWithCommittableContext[I, Either[L, R]],
@@ -59,7 +59,7 @@ object Splitter {
   }
 
   /**
-   * A Sink that splits elements based on a flow of type `FlowWithOffsetContext[I, Either[L, R]]`.
+   * A Sink that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
   def sink[I, L, R](
@@ -69,7 +69,7 @@ object Splitter {
   ): Sink[(I, Committable), NotUsed] = Sink.fromGraph(graph(flow, left, right))
 
   /**
-   * A Sink that splits elements based on a flow of type `FlowWithOffsetContext[I, Either[L, R]]`.
+   * A Sink that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
   def sink[I, L, R](
@@ -82,7 +82,7 @@ object Splitter {
   }
 
   /**
-   * A Sink that splits elements based on a flow of type `FlowWithOffsetContext[I, Either[L, R]]`.
+   * A Sink that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
   def sink[I, L, R](

--- a/core/cloudflow-akka-util/src/test/java/cloudflow/akkastream/util/javadsl/MergeTest.java
+++ b/core/cloudflow-akka-util/src/test/java/cloudflow/akkastream/util/javadsl/MergeTest.java
@@ -19,7 +19,9 @@ package cloudflow.akkastream.util.javadsl;
 import java.util.ArrayList;
 import java.util.List;
 
+import akka.stream.javadsl.RunnableGraph;
 import cloudflow.akkastream.AkkaStreamlet;
+import cloudflow.akkastream.javadsl.RunnableGraphStreamletLogic;
 import cloudflow.akkastream.testdata.Data;
 import cloudflow.streamlets.CodecInlet;
 import cloudflow.streamlets.StreamletShape;
@@ -45,11 +47,12 @@ public class MergeTest extends JUnitSuite {
         public StreamletShape shape() {
          return StreamletShape.createWithInlets(inlet1, inlet2).withOutlets(outlet);
         }
-        public MergeLogic createLogic() {
-          List<CodecInlet<Data>> inlets = new ArrayList<CodecInlet<Data>>();
-          inlets.add(inlet1);
-          inlets.add(inlet2);
-          return new MergeLogic(inlets, outlet, getContext());
+        public RunnableGraphStreamletLogic createLogic() {
+          return new RunnableGraphStreamletLogic(getContext()) {
+            public RunnableGraph createRunnableGraph() {
+              return Merger.source(getContext(), inlet1, inlet2).to(getCommittableSink(outlet));
+            }
+          };
         }
     }
 }

--- a/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/MergeSpec.scala
+++ b/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/MergeSpec.scala
@@ -146,7 +146,7 @@ class JavaTestMerge(inletCount: Int) extends TestMerge {
    */
   override final def createLogic = new cloudflow.akkastream.javadsl.RunnableGraphStreamletLogic(context) {
     def createRunnableGraph = {
-      cloudflow.akkastream.util.javadsl.Merger.source(inletPorts.asJava, context).to(getCommittableSink(outlet))
+      cloudflow.akkastream.util.javadsl.Merger.source(context, inletPorts.asJava).to(getCommittableSink(outlet))
     }
   }
 }

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -20,9 +20,10 @@ import scala.concurrent.Future
 
 import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.kafka.ConsumerMessage.{ Committable, CommittableOffset }
+import akka.kafka.CommitterSettings
 import akka.stream._
 import akka.stream.scaladsl._
-
 import cloudflow.streamlets._
 
 /**
@@ -34,9 +35,16 @@ import cloudflow.streamlets._
  */
 trait AkkaStreamletContext extends StreamletContext {
   private[akkastream] def sourceWithOffsetContext[T](inlet: CodecInlet[T]): scaladsl.SourceWithOffsetContext[T]
-  private[akkastream] def flowWithOffsetContext[T](outlet: CodecOutlet[T]): scaladsl.FlowWithOffsetContext[T, _]
   private[akkastream] def plainSource[T](inlet: CodecInlet[T], resetPosition: ResetPosition): Source[T, NotUsed]
   private[akkastream] def plainSink[T](outlet: CodecOutlet[T]): Sink[T, NotUsed]
+
+  private[akkastream] def committableSink[T](outlet: CodecOutlet[T], committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed]
+  private[akkastream] def committableSink[T](committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed]
+
+  @deprecated("Use `committableSink` instead.", "1.3.1")
+  private[akkastream] def sinkWithOffsetContext[T](outlet: CodecOutlet[T], committerSettings: CommitterSettings): Sink[(T, CommittableOffset), NotUsed]
+  @deprecated("Use `committableSink` instead.", "1.3.1")
+  private[akkastream] def sinkWithOffsetContext[T](committerSettings: CommitterSettings): Sink[(T, CommittableOffset), NotUsed]
 
   /**
    * Creates a [[akka.stream.SinkRef SinkRef]] to write to, for the specified [[cloudflow.streamlets.CodecOutlet CodecOutlet]]

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
@@ -118,6 +118,11 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
   def getSourceWithOffsetContext[T](inlet: CodecInlet[T]): javadsl.SourceWithOffsetContext[T] = sourceWithOffsetContext(inlet).asJava
 
   /**
+   * Java API
+   */
+  def getSourceWithCommittableContext[T](inlet: CodecInlet[T]): akka.stream.javadsl.SourceWithContext[T, Committable, _] = getSourceWithOffsetContext(inlet)
+
+  /**
    * The `plainSource` emits `T` records (as received through the `inlet`).
    *
    * It has no support for committing offsets to Kafka.

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
@@ -45,15 +45,15 @@ final class KafkaSinkRef[T](
 
   private val producer = producerSettings.createKafkaProducer()
 
-  def sink: Sink[(T, CommittableOffset), NotUsed] = {
+  def sink: Sink[(T, Committable), NotUsed] = {
     system.log.info(s"Creating sink for topic: $topic")
 
-    Flow[(T, CommittableOffset)]
+    Flow[(T, Committable)]
       .map {
         case (value, offset) ⇒
           val key = outlet.partitioner(value)
           val bytesValue = outlet.codec.encode(value)
-          ProducerMessage.Message[Array[Byte], Array[Byte], CommittableOffset](new ProducerRecord(topic, key.getBytes("UTF8"), bytesValue), offset)
+          ProducerMessage.Message[Array[Byte], Array[Byte], Committable](new ProducerRecord(topic, key.getBytes("UTF8"), bytesValue), offset)
       }
       .via(Producer.flexiFlow(producerSettings, producer))
       .via(handleTermination)

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
@@ -55,7 +55,7 @@ final class KafkaSinkRef[T](
           val bytesValue = outlet.codec.encode(value)
           ProducerMessage.Message[Array[Byte], Array[Byte], Committable](new ProducerRecord(topic, key.getBytes("UTF8"), bytesValue), offset)
       }
-      .via(Producer.flexiFlow(producerSettings, producer))
+      .via(Producer.flexiFlow(producerSettings.withProducer(producer)))
       .via(handleTermination)
       .to(Sink.ignore).mapMaterializedValue(_ ⇒ NotUsed)
   }

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/SinkRefs.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/SinkRefs.scala
@@ -22,7 +22,7 @@ import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
 
 import akka.stream._
-import akka.kafka.ConsumerMessage.CommittableOffset
+import akka.kafka.ConsumerMessage.Committable
 /**
  * Extends [[akka.stream.SinkRef]] with a `write` method that can be used to
  * write data directly to the implementation that `SinkRef.sink` writes to.
@@ -34,7 +34,7 @@ import akka.kafka.ConsumerMessage.CommittableOffset
  * }}}
  * but in that case it is not known when the value has been written.
  */
-trait WritableSinkRef[T] extends SinkRef[(T, CommittableOffset)] {
+trait WritableSinkRef[T] extends SinkRef[(T, Committable)] {
   /**
    * Writes the value to this SinkRef. The Future contains the written value
    * once the value has been written.

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
@@ -19,13 +19,17 @@ package cloudflow.akkastream
 import akka.NotUsed
 import akka.stream.javadsl._
 
-import akka.kafka.ConsumerMessage.CommittableOffset
+import akka.kafka.ConsumerMessage._
 
 package object javadsl {
   /**
    * Java API
    */
+  @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
   type FlowWithOffsetContext[In, Out] = FlowWithContext[In, CommittableOffset, Out, CommittableOffset, NotUsed]
+
+  type FlowWithCommittableContext[In, Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
+
   /**
    * Java API
    */
@@ -36,10 +40,21 @@ package javadsl {
   /**
    * Java API
    */
+  @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
   object FlowWithOffsetContext {
     /**
      * Creates a [[akka.stream.javadsl.FlowWithContext FlowWithContext]] that makes it possible for cloudflow to commit reads.
      */
+    @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
     def create[In]() = FlowWithContext.create[In, CommittableOffset]()
+  }
+  /**
+   * Java API
+   */
+  object FlowWithCommittableContext {
+    /**
+     * Creates a [[akka.stream.javadsl.FlowWithContext FlowWithContext]] that makes it possible for cloudflow to commit reads.
+     */
+    def create[In]() = FlowWithContext.create[In, Committable]()
   }
 }

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
@@ -33,7 +33,7 @@ package object javadsl {
   /**
    * Java API
    */
-  type SourceWithOffsetContext[T] = SourceWithContext[T, CommittableOffset, _]
+  type SourceWithOffsetContext[+T] = SourceWithContext[T, CommittableOffset, _]
 }
 
 package javadsl {

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
@@ -18,17 +18,30 @@ package cloudflow.akkastream
 
 import akka.NotUsed
 import akka.stream.scaladsl._
-import akka.kafka.ConsumerMessage.CommittableOffset
+import akka.kafka.ConsumerMessage._
 
 package object scaladsl {
+  @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
   type FlowWithOffsetContext[-In, +Out] = FlowWithContext[In, CommittableOffset, Out, CommittableOffset, NotUsed]
+  type FlowWithCommittableContext[-In, +Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
+
   type SourceWithOffsetContext[T] = SourceWithContext[T, CommittableOffset, NotUsed]
 
+  @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
   object FlowWithOffsetContext {
     /**
      * Creates a [[akka.stream.scaladsl.FlowWithContext FlowWithContext]] that makes it possible for cloudflow to commit reads when
      * `StreamletLogic.atLeastOnceSource` and `StreamletLogic.atLeastOnceSink` is used.
      */
+    @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
     def apply[In]() = FlowWithContext[In, CommittableOffset]
+  }
+
+  object FlowWithCommittableContext {
+    /**
+     * Creates a [[akka.stream.scaladsl.FlowWithContext FlowWithContext]] that makes it possible for cloudflow to commit reads when
+     * `StreamletLogic.atLeastOnceSource` and `StreamletLogic.atLeastOnceSink` is used.
+     */
+    def apply[In]() = FlowWithContext[In, Committable]
   }
 }

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
@@ -25,7 +25,7 @@ package object scaladsl {
   type FlowWithOffsetContext[-In, +Out] = FlowWithContext[In, CommittableOffset, Out, CommittableOffset, NotUsed]
   type FlowWithCommittableContext[-In, +Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
 
-  type SourceWithOffsetContext[T] = SourceWithContext[T, CommittableOffset, NotUsed]
+  type SourceWithOffsetContext[T] = SourceWithContext[T, CommittableOffset, _]
 
   @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
   object FlowWithOffsetContext {

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
@@ -25,7 +25,7 @@ package object scaladsl {
   type FlowWithOffsetContext[-In, +Out] = FlowWithContext[In, CommittableOffset, Out, CommittableOffset, NotUsed]
   type FlowWithCommittableContext[-In, +Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
 
-  type SourceWithOffsetContext[T] = SourceWithContext[T, CommittableOffset, _]
+  type SourceWithOffsetContext[+T] = SourceWithContext[T, CommittableOffset, _]
 
   @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
   object FlowWithOffsetContext {

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -2,11 +2,13 @@ import sbt._
 
 // format: OFF
 object Version {
-  val Scala     = "2.12.9"
-  val Akka      = "2.5.24"
-  val AkkaHttp  = "10.1.9"
-  val Spark     = "2.4.4"
-  val Flink     = "1.9.1"
+  val Scala        = "2.12.9"
+  val Akka         = "2.5.24"
+  val Kafka        = "2.4.0"
+  val AlpakkaKafka = "2.0.0"
+  val AkkaHttp     = "10.1.9"
+  val Spark        = "2.4.4"
+  val Flink        = "1.9.1"
 }
 
 object Library {
@@ -17,9 +19,9 @@ object Library {
   val AkkaStream            = "com.typesafe.akka"     %% "akka-stream"              % Version.Akka
   val AkkaSlf4j             = "com.typesafe.akka"     %% "akka-slf4j"               % Version.Akka
   val AkkaStreamContrib     = "com.typesafe.akka"     %% "akka-stream-contrib"      % "0.10"
-  val AkkaStreamKafka       = "com.typesafe.akka"     %% "akka-stream-kafka"        % "1.1.0"
+  val AkkaStreamKafka       = "com.typesafe.akka"     %% "akka-stream-kafka"        % Version.AlpakkaKafka
   val EmbeddedKafkaOrg      = "io.github.embeddedkafka"
-  val EmbeddedKafka         = EmbeddedKafkaOrg        %% "embedded-kafka"           % "2.2.0" exclude("com.fasterxml.jackson.core","jackson-databind")
+  val EmbeddedKafka         = EmbeddedKafkaOrg        %% "embedded-kafka"           % Version.Kafka exclude("com.fasterxml.jackson.core","jackson-databind")
   val Ficus                 = "com.iheart"            %% "ficus"                    % "1.4.7"
   val Config                = "com.typesafe"           % "config"                   % "1.3.4"
   val Logback               = "ch.qos.logback"         % "logback-classic"          % "1.2.3"
@@ -44,20 +46,21 @@ object Library {
   val FlinkAvro             = "org.apache.flink"       % "flink-avro"               % Version.Flink
   val FlinkKafka            = "org.apache.flink"      %% "flink-connector-kafka"    % Version.Flink
 
-  val FastClasspathScanner  = "io.github.lukehutch"    % "fast-classpath-scanner"   % "2.21"
-  val ScalaCheck            = "org.scalacheck"          %% "scalacheck"             % "1.14.0"
-  val Avro4sJson            = "com.sksamuel.avro4s"     %% "avro4s-json"            % "3.0.0"
+  val FastClasspathScanner  = "io.github.lukehutch"   %  "fast-classpath-scanner"   % "2.21"
+  val ScalaCheck            = "org.scalacheck"        %% "scalacheck"               % "1.14.0"
+  val Avro4sJson            = "com.sksamuel.avro4s"   %% "avro4s-json"              % "3.0.0"
 
   // Test Dependencies
-  val AkkaHttpTestkit       = "com.typesafe.akka"   %% "akka-http-testkit"          % Version.AkkaHttp % Test
-  val AkkaHttpSprayJsonTest = AkkaHttpSprayJson                                                        % Test
-  val AkkaStreamTestkit     = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka     % Test
-  val Avro4sTest            = "com.sksamuel.avro4s" %% "avro4s-core"                % "3.0.0"          % Test
-  val AkkaTestkit           = "com.typesafe.akka"   %% "akka-testkit"               % Version.Akka
-  val ScalaTest             = ScalaTestUnscoped                                                        % Test
-  val Junit                 = "junit"                % "junit"                      % "4.12"           % Test
-  val JUnitInterface        = "com.novocode"         % "junit-interface"            % "0.11"           % Test
-  val MockitoScala          = "org.mockito"         %% "mockito-scala-scalatest"    % "1.5.16"         % Test
+  val AkkaHttpTestkit        = "com.typesafe.akka"   %% "akka-http-testkit"          % Version.AkkaHttp % Test
+  val AkkaHttpSprayJsonTest  = AkkaHttpSprayJson                                                        % Test
+  val AkkaStreamKafkaTestkit = "com.typesafe.akka"   %% "akka-stream-kafka-testkit"  % Version.AlpakkaKafka
+  val AkkaStreamTestkit      = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka     % Test
+  val Avro4sTest             = "com.sksamuel.avro4s" %% "avro4s-core"                % "3.0.0"          % Test
+  val AkkaTestkit            = "com.typesafe.akka"   %% "akka-testkit"               % Version.Akka
+  val ScalaTest              = ScalaTestUnscoped                                                        % Test
+  val Junit                  = "junit"                % "junit"                      % "4.12"           % Test
+  val JUnitInterface         = "com.novocode"         % "junit-interface"            % "0.11"           % Test
+  val MockitoScala           = "org.mockito"         %% "mockito-scala-scalatest"    % "1.5.16"         % Test
 }
 
 // format: ON

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -19,9 +19,9 @@ object Library {
   val AkkaStream            = "com.typesafe.akka"     %% "akka-stream"              % Version.Akka
   val AkkaSlf4j             = "com.typesafe.akka"     %% "akka-slf4j"               % Version.Akka
   val AkkaStreamContrib     = "com.typesafe.akka"     %% "akka-stream-contrib"      % "0.10"
-  val AkkaStreamKafka       = "com.typesafe.akka"     %% "akka-stream-kafka"        % Version.AlpakkaKafka
+  val AkkaStreamKafka       = "com.typesafe.akka"     %% "akka-stream-kafka"        % Version.AlpakkaKafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
   val EmbeddedKafkaOrg      = "io.github.embeddedkafka"
-  val EmbeddedKafka         = EmbeddedKafkaOrg        %% "embedded-kafka"           % Version.Kafka exclude("com.fasterxml.jackson.core","jackson-databind")
+  val EmbeddedKafka         = EmbeddedKafkaOrg        %% "embedded-kafka"           % Version.Kafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
   val Ficus                 = "com.iheart"            %% "ficus"                    % "1.4.7"
   val Config                = "com.typesafe"           % "config"                   % "1.3.4"
   val Logback               = "ch.qos.logback"         % "logback-classic"          % "1.2.3"

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -20,6 +20,7 @@ object Library {
   val AkkaSlf4j             = "com.typesafe.akka"     %% "akka-slf4j"               % Version.Akka
   val AkkaStreamContrib     = "com.typesafe.akka"     %% "akka-stream-contrib"      % "0.10"
   val AkkaStreamKafka       = "com.typesafe.akka"     %% "akka-stream-kafka"        % Version.AlpakkaKafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
+  val AkkaStreamKafkaTestkit = "com.typesafe.akka"   %% "akka-stream-kafka-testkit" % Version.AlpakkaKafka exclude("com.typesafe.akka", "akka-stream-testkit")
   val EmbeddedKafkaOrg      = "io.github.embeddedkafka"
   val EmbeddedKafka         = EmbeddedKafkaOrg        %% "embedded-kafka"           % Version.Kafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
   val Ficus                 = "com.iheart"            %% "ficus"                    % "1.4.7"
@@ -51,16 +52,15 @@ object Library {
   val Avro4sJson            = "com.sksamuel.avro4s"   %% "avro4s-json"              % "3.0.0"
 
   // Test Dependencies
-  val AkkaHttpTestkit        = "com.typesafe.akka"   %% "akka-http-testkit"          % Version.AkkaHttp % Test
-  val AkkaHttpSprayJsonTest  = AkkaHttpSprayJson                                                        % Test
-  val AkkaStreamKafkaTestkit = "com.typesafe.akka"   %% "akka-stream-kafka-testkit"  % Version.AlpakkaKafka
-  val AkkaStreamTestkit      = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka     % Test
-  val Avro4sTest             = "com.sksamuel.avro4s" %% "avro4s-core"                % "3.0.0"          % Test
+  val AkkaHttpTestkit        = "com.typesafe.akka"   %% "akka-http-testkit"          % Version.AkkaHttp     % Test
+  val AkkaHttpSprayJsonTest  = AkkaHttpSprayJson                                                            % Test
+  val AkkaStreamTestkit      = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka         % Test 
+  val Avro4sTest             = "com.sksamuel.avro4s" %% "avro4s-core"                % "3.0.0"              % Test
   val AkkaTestkit            = "com.typesafe.akka"   %% "akka-testkit"               % Version.Akka
-  val ScalaTest              = ScalaTestUnscoped                                                        % Test
-  val Junit                  = "junit"                % "junit"                      % "4.12"           % Test
-  val JUnitInterface         = "com.novocode"         % "junit-interface"            % "0.11"           % Test
-  val MockitoScala           = "org.mockito"         %% "mockito-scala-scalatest"    % "1.5.16"         % Test
+  val ScalaTest              = ScalaTestUnscoped                                                            % Test
+  val Junit                  = "junit"                % "junit"                      % "4.12"               % Test
+  val JUnitInterface         = "com.novocode"         % "junit-interface"            % "0.11"               % Test
+  val MockitoScala           = "org.mockito"         %% "mockito-scala-scalatest"    % "1.5.16"             % Test
 }
 
 // format: ON

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Version {
   val Scala        = "2.12.9"
   val Akka         = "2.5.24"
   val Kafka        = "2.4.0"
-  val AlpakkaKafka = "2.0.0"
+  val AlpakkaKafka = "2.0.1"
   val AkkaHttp     = "10.1.9"
   val Spark        = "2.4.4"
   val Flink        = "1.9.1"
@@ -13,14 +13,14 @@ object Version {
 
 object Library {
   // External Libraries
-  val AkkaHttp              = "com.typesafe.akka"     %% "akka-http"                % Version.AkkaHttp
-  val AkkaHttpJackson       = "com.typesafe.akka"     %% "akka-http-jackson"        % Version.AkkaHttp
-  val AkkaHttpSprayJson     = "com.typesafe.akka"     %% "akka-http-spray-json"     % Version.AkkaHttp
-  val AkkaStream            = "com.typesafe.akka"     %% "akka-stream"              % Version.Akka
-  val AkkaSlf4j             = "com.typesafe.akka"     %% "akka-slf4j"               % Version.Akka
-  val AkkaStreamContrib     = "com.typesafe.akka"     %% "akka-stream-contrib"      % "0.10"
-  val AkkaStreamKafka       = "com.typesafe.akka"     %% "akka-stream-kafka"        % Version.AlpakkaKafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
-  val AkkaStreamKafkaTestkit = "com.typesafe.akka"   %% "akka-stream-kafka-testkit" % Version.AlpakkaKafka exclude("com.typesafe.akka", "akka-stream-testkit")
+  val AkkaHttp              = "com.typesafe.akka"     %% "akka-http"                 % Version.AkkaHttp
+  val AkkaHttpJackson       = "com.typesafe.akka"     %% "akka-http-jackson"         % Version.AkkaHttp
+  val AkkaHttpSprayJson     = "com.typesafe.akka"     %% "akka-http-spray-json"      % Version.AkkaHttp
+  val AkkaStream            = "com.typesafe.akka"     %% "akka-stream"               % Version.Akka
+  val AkkaSlf4j             = "com.typesafe.akka"     %% "akka-slf4j"                % Version.Akka
+  val AkkaStreamContrib     = "com.typesafe.akka"     %% "akka-stream-contrib"       % "0.10"
+  val AkkaStreamKafka       = "com.typesafe.akka"     %% "akka-stream-kafka"         % Version.AlpakkaKafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
+  val AkkaStreamKafkaTestkit = "com.typesafe.akka"    %% "akka-stream-kafka-testkit" % Version.AlpakkaKafka exclude("com.typesafe.akka", "akka-stream-testkit")
   val EmbeddedKafkaOrg      = "io.github.embeddedkafka"
   val EmbeddedKafka         = EmbeddedKafkaOrg        %% "embedded-kafka"           % Version.Kafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
   val Ficus                 = "com.iheart"            %% "ficus"                    % "1.4.7"

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowSparkLibraryPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowSparkLibraryPlugin.scala
@@ -33,7 +33,8 @@ object CloudflowSparkLibraryPlugin extends AutoPlugin {
       "com.lightbend.cloudflow" %% "cloudflow-spark" % BuildInfo.version,
       "com.lightbend.cloudflow" %% "cloudflow-spark-testkit" % BuildInfo.version % "test"
     ),
-
+    dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9",
+    dependencyOverrides += "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9",
     javaOptions in com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.Universal ++= Seq( // this is for local experimentation - do not remove
     // -J params will be added as jvm parameters
     // "-J-Xmx1536m",

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowSparkLibraryPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowSparkLibraryPlugin.scala
@@ -33,8 +33,9 @@ object CloudflowSparkLibraryPlugin extends AutoPlugin {
       "com.lightbend.cloudflow" %% "cloudflow-spark" % BuildInfo.version,
       "com.lightbend.cloudflow" %% "cloudflow-spark-testkit" % BuildInfo.version % "test"
     ),
+    // FIX for making sure these libraries do not get evicted, since that makes spark fail.
     dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9",
-    dependencyOverrides += "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9",
+    dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.9",
     javaOptions in com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.Universal ++= Seq( // this is for local experimentation - do not remove
     // -J params will be added as jvm parameters
     // "-J-Xmx1536m",

--- a/examples/call-record-aggregator/akka-cdr-ingestor/src/main/scala/carly/ingestor/CallRecordMerge.scala
+++ b/examples/call-record-aggregator/akka-cdr-ingestor/src/main/scala/carly/ingestor/CallRecordMerge.scala
@@ -19,7 +19,8 @@ package carly.ingestor
 import cloudflow.streamlets._
 import cloudflow.streamlets.avro._
 import cloudflow.akkastream._
-import cloudflow.akkastream.util.scaladsl.MergeLogic
+import cloudflow.akkastream.scaladsl._
+import cloudflow.akkastream.util.scaladsl.Merger
 
 import carly.data._
 
@@ -28,7 +29,9 @@ class CallRecordMerge extends AkkaStreamlet {
   val in1 = AvroInlet[CallRecord]("in-1")
   val in2 = AvroInlet[CallRecord]("in-2")
   val out = AvroOutlet[CallRecord]("out", _.user)
+
   final override val shape = StreamletShape.withInlets(in0, in1, in2).withOutlets(out)
+
   final override def createLogic = new RunnableGraphStreamletLogic() {
     def runnableGraph = Merger.source(in0, in1, in2).to(committableSink(out))
   }

--- a/examples/call-record-aggregator/akka-cdr-ingestor/src/main/scala/carly/ingestor/CallRecordMerge.scala
+++ b/examples/call-record-aggregator/akka-cdr-ingestor/src/main/scala/carly/ingestor/CallRecordMerge.scala
@@ -29,5 +29,7 @@ class CallRecordMerge extends AkkaStreamlet {
   val in2 = AvroInlet[CallRecord]("in-2")
   val out = AvroOutlet[CallRecord]("out", _.user)
   final override val shape = StreamletShape.withInlets(in0, in1, in2).withOutlets(out)
-  final override def createLogic = new MergeLogic(Vector(in0, in1, in2), out)
+  final override def createLogic = new RunnableGraphStreamletLogic() {
+    def runnableGraph = Merger.source(in0, in1, in2).to(committableSink(out))
+  }
 }

--- a/examples/call-record-aggregator/build.sbt
+++ b/examples/call-record-aggregator/build.sbt
@@ -39,9 +39,7 @@ lazy val akkaCdrIngestor= appModule("akka-cdr-ingestor")
         "com.typesafe.akka"         %% "akka-http-spray-json"   % "10.1.10",
         "ch.qos.logback"            %  "logback-classic"        % "1.2.3",
         "org.scalatest"             %% "scalatest"              % "3.0.8"    % "test"
-      ), 
-      dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9",
-      dependencyOverrides += "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9",
+      )
     )
   .dependsOn(datamodel)
 
@@ -53,9 +51,7 @@ lazy val akkaJavaAggregationOutput= appModule("akka-java-aggregation-output")
       "com.typesafe.akka"      %% "akka-http-spray-json"   % "10.1.10",
       "ch.qos.logback"         %  "logback-classic"        % "1.2.3",
       "org.scalatest"          %% "scalatest"              % "3.0.8"    % "test"
-    ), 
-      dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9",
-      dependencyOverrides += "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9",
+    )
   )
   .dependsOn(datamodel)
 
@@ -68,9 +64,7 @@ lazy val sparkAggregation = appModule("spark-aggregation")
       libraryDependencies ++= Seq(
 	      "ch.qos.logback" %  "logback-classic"    % "1.2.3",
         "org.scalatest"  %% "scalatest"          % "3.0.8"  % "test"
-      ), 
-      dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9",
-      dependencyOverrides += "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9",
+      )
     )
   .dependsOn(datamodel)
 

--- a/examples/call-record-aggregator/build.sbt
+++ b/examples/call-record-aggregator/build.sbt
@@ -39,7 +39,9 @@ lazy val akkaCdrIngestor= appModule("akka-cdr-ingestor")
         "com.typesafe.akka"         %% "akka-http-spray-json"   % "10.1.10",
         "ch.qos.logback"            %  "logback-classic"        % "1.2.3",
         "org.scalatest"             %% "scalatest"              % "3.0.8"    % "test"
-      )
+      ), 
+      dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9",
+      dependencyOverrides += "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9",
     )
   .dependsOn(datamodel)
 
@@ -51,7 +53,9 @@ lazy val akkaJavaAggregationOutput= appModule("akka-java-aggregation-output")
       "com.typesafe.akka"      %% "akka-http-spray-json"   % "10.1.10",
       "ch.qos.logback"         %  "logback-classic"        % "1.2.3",
       "org.scalatest"          %% "scalatest"              % "3.0.8"    % "test"
-    )
+    ), 
+      dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9",
+      dependencyOverrides += "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9",
   )
   .dependsOn(datamodel)
 
@@ -64,7 +68,9 @@ lazy val sparkAggregation = appModule("spark-aggregation")
       libraryDependencies ++= Seq(
 	      "ch.qos.logback" %  "logback-classic"    % "1.2.3",
         "org.scalatest"  %% "scalatest"          % "3.0.8"  % "test"
-      )
+      ), 
+      dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9",
+      dependencyOverrides += "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9",
     )
   .dependsOn(datamodel)
 

--- a/examples/call-record-aggregator/project/cloudflow-plugins.sbt
+++ b/examples/call-record-aggregator/project/cloudflow-plugins.sbt
@@ -2,4 +2,4 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.0")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-SNAPSHOT")

--- a/examples/sensor-data-java/project/cloudflow-plugins.sbt
+++ b/examples/sensor-data-java/project/cloudflow-plugins.sbt
@@ -2,4 +2,4 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.0")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-SNAPSHOT")

--- a/examples/sensor-data-java/src/main/java/sensordata/MetricsValidation.java
+++ b/examples/sensor-data-java/src/main/java/sensordata/MetricsValidation.java
@@ -44,7 +44,7 @@ public class MetricsValidation extends AkkaStreamlet {
   public AkkaStreamletLogic createLogic() {
     return new RunnableGraphStreamletLogic(getContext()) {
       public RunnableGraph createRunnableGraph() {
-        return getSourceWithOffsetContext(inlet).to(Splitter.<Metric, InvalidMetric, Metric>sink(createFlow(), invalidOutlet, validOutlet, getContext()));
+        return getSourceWithCommittableContext(inlet).to(Splitter.sink(createFlow(), invalidOutlet, validOutlet, getContext()));
       }
     };
   }

--- a/examples/sensor-data-java/src/main/java/sensordata/SensorDataToMetrics.java
+++ b/examples/sensor-data-java/src/main/java/sensordata/SensorDataToMetrics.java
@@ -19,7 +19,7 @@ package sensordata;
 import java.util.Arrays;
 
 import akka.stream.javadsl.*;
-import akka.kafka.ConsumerMessage.CommittableOffset;
+import akka.kafka.ConsumerMessage.Committable;
 
 import akka.NotUsed;
 
@@ -37,8 +37,8 @@ public class SensorDataToMetrics extends AkkaStreamlet {
    return StreamletShape.createWithInlets(in).withOutlets(out);
   }
 
-  private FlowWithContext<SensorData,CommittableOffset,Metric,CommittableOffset,NotUsed> flowWithContext() {
-    return FlowWithOffsetContext.<SensorData>create()
+  private FlowWithContext<SensorData,Committable,Metric,Committable,NotUsed> flowWithContext() {
+    return FlowWithCommittableContext.<SensorData>create()
       .mapConcat(data ->
         Arrays.asList(
           new Metric(data.getDeviceId(), data.getTimestamp(), "power", data.getMeasurements().getPower()),
@@ -51,7 +51,7 @@ public class SensorDataToMetrics extends AkkaStreamlet {
   public AkkaStreamletLogic createLogic() {
     return new RunnableGraphStreamletLogic(getContext()) {
       public RunnableGraph createRunnableGraph() {
-        return getSourceWithOffsetContext(in).via(flowWithContext()).to(getSinkWithOffsetContext(out));
+        return getSourceWithCommittableContext(in).via(flowWithContext()).to(getCommittableSink(out));
       }
     };
   }

--- a/examples/sensor-data-scala/project/cloudflow-plugins.sbt
+++ b/examples/sensor-data-scala/project/cloudflow-plugins.sbt
@@ -2,4 +2,4 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.0")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-SNAPSHOT")

--- a/examples/sensor-data-scala/src/main/resources/local.conf
+++ b/examples/sensor-data-scala/src/main/resources/local.conf
@@ -1,3 +1,6 @@
 file-ingress {
   source-data-mount="/tmp/cloudflow"
 }
+valid-logger {
+  log-level = "info"
+}

--- a/examples/sensor-data-scala/src/main/scala/sensordata/InvalidMetricLogger.scala
+++ b/examples/sensor-data-scala/src/main/scala/sensordata/InvalidMetricLogger.scala
@@ -26,14 +26,14 @@ class InvalidMetricLogger extends AkkaStreamlet {
   val shape = StreamletShape.withInlets(inlet)
 
   override def createLogic = new RunnableGraphStreamletLogic() {
-    val flow = FlowWithOffsetContext[InvalidMetric]
+    val flow = FlowWithCommittableContext[InvalidMetric]
       .map { invalidMetric ⇒
         system.log.warning(s"Invalid metric detected! $invalidMetric")
         invalidMetric
       }
 
     def runnableGraph = {
-      sourceWithOffsetContext(inlet).via(flow).to(sinkWithOffsetContext)
+      sourceWithOffsetContext(inlet).via(flow).to(committableSink)
     }
   }
 }

--- a/examples/sensor-data-scala/src/main/scala/sensordata/RotorSpeedFilter.scala
+++ b/examples/sensor-data-scala/src/main/scala/sensordata/RotorSpeedFilter.scala
@@ -27,7 +27,7 @@ class RotorSpeedFilter extends AkkaStreamlet {
   val shape = StreamletShape(in, out)
 
   override def createLogic = new RunnableGraphStreamletLogic() {
-    def runnableGraph = sourceWithOffsetContext(in).via(flow).to(sinkWithOffsetContext(out))
-    def flow = FlowWithOffsetContext[Metric].filter(_.name == "rotorSpeed")
+    def runnableGraph = sourceWithOffsetContext(in).via(flow).to(committableSink(out))
+    def flow = FlowWithCommittableContext[Metric].filter(_.name == "rotorSpeed")
   }
 }

--- a/examples/sensor-data-scala/src/main/scala/sensordata/SensorDataToMetrics.scala
+++ b/examples/sensor-data-scala/src/main/scala/sensordata/SensorDataToMetrics.scala
@@ -26,7 +26,7 @@ class SensorDataToMetrics extends AkkaStreamlet {
   val out = AvroOutlet[Metric]("out").withPartitioner(RoundRobinPartitioner)
   val shape = StreamletShape(in, out)
   def flow = {
-    FlowWithOffsetContext[SensorData]
+    FlowWithCommittableContext[SensorData]
       .mapConcat { data ⇒
         List(
           Metric(data.deviceId, data.timestamp, "power", data.measurements.power),
@@ -36,6 +36,6 @@ class SensorDataToMetrics extends AkkaStreamlet {
       }
   }
   override def createLogic = new RunnableGraphStreamletLogic() {
-    def runnableGraph = sourceWithOffsetContext(in).via(flow).to(sinkWithOffsetContext(out))
+    def runnableGraph = sourceWithOffsetContext(in).via(flow).to(committableSink(out))
   }
 }

--- a/examples/sensor-data-scala/src/main/scala/sensordata/ValidMetricLogger.scala
+++ b/examples/sensor-data-scala/src/main/scala/sensordata/ValidMetricLogger.scala
@@ -54,7 +54,7 @@ class ValidMetricLogger extends AkkaStreamlet {
     }
 
     def flow = {
-      FlowWithOffsetContext[Metric]
+      FlowWithCommittableContext[Metric]
         .map { validMetric ⇒
           log(validMetric)
           validMetric
@@ -62,7 +62,7 @@ class ValidMetricLogger extends AkkaStreamlet {
     }
 
     def runnableGraph = {
-      sourceWithOffsetContext(inlet).via(flow).to(sinkWithOffsetContext)
+      sourceWithOffsetContext(inlet).via(flow).to(committableSink)
     }
   }
 }

--- a/examples/spark-sensors/project/cloudflow-plugins.sbt
+++ b/examples/spark-sensors/project/cloudflow-plugins.sbt
@@ -2,4 +2,4 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.0")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-SNAPSHOT")

--- a/examples/taxi-ride/logger/src/main/scala/taxiride/logger/FarePerRideLogger.scala
+++ b/examples/taxi-ride/logger/src/main/scala/taxiride/logger/FarePerRideLogger.scala
@@ -55,7 +55,7 @@ class FarePerRideLogger extends AkkaStreamlet {
     }
 
     def flow = {
-      FlowWithOffsetContext[TaxiRideFare]
+      FlowWithCommittableContext[TaxiRideFare]
         .map { taxiRideFare ⇒
           log(taxiRideFare)
           taxiRideFare
@@ -65,6 +65,6 @@ class FarePerRideLogger extends AkkaStreamlet {
     def runnableGraph =
       sourceWithOffsetContext(inlet)
         .via(flow)
-        .to(sinkWithOffsetContext)
+        .to(committableSink)
   }
 }

--- a/examples/taxi-ride/project/cloudflow-plugins.sbt
+++ b/examples/taxi-ride/project/cloudflow-plugins.sbt
@@ -2,4 +2,4 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.0")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-SNAPSHOT")

--- a/examples/tensorflow-akka/project/cloudflow-plugins.sbt
+++ b/examples/tensorflow-akka/project/cloudflow-plugins.sbt
@@ -2,4 +2,4 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.0")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-SNAPSHOT")

--- a/examples/tensorflow-akka/src/main/scala/modelserving/wine/WineResultConsoleEgress.scala
+++ b/examples/tensorflow-akka/src/main/scala/modelserving/wine/WineResultConsoleEgress.scala
@@ -36,6 +36,6 @@ final case object WineResultConsoleEgress extends AkkaStreamlet {
 
     def write(record: WineResult): Unit = println(record.toString)
 
-    def runnableGraph = sourceWithOffsetContext(in).map(write(_)).to(sinkWithOffsetContext)
+    def runnableGraph = sourceWithOffsetContext(in).map(write(_)).to(committableSink)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
- Updated Alpakka Kafka to 2.0.1 release.
- Added committableSink and getCommittableSink methods, so that Committable can be used instead of CommittableOffset, so batches can be created.
- Deprecated sinkWithOffsetContext and getSinkWithOffsetContext methods.
- Deprecated use of FlowWithOffsetContext.
- Added better API for splitting and merging, `Splitter.sink` and `Merger.source`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
A new version of Alpakka Kafka was released, 2.0.1, which introduces many improvements.
https://github.com/lightbend/cloudflow/issues/100
https://github.com/lightbend/cloudflow/issues/96

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, new methods, committableSink, getCommittableSink, and FlowWithCommittableContext type aliases. Deprecation of sinkWithOffsetContext, getSinkWithOffsetContext, and FlowWithOffsetContext type aliases. Applies to both Java and Scala API.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The project builds, unit tests are green. (sbt internalRelease did not work properly, so examples are using snapshots in this PR.)

Example projects have been tested.
- [x] sensor-data-scala builds without changes (with deprecation warnings, as expected)
- [x] sensor-data-scala running locally as expected.
- [x] sensor-data-java builds without changes (with deprecation warnings, as expected)
- [x] sensor-data-scala running locally as expected.
- [x] taxi-ride builds without changes (with deprecation warnings, as expected)
- [x] taxi-ride running locally as expected.
- [x] call-record-aggregator builds as expected. jackson dependency problem is solved by setting the specific override in the CloudflowSparkLibraryPlugin.
- [x] call-record-aggregator runnin locally as expected.
- [x] All example projects are updated to not use deprecated API.