### PR TITLE
Change StreamletDescriptor, remove image and projectId - MultiImage epic

### DIFF
--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/StreamletDescriptor.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/StreamletDescriptor.scala
@@ -23,7 +23,6 @@ object StreamletDescriptor {
 }
 
 final case class StreamletDescriptor(
-    projectId: String,
     className: String,
     runtime: StreamletRuntimeDescriptor,
     labels: immutable.IndexedSeq[String],
@@ -32,7 +31,6 @@ final case class StreamletDescriptor(
     outlets: immutable.IndexedSeq[OutletDescriptor],
     configParameters: immutable.IndexedSeq[ConfigParameterDescriptor],
     attributes: immutable.IndexedSeq[StreamletAttributeDescriptor] = Vector.empty,
-    image: String,
     volumeMounts: immutable.IndexedSeq[VolumeMountDescriptor]
 ) {
   def isIngress: Boolean = inlets.isEmpty && outlets.nonEmpty

--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/StreamletDescriptorFormat.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/StreamletDescriptorFormat.scala
@@ -40,7 +40,6 @@ trait StreamletDescriptorFormat extends DefaultJsonProtocol {
 
   implicit val streamletDescriptorFormat = jsonFormat(
     StreamletDescriptor.apply,
-    "project_id",
     "class_name",
     "runtime",
     "labels",
@@ -49,7 +48,6 @@ trait StreamletDescriptorFormat extends DefaultJsonProtocol {
     "outlets",
     "config_parameters",
     "attributes",
-    "image",
     "volume_mounts"
   )
 }

--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/deployment/ApplicationDescriptor.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/deployment/ApplicationDescriptor.scala
@@ -54,6 +54,7 @@ object ApplicationDescriptor {
   def apply(
       appId: String,
       appVersion: String,
+      image: String,
       streamlets: Vector[StreamletInstance],
       connections: Vector[Connection],
       deployments: Vector[StreamletDeployment],
@@ -64,7 +65,7 @@ object ApplicationDescriptor {
       appVersion,
       streamlets,
       connections,
-      deployments,
+      deployments.map(deployment ⇒ deployment.copy(image = image)),
       agentPaths,
       Version,
       LibraryVersion
@@ -74,6 +75,7 @@ object ApplicationDescriptor {
   def apply(
       appId: String,
       appVersion: String,
+      image: String,
       blueprint: VerifiedBlueprint,
       agentPaths: Map[String, String]): ApplicationDescriptor = {
 
@@ -85,7 +87,7 @@ object ApplicationDescriptor {
         .zipWithIndex
         .map {
           case (streamlet, index) ⇒
-            StreamletDeployment(sanitizedApplicationId, streamlet, index, connections)
+            StreamletDeployment(sanitizedApplicationId, streamlet, image, index, connections)
         }
 
     ApplicationDescriptor(sanitizedApplicationId, appVersion, namedStreamletDescriptors, connections, deployments, agentPaths, Version, LibraryVersion)
@@ -154,6 +156,7 @@ object StreamletDeployment {
   def apply(
       appId: String,
       streamlet: StreamletInstance,
+      image: String,
       index: Int,
       allConnections: Vector[Connection],
       replicas: Option[Int] = None): StreamletDeployment = {
@@ -161,7 +164,7 @@ object StreamletDeployment {
     StreamletDeployment(
       name(appId, streamlet.name),
       streamlet.descriptor.runtime.name,
-      streamlet.descriptor.image,
+      image,
       streamlet.name,
       streamlet.descriptor.className,
       endpoint,

--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/StreamletDescriptorBuilder.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/StreamletDescriptorBuilder.scala
@@ -198,7 +198,6 @@ trait StreamletDescriptorBuilder extends EitherValues with OptionValues {
       runtime: String
   ): StreamletDescriptor = {
     StreamletDescriptor(
-      projectId = "prj",
       className = className,
       runtime = StreamletRuntimeDescriptor(runtime),
       labels = Vector.empty,
@@ -207,13 +206,11 @@ trait StreamletDescriptorBuilder extends EitherValues with OptionValues {
       outlets = Vector.empty,
       configParameters = Vector.empty,
       attributes = Vector.empty,
-      image = "image",
       volumeMounts = Vector.empty
     )
   }
 
   def buildStreamletDescriptor(
-      projectId: String,
       className: String,
       runtime: StreamletRuntimeDescriptor,
       labels: Vector[String],
@@ -222,11 +219,9 @@ trait StreamletDescriptorBuilder extends EitherValues with OptionValues {
       outlets: Vector[OutletDescriptor],
       configParameters: Vector[ConfigParameterDescriptor],
       attributes: Vector[StreamletAttributeDescriptor],
-      image: String,
       volumeMounts: Vector[VolumeMountDescriptor]
   ): StreamletDescriptor = {
     StreamletDescriptor(
-      projectId = projectId,
       className = className,
       runtime = runtime,
       labels = labels,
@@ -235,7 +230,6 @@ trait StreamletDescriptorBuilder extends EitherValues with OptionValues {
       outlets = outlets,
       configParameters = configParameters,
       attributes = attributes,
-      image = image,
       volumeMounts = volumeMounts
     )
   }
@@ -247,7 +241,6 @@ trait StreamletDescriptorBuilder extends EitherValues with OptionValues {
       className: String
   ): StreamletDescriptor = {
     StreamletDescriptor(
-      projectId = "prj",
       className = className,
       runtime = StreamletRuntimeDescriptor("akka"),
       labels = Vector.empty,
@@ -256,7 +249,6 @@ trait StreamletDescriptorBuilder extends EitherValues with OptionValues {
       outlets = Vector.empty,
       configParameters = Vector.empty,
       attributes = Vector.empty,
-      image = "image",
       volumeMounts = Vector.empty
     )
   }

--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/ApplicationDescriptorSpec.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/ApplicationDescriptorSpec.scala
@@ -20,6 +20,8 @@ import com.typesafe.config._
 import org.scalatest._
 
 import cloudflow.blueprint._
+import spray.json._
+import ApplicationDescriptorJsonFormat._
 
 class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherValues with OptionValues with GivenWhenThen {
   case class Foo(name: String)
@@ -49,7 +51,8 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
       val appId = "-monstrous-some-very-long-NAME-with-ü-in-the-middle-that-still-needs-more-characters-mite-12345."
       val truncatedAppId = "monstrous-some-very-long-name-with-u-in-the-middle-that-still"
       val appVersion = "42-abcdef0"
-      val descriptor = ApplicationDescriptor(appId, appVersion, verifiedBlueprint, agentPaths)
+      val image = "image-1"
+      val descriptor = ApplicationDescriptor(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       Then("the resulting descriptor application id and secret name must be valid")
       descriptor.appId mustBe truncatedAppId
@@ -77,12 +80,15 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
       When("I create a deployment descriptor from that blueprint")
       val appId = "monstrous-mite-12345"
       val appVersion = "42-abcdef0"
-      val descriptor = ApplicationDescriptor(appId, appVersion, verifiedBlueprint, agentPaths)
+      val image = "image-1"
+      val descriptor = ApplicationDescriptor(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       Then("the descriptor must be valid")
       descriptor.appId mustBe appId
       descriptor.appVersion mustBe appVersion
       descriptor.deployments.size mustBe 3
+      descriptor.deployments.map(_.image).toSet.size mustBe 1
+      descriptor.deployments.map(_.image).toSet.head mustBe image
       descriptor.streamlets.size mustBe 3
       descriptor.connections.size mustBe 2
 
@@ -97,7 +103,7 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
 
       ingressDeployment.name mustBe s"${appId}.${ingressRef.name}"
       ingressDeployment.runtime mustBe ingress.runtime.name
-      ingressDeployment.image mustBe ingress.image
+      ingressDeployment.image mustBe image
       ingressDeployment.className mustBe ingress.className
       ingressDeployment.endpoint mustBe Some(Endpoint(appId, ingressRef.name, ingressContainerPort))
       ingressDeployment.config.getInt("cloudflow.internal.server.container-port") mustBe ingressContainerPort
@@ -107,7 +113,7 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
 
       processorDeployment.name mustBe s"${appId}.${processorRef.name}"
       processorDeployment.runtime mustBe processor.runtime.name
-      processorDeployment.image mustBe processor.image
+      processorDeployment.image mustBe image
       processorDeployment.className mustBe processor.className
       processorDeployment.endpoint mustBe None
       processorDeployment.config mustBe ConfigFactory.empty()
@@ -118,7 +124,7 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
 
       egressDeployment.name mustBe s"${appId}.${egressRef.name}"
       egressDeployment.runtime mustBe egress.runtime.name
-      egressDeployment.image mustBe egress.image
+      egressDeployment.image mustBe image
       egressDeployment.className mustBe egress.className
       egressDeployment.endpoint mustBe Some(Endpoint(appId, egressRef.name, egressContainerPort))
       egressDeployment.config.getInt("cloudflow.internal.server.container-port") mustBe egressContainerPort
@@ -153,7 +159,8 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
       When("I create a deployment descriptor from that blueprint")
       val appId = "noisy-nissan-42"
       val appVersion = "1-2345678"
-      val descriptor = ApplicationDescriptor(appId, appVersion, verifiedBlueprint, agentPaths)
+      val image = "image-1"
+      val descriptor = ApplicationDescriptor(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       Then("the descriptor must be valid")
       descriptor.deployments.size mustBe 4
@@ -201,7 +208,8 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
       When("I create a deployment descriptor from that blueprint")
       val appId = "funky-foofighter-9862"
       val appVersion = "12-3456789"
-      val descriptor = ApplicationDescriptor(appId, appVersion, verifiedBlueprint, agentPaths)
+      val image = "image-1"
+      val descriptor = ApplicationDescriptor(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       Then("the descriptor must be valid")
       descriptor.deployments.size mustBe 3

--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/RunnerConfigSpec.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/RunnerConfigSpec.scala
@@ -106,6 +106,7 @@ class RunnerConfigSpec extends WordSpec with MustMatchers with OptionValues with
 
   val appId = "monstrous-mite-12345"
   val appVersion = "42-abcdef0"
+  val image = "image-1"
 
   val agentPaths = Map(ApplicationDescriptor.PrometheusAgentKey -> "/app/prometheus/prometheus.jar")
   val kafkaBootstrapServers = "kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092"
@@ -123,7 +124,7 @@ class RunnerConfigSpec extends WordSpec with MustMatchers with OptionValues with
     .connect(ingressRef.out, processorRef.in)
 
   val verifiedBlueprint = blueprint.verified.right.get
-  val descriptor = ApplicationDescriptor(appId, appVersion, verifiedBlueprint, agentPaths)
+  val descriptor = ApplicationDescriptor(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
   val allDeployments = descriptor.deployments
   val ingressDeployment = allDeployments.find(_.streamletName == ingressRef.name).value

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/CloudflowApplicationSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/CloudflowApplicationSpec.scala
@@ -49,9 +49,10 @@ class CloudflowApplicationSpec extends WordSpec
 
       val appId = "def-jux-12345"
       val appVersion = "42-abcdef0"
+      val image = "image-1"
       val agentPaths = Map("prometheus" -> "/app/prometheus/prometheus.jar")
 
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
       val cr = CloudflowApplication(newApp)
       val customResource = Json.fromJson[CloudflowApplication.CR](Json.toJson(cr)).asEither.right.value
       customResource.spec mustBe cr.spec

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/ResourceNamesSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/ResourceNamesSpec.scala
@@ -44,6 +44,7 @@ class ResourceNamesSpec extends WordSpec
   val testApp01 = {
     val appVersion = "001"
     val appId = "longappid9012345678900123456789001234567890"
+    val image = "image-1"
 
     val ingress = randomStreamlet().asIngress[Foo].withServerAttribute
     val egress = randomStreamlet().asEgress[Foo].withServerAttribute
@@ -58,13 +59,14 @@ class ResourceNamesSpec extends WordSpec
       .connect(ingressRef.out, egressRef.in)
       .verified.right.value
 
-    CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+    CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
   }
 
   // appId 80 characters.
   val testApp02 = {
     val appVersion = "001"
     val appId = "longappid9012345678900123456789001234567890012345678900123456789012345678901234567890"
+    val image = "image-1"
 
     val ingress = randomStreamlet().asIngress[Foo].withServerAttribute
     val egress = randomStreamlet().asEgress[Foo].withServerAttribute
@@ -79,7 +81,7 @@ class ResourceNamesSpec extends WordSpec
       .connect(ingressRef.out, egressRef.in)
       .verified.right.value
 
-    CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+    CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
   }
 
   "Deployments" should {

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/TestApplication.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/TestApplication.scala
@@ -26,6 +26,7 @@ object CloudflowApplicationSpecBuilder {
   def create(
       appId: String,
       appVersion: String,
+      image: String,
       blueprint: VerifiedBlueprint,
       agentPaths: Map[String, String]): CloudflowApplication.Spec = {
 
@@ -37,7 +38,7 @@ object CloudflowApplicationSpecBuilder {
         .zipWithIndex
         .map {
           case (streamlet, index) ⇒
-            StreamletDeployment(sanitizedApplicationId, streamlet, index, connections)
+            StreamletDeployment(sanitizedApplicationId, streamlet, image, index, connections)
         }
 
     CloudflowApplication.Spec(sanitizedApplicationId, appVersion, streamlets, connections, deployments, agentPaths)

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/EndpointActionsSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/EndpointActionsSpec.scala
@@ -57,9 +57,10 @@ class EndpointActionsSpec extends WordSpec
 
       val appId = "def-jux-12345"
       val appVersion = "42-abcdef0"
+      val image = "image-1"
 
       val currentApp = None
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       When("endpoint actions are created from a new app")
       val actions = EndpointActions(newApp, currentApp, namespace)
@@ -97,8 +98,9 @@ class EndpointActionsSpec extends WordSpec
 
       val appId = "def-jux-12345"
       val appVersion = "42-abcdef0"
+      val image = "image-1"
 
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
       val currentApp = Some(newApp)
 
       When("nothing changes in the new app")
@@ -126,12 +128,13 @@ class EndpointActionsSpec extends WordSpec
       val appId = "killer-mike-12345"
       val appVersion = "42-abcdef0"
       val newAppVersion = "43-abcdef0"
-      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val image = "image-1"
+      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       When("the new app removes the egress")
       val newBp =
         bp.disconnect(egressRef.in).remove(egressRef.name)
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, newBp.verified.right.value, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, image, newBp.verified.right.value, agentPaths)
       val actions = EndpointActions(newApp, Some(currentApp), namespace)
 
       Then("delete actions should be created")
@@ -164,14 +167,15 @@ class EndpointActionsSpec extends WordSpec
 
       val appId = "odd-future-12345"
       val appVersion = "42-abcdef0"
-      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val image = "image-1"
+      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       When("the new app adds an endpoint, ingress -> egress")
       val egressRef = egress.ref("egress")
       val newBp = bp.use(egressRef)
         .connect(ingressRef.out, egressRef.in)
       val newAppVersion = "43-abcdef0"
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, newBp.verified.right.value, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, image, newBp.verified.right.value, agentPaths)
 
       Then("create actions for service should be created for the new endpoint")
       val actions = EndpointActions(newApp, Some(currentApp), namespace)

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/EventActionsSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/EventActionsSpec.scala
@@ -48,11 +48,12 @@ class EventActionsSpec extends WordSpec
 
   val appId = "def-jux-12345"
   val appVersion = "42-abcdef0"
+  val image = "image-1"
 
   "EventActions" should {
     "create event resources for a new deployed app" in {
       Given("a new app")
-      val app = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val app = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
       val appCr = CloudflowApplication(app)
 
       When("Event actions are created from a new app")
@@ -67,8 +68,8 @@ class EventActionsSpec extends WordSpec
 
     "create event resources for an updated app that's already been deployed" in {
       Given("a new app")
-      val app = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
-      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val app = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
+      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       val currentAppCr = CloudflowApplication(currentApp)
 
@@ -84,7 +85,7 @@ class EventActionsSpec extends WordSpec
 
     "create event resources for an already deployed app with scaled streamlets" in {
       Given("a current app and a new app")
-      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
       val app = currentApp.copy(deployments = currentApp.deployments.map(deployment ⇒ deployment.copy(replicas = Some(2))))
 
       val currentAppCr = CloudflowApplication(currentApp)
@@ -104,7 +105,7 @@ class EventActionsSpec extends WordSpec
 
     "create event resources when streamlet configuration changes" in {
       Given("a current app")
-      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
       val currentAppCr = CloudflowApplication(currentApp)
 
       When("Event actions are created for a streamlet")
@@ -116,7 +117,7 @@ class EventActionsSpec extends WordSpec
 
     "create event resources for an app that is undeployed" in {
       Given("a current app")
-      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
       val currentAppCr = CloudflowApplication(currentApp)
 
       When("Event actions are created for a streamlet")

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/RunnerActionsSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/RunnerActionsSpec.scala
@@ -58,9 +58,10 @@ class RunnerActionsSpec extends WordSpec
 
       val appId = "def-jux-12345"
       val appVersion = "42-abcdef0"
+      val image = "image-1"
 
       val currentApp = None
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       When("runner actions are created from a new app")
       val actions = AkkaRunnerActions(newApp, currentApp, namespace)
@@ -104,8 +105,9 @@ class RunnerActionsSpec extends WordSpec
 
       val appId = "def-jux-12345"
       val appVersion = "42-abcdef0"
+      val image = "image-1"
 
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
       val currentApp = Some(newApp)
 
       When("nothing changes in the new app")
@@ -133,13 +135,14 @@ class RunnerActionsSpec extends WordSpec
 
       val appId = "thundercat-12345"
       val appVersion = "42-abcdef0"
+      val image = "image-1"
       val newAppVersion = appVersion // to compare configmap contents easier.
-      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       When("the new app removes the egress")
       val newBp =
         bp.disconnect(egressRef.in).remove(egressRef.name)
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, newBp.verified.right.value, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, image, newBp.verified.right.value, agentPaths)
       val actions = AkkaRunnerActions(newApp, Some(currentApp), namespace)
 
       Then("delete actions should be created")
@@ -175,14 +178,15 @@ class RunnerActionsSpec extends WordSpec
 
       val appId = "lord-quas-12345"
       val appVersion = "42-abcdef0"
-      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val image = "image-1"
+      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       When("the new app adds a runner, ingress -> egress")
       val egressRef = egress.ref("egress")
       val newBp = bp.use(egressRef)
         .connect(ingressRef.out, egressRef.in)
       val newAppVersion = appVersion // to compare configmap contents easier.
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, newBp.verified.right.value, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, image, newBp.verified.right.value, agentPaths)
 
       Then("create actions for runner resources should be created for the new endpoint")
       val actions = AkkaRunnerActions(newApp, Some(currentApp), namespace)

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/SavepointActionsSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/SavepointActionsSpec.scala
@@ -30,6 +30,7 @@ class SavepointActionsSpec extends WordSpec
   case class Bar(name: String)
   val namespace = "ns"
   val appVersion = "0.0.1"
+  val image = "image-1"
   val agentPaths = Map("prometheus" -> "/app/prometheus/prometheus.jar")
 
   "SavepointActions" should {
@@ -92,7 +93,8 @@ class SavepointActionsSpec extends WordSpec
       val appId = "monstrous-mite-12345"
       val appVersion = "42-abcdef0"
       val newAppVersion = "43-abcdef0"
-      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val image = "image-1"
+      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       val savepoint = currentApp.deployments.find(_.streamletName == "processor").value.portMappings(processor.out.name)
 
@@ -100,7 +102,7 @@ class SavepointActionsSpec extends WordSpec
       val newBp =
         bp.disconnect(egressRef.in).remove(egressRef.name)
           .disconnect(processorRef.in).remove(processorRef.name)
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, newBp.verified.right.value, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, image, newBp.verified.right.value, agentPaths)
       val actions = SavepointActions(newApp, Some(currentApp), true)
 
       Then("one delete action should be created for the processor outlet savepoint")
@@ -132,7 +134,8 @@ class SavepointActionsSpec extends WordSpec
 
       val appId = "monstrous-mite-12345"
       val appVersion = "42-abcdef0"
-      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+      val image = "image-1"
+      val currentApp = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
       When("the new app adds a savepoint, ingress -> processor -> egress")
       val processorRef = processor.ref("processor")
@@ -142,7 +145,7 @@ class SavepointActionsSpec extends WordSpec
         .connect(ingressRef.out, processorRef.in)
         .connect(processorRef.out, egressRef.in)
       val newAppVersion = "43-abcdef0"
-      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, newBp.verified.right.value, agentPaths)
+      val newApp = CloudflowApplicationSpecBuilder.create(appId, newAppVersion, image, newBp.verified.right.value, agentPaths)
       val savepoint = newApp.deployments.find(_.streamletName == "processor").value.portMappings(processor.out.name)
 
       Then("one create action should be created for the new savepoint between processor and egress")
@@ -188,7 +191,8 @@ class SavepointActionsSpec extends WordSpec
 
     val appId = "monstrous-mite-12345"
     val appVersion = "42-abcdef0"
+    val image = "image-1"
 
-    CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+    CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
   }
 }

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
@@ -64,7 +64,7 @@ class FlinkRunnerSpec extends WordSpecLike
       .connect(ingressRef.out, egressRef.in)
       .verified.right.value
 
-    val app = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+    val app = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
     val deployment = StreamletDeployment(
       name = appId,

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/SparkRunnerSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/SparkRunnerSpec.scala
@@ -64,7 +64,7 @@ class SparkRunnerSpec extends WordSpecLike
       .connect(ingressRef.out, egressRef.in)
       .verified.right.value
 
-    val app = CloudflowApplicationSpecBuilder.create(appId, appVersion, verifiedBlueprint, agentPaths)
+    val app = CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths)
 
     val deployment = StreamletDeployment(
       name = appId,

--- a/core/cloudflow-runner/src/main/scala/cloudflow/runner/LocalRunner.scala
+++ b/core/cloudflow-runner/src/main/scala/cloudflow/runner/LocalRunner.scala
@@ -117,7 +117,7 @@ object LocalRunner extends StreamletLoader {
         // Make sure that we convert any backslash in the path to a forward slash since we want to store this in a JSON value
         val localStorageDirectory = Files.createTempDirectory(s"local-runner-storage-${streamletName}").toFile.getAbsolutePath.replace('\\', '/')
         log.info(s"Using local storage directory: $localStorageDirectory")
-        val deployment: StreamletDeployment = StreamletDeployment(appDescriptor.appId, streamletDescriptor, idx, appDescriptor.connections)
+        val deployment: StreamletDeployment = StreamletDeployment(appDescriptor.appId, streamletDescriptor, "", idx, appDescriptor.connections)
         val runnerConfigObj = RunnerConfig(appId, appVersion, deployment, "localhost:" + kafkaPort)
         val runnerConfig = addStorageConfig(ConfigFactory.parseString(runnerConfigObj.data), localStorageDirectory)
         val streamletParamConfig = streamletParameterConfig.atPath("cloudflow.streamlets")

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/BlueprintVerificationPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/BlueprintVerificationPlugin.scala
@@ -71,11 +71,12 @@ object BlueprintVerificationPlugin extends AutoPlugin {
       val appId = (ThisProject / name).value
       val appVersion = cloudflowBuildNumber.value.buildNumber
       val agentPathsMap = agentPaths.value
+      val dockerImageName = cloudflowDockerImageName.value
 
       for {
         BlueprintVerified(bp, _) ← verificationResult.value.toOption
         verifiedBlueprint ← bp.verified.toOption
-      } yield ApplicationDescriptor(appId, appVersion, verifiedBlueprint, agentPathsMap)
+      } yield ApplicationDescriptor(appId, appVersion, dockerImageName.get.name, verifiedBlueprint, agentPathsMap)
     },
 
     fork in Compile := true

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
@@ -232,7 +232,7 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
     val streamletDescriptors: Seq[StreamletInstance] = appDescriptor.streamlets.sortBy(_.name)
     val streamletInfo = streamletDescriptors.zipWithIndex.map {
       case (streamlet, idx) ⇒
-        val deployment = StreamletDeployment(appDescriptor.appId, streamlet, idx, appDescriptor.connections)
+        val deployment = StreamletDeployment(appDescriptor.appId, streamlet, "", idx, appDescriptor.connections)
         val serverPort: Option[Int] = if (deployment.config.hasPath(ServerAttribute.configPath)) {
           Some(ServerAttribute.containerPort(deployment.config))
         } else {

--- a/kubectl-cloudflow/deploy/deploy.go
+++ b/kubectl-cloudflow/deploy/deploy.go
@@ -89,10 +89,6 @@ func GetCloudflowApplicationDescriptorFromDockerImage(dockerRegistryURL string, 
 	for i := range spec.Deployments {
 		spec.Deployments[i].Image = imageRef
 	}
-	// replace tagged images with digest based names
-	for i := range spec.Streamlets {
-		spec.Streamlets[i].Descriptor.DockerImage = imageRef
-	}
 	return spec, *pulledImage
 }
 

--- a/kubectl-cloudflow/domain/cloudflowapplication.go
+++ b/kubectl-cloudflow/domain/cloudflowapplication.go
@@ -95,11 +95,9 @@ type Descriptor struct {
 	ClassName        string                      `json:"class_name"`
 	ConfigParameters []ConfigParameterDescriptor `json:"config_parameters"`
 	VolumeMounts     []VolumeMountDescriptor     `json:"volume_mounts"`
-	DockerImage      string                      `json:"image"`
 	Inlets           []InOutlet                  `json:"inlets"`
 	Labels           []string                    `json:"labels"`
 	Outlets          []InOutlet                  `json:"outlets"`
-	ProjectID        string                      `json:"project_id"`
 	Runtime          string                      `json:"runtime"`
 	Description      string                      `json:"description"`
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
* This is one of the tasks in multi-image epic where the user would like to deploy a cloudflow application with multiple images. This one refactors `ApplicationDescriptor` and associated changes in `StreamletDescriptor`, `StreamletDeployment` and other classes.
* Associated changes in CLI

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

* This is one of the first steps towards multi-image cloudflow application deployment 

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

* Yes, it has user facing changes as it's an architectural change for cloudflow

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

* All unit tests are made to run green
* Tested the following configurations on GKE (no changes in operator):
  * New library + new CLI => works
  * Old library + new CLI   => works
  * New library + old CLI   => works