### PR TITLE
Config file support, env var support, application and streamlet level support.

### DIFF
--- a/kubectl-cloudflow/cmd/configure.go
+++ b/kubectl-cloudflow/cmd/configure.go
@@ -41,11 +41,15 @@ func (c *configureApplicationCMD) configureImpl(cmd *cobra.Command, args []strin
 	version.FailOnProtocolVersionMismatch()
 
 	applicationName := args[0]
+
+	// TODO parse configFiles and validate them against descriptor (done in separate task)
+
 	for _, file := range c.configFiles {
 		if !deploy.FileExists(file) {
 			util.LogAndExit("configuration file %s passed with --conf does not exist", file)
 		}
 	}
+
 	cloudflowApplicationClient, err := k8s.GetCloudflowApplicationClient(applicationName)
 	if err != nil {
 		util.LogAndExit("Failed to create new client for Cloudflow application `%s`, %s", applicationName, err.Error())

--- a/kubectl-cloudflow/cmd/deploy.go
+++ b/kubectl-cloudflow/cmd/deploy.go
@@ -132,9 +132,9 @@ func (opts *deployOptions) deployImpl(cmd *cobra.Command, args []string) {
 
 	configurationArguments := deploy.SplitConfigurationParameters(args[1:])
 
-	deploy.HandleConfig(k8sClient, namespace, applicationSpec, configurationArguments, opts.configFiles)
-
 	createNamespaceIfNotExist(k8sClient, applicationSpec)
+
+	deploy.HandleConfig(k8sClient, namespace, applicationSpec, configurationArguments, opts.configFiles)
 
 	if pulledImage.Authenticated {
 		if err := verifyPasswordOptions(opts); err == nil {

--- a/kubectl-cloudflow/cmd/deploy.go
+++ b/kubectl-cloudflow/cmd/deploy.go
@@ -140,7 +140,7 @@ func (opts *deployOptions) deployImpl(cmd *cobra.Command, args []string) {
 	configurationParameters = deploy.AppendDefaultValuesForMissingConfigurationValues(applicationSpec, configurationParameters)
 	configurationKeyValues, validationError := deploy.ValidateConfigurationAgainstDescriptor(applicationSpec, configurationParameters)
 
-	// TODO validate configuration files against descriptor (done in separate task)
+	// TODO parse configFiles and validate them against descriptor (done in separate task)
 
 	if validationError != nil {
 		util.LogAndExit("%s", validationError.Error())

--- a/kubectl-cloudflow/deploy/deploy.go
+++ b/kubectl-cloudflow/deploy/deploy.go
@@ -365,7 +365,7 @@ func addApplicationLevelConfig(configMergedFromFiles *configuration.Config, stre
 			}
 		}
 
-		streamletLevelConf := streamletConfig.GetConfig(fmt.Sprintf("cloudflow.streamlets.%s.application-level", streamletName))
+		streamletLevelConf := streamletConfig.GetConfig(fmt.Sprintf("cloudflow.streamlets.%s.application-conf", streamletName))
 		if streamletLevelConf != nil {
 			streamletConfigs[streamletName] = mergeWithFallback(streamletLevelConf, streamletConfig)
 		}

--- a/kubectl-cloudflow/deploy/deploy.go
+++ b/kubectl-cloudflow/deploy/deploy.go
@@ -465,6 +465,12 @@ func addArguments(spec domain.CloudflowApplicationSpec, configs map[string]*conf
 
 // workaround for WithFallback not working in go-akka/configuration
 func mergeWithFallback(config *configuration.Config, fallback *configuration.Config) *configuration.Config {
+	if config == nil {
+		config = configuration.ParseString("")
+	}
+	if fallback == nil {
+		fallback = configuration.ParseString("")
+	}
 	confStr := config.String()
 	fallbackStr := fallback.String()
 	var sb strings.Builder

--- a/kubectl-cloudflow/deploy/deploy.go
+++ b/kubectl-cloudflow/deploy/deploy.go
@@ -451,17 +451,17 @@ func addArguments(spec domain.CloudflowApplicationSpec, configs map[string]*conf
 		}
 	}
 
-	var sbAppLevel strings.Builder
+	var sbNonValidatedParameters strings.Builder
 	for key, configValue := range configurationArguments {
 		if _, ok := written[key]; !ok {
-			sbAppLevel.WriteString(fmt.Sprintf("%s=\"%s\"\r\n", key, configValue))
+			sbNonValidatedParameters.WriteString(fmt.Sprintf("%s%s=\"%s\"\r\n", cloudflowStreamletsPrefix, key, configValue))
 		}
 	}
-	if sbAppLevel.Len() > 0 {
-		appLevelConfFromArgs := configuration.ParseString(sbAppLevel.String())
+	if sbNonValidatedParameters.Len() > 0 {
+		nonValidatedConfFromArgs := configuration.ParseString(sbNonValidatedParameters.String())
 
 		for streamletName, config := range configs {
-			configs[streamletName] = mergeWithFallback(appLevelConfFromArgs, config)
+			configs[streamletName] = mergeWithFallback(nonValidatedConfFromArgs, config)
 		}
 	}
 	return configs

--- a/kubectl-cloudflow/deploy/deploy.go
+++ b/kubectl-cloudflow/deploy/deploy.go
@@ -206,7 +206,7 @@ func validateConfigurationAgainstDescriptor(spec domain.CloudflowApplicationSpec
 	for _, streamlet := range spec.Streamlets {
 		conf := streamletConfigs[streamlet.Name]
 		if conf == nil {
-			conf = configuration.ParseString("")
+			conf = EmptyConfig()
 		}
 		for _, descriptor := range streamlet.Descriptor.ConfigParameters {
 			streamletConfigKey := prefixWithStreamletName(streamlet.Name, descriptor.Key)
@@ -470,10 +470,10 @@ func addArguments(spec domain.CloudflowApplicationSpec, configs map[string]*conf
 // workaround for WithFallback not working in go-akka/configuration
 func mergeWithFallback(config *configuration.Config, fallback *configuration.Config) *configuration.Config {
 	if config == nil {
-		config = configuration.ParseString("")
+		config = EmptyConfig()
 	}
 	if fallback == nil {
-		fallback = configuration.ParseString("")
+		fallback = EmptyConfig()
 	}
 	confStr := config.String()
 	fallbackStr := fallback.String()
@@ -487,6 +487,11 @@ func mergeWithFallback(config *configuration.Config, fallback *configuration.Con
 	sb.WriteString("\n")
 	conf := configuration.ParseString(sb.String()).GetConfig("a")
 	return conf
+}
+
+//EmptyConfig creates an empty config (workaround, not found in go-akka configuration)
+func EmptyConfig() *configuration.Config {
+	return configuration.ParseString("")
 }
 
 func createStreamletSecrets(k8sClient *kubernetes.Clientset, namespace string, streamletNameSecretMap map[string]*corev1.Secret) {

--- a/kubectl-cloudflow/deploy/deploy.go
+++ b/kubectl-cloudflow/deploy/deploy.go
@@ -306,7 +306,7 @@ func handleConfig(
 	configFiles []string,
 	existingConfigs map[string]*configuration.Config) (map[string]*corev1.Secret, error) {
 
-	configMergedFromFiles, err := loadAndMergeConfigs(applicationSpec, configFiles, configurationArguments)
+	configMergedFromFiles, err := loadAndMergeConfigs(configFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +382,7 @@ func moveToRoot(config *configuration.Config, root string) *configuration.Config
 }
 
 //LoadAndMergeConfigs loads specified configuration files and merges them into one Config
-func loadAndMergeConfigs(spec domain.CloudflowApplicationSpec, configFiles []string, configurationArguments map[string]string) (*configuration.Config, error) {
+func loadAndMergeConfigs(configFiles []string) (*configuration.Config, error) {
 	// For some reason WithFallback does not work as expected, so we'll use this workaround for now.
 	var sb strings.Builder
 

--- a/kubectl-cloudflow/deploy/deploy_test.go
+++ b/kubectl-cloudflow/deploy/deploy_test.go
@@ -94,3 +94,24 @@ func Test_CreateSecretsData(t *testing.T) {
 	assert.True(t, config.GetString("cloudflow.streamlets.valid-logger.log-level") == "warning")
 	assert.True(t, config.GetString("cloudflow.streamlets.valid-logger.msg-prefix") == "test")
 }
+
+func Test_loadAndMergeConfigs(t *testing.T) {
+	conf, err := loadAndMergeConfigs([]string{"non-existing.conf", "non-existing.conf"})
+	assert.NotEmpty(t, err)
+
+	_, err = loadAndMergeConfigs([]string{"non-existing.conf", "test_config_files/test1.conf"})
+	assert.NotEmpty(t, err)
+
+	conf, err = loadAndMergeConfigs([]string{"test_config_files/test1.conf", "test_config_files/test2.conf"})
+	assert.Empty(t, err)
+	assert.Equal(t, "5m", conf.GetString("cloudflow.streamlets.cdr-aggregator.watermark"))
+	assert.Equal(t, "12m", conf.GetString("cloudflow.streamlets.cdr-aggregator.group-by-window"))
+	assert.EqualValues(t, 5, conf.GetInt32("cloudflow.streamlets.cdr-generator1.records-per-second"))
+
+	conf, err = loadAndMergeConfigs([]string{"test_config_files/test1.conf", "test_config_files/test2.conf", "test_config_files/test3.conf"})
+	assert.Empty(t, err)
+	assert.Equal(t, "5m", conf.GetString("cloudflow.streamlets.cdr-aggregator.watermark"))
+	assert.Equal(t, "11m", conf.GetString("cloudflow.streamlets.cdr-aggregator.group-by-window"))
+	assert.EqualValues(t, 5, conf.GetInt32("cloudflow.streamlets.cdr-generator1.records-per-second"))
+	assert.Equal(t, "WARNING", conf.GetString("cloudflow.streamlets.cdr-aggregator.application-conf.akka.loglevel"))
+}

--- a/kubectl-cloudflow/deploy/deploy_test.go
+++ b/kubectl-cloudflow/deploy/deploy_test.go
@@ -160,7 +160,7 @@ func Test_addArguments(t *testing.T) {
 	aggConf := configuration.LoadConfig("test_config_files/cdr-aggregator.conf")
 
 	genConf := configuration.LoadConfig("test_config_files/cdr-generator1.conf")
-	conf := configuration.ParseString("")
+	conf := EmptyConfig()
 
 	spec := domain.CloudflowApplicationSpec{
 		Streamlets: []domain.Streamlet{
@@ -258,7 +258,7 @@ func Test_validateConfigFiles(t *testing.T) {
 	aggConf := configuration.LoadConfig("test_config_files/cdr-aggregator.conf")
 
 	genConf := configuration.LoadConfig("test_config_files/cdr-generator1.conf")
-	conf := configuration.ParseString("")
+	conf := EmptyConfig()
 
 	spec := domain.CloudflowApplicationSpec{
 		Streamlets: []domain.Streamlet{

--- a/kubectl-cloudflow/deploy/deploy_test.go
+++ b/kubectl-cloudflow/deploy/deploy_test.go
@@ -78,7 +78,8 @@ func Test_CreateSecretsData(t *testing.T) {
 
 	properConfig := SplitConfigurationParameters(commandLineForConfiguration())
 
-	secrets := CreateSecretsData(&spec, properConfig)
+	secrets, err := CreateSecretsData(&spec, properConfig, []string{})
+	assert.Empty(t, err)
 
 	assert.NotEmpty(t, secrets)
 	assert.True(t, len(secrets["valid-logger"].Name) <= 63)

--- a/kubectl-cloudflow/deploy/test_config_files/bad-cdr-aggregator.conf
+++ b/kubectl-cloudflow/deploy/test_config_files/bad-cdr-aggregator.conf
@@ -1,0 +1,4 @@
+cloudflow.streamlets.cdr-aggregator {
+  watermark="test"
+  group-by-window="bla"
+}

--- a/kubectl-cloudflow/deploy/test_config_files/cdr-aggregator-with-app-level.conf
+++ b/kubectl-cloudflow/deploy/test_config_files/cdr-aggregator-with-app-level.conf
@@ -1,0 +1,31 @@
+cloudflow {
+  streamlets {
+    cdr-aggregator {
+      group-by-window="12m"
+      application-conf {
+        akka.loglevel = "INFO"
+        akka {
+          stdout-loglevel = "WARNING"
+          kafka.producer {
+            # Config path of Akka Discovery method
+            # "akka.discovery" to use the Akka Discovery method configured for the ActorSystem
+            discovery-method = akka.discovery
+
+            # Set a service name for use with Akka Discovery
+            # https://doc.akka.io/docs/alpakka-kafka/current/discovery.html
+            service-name = "my-service"
+
+            # Timeout for getting a reply from the discovery-method lookup
+            resolve-timeout = 5 seconds
+
+            # Tuning parameter of how many sends that can run in parallel.
+            # In 2.0.0: changed the default from 100 to 10000
+            parallelism = 20000
+
+            # Duration to wait for `KafkaProducer.close` to finish.
+            close-timeout = 120s
+        }
+      }
+    }
+  }
+}

--- a/kubectl-cloudflow/deploy/test_config_files/cdr-aggregator.conf
+++ b/kubectl-cloudflow/deploy/test_config_files/cdr-aggregator.conf
@@ -1,0 +1,4 @@
+cloudflow.streamlets.cdr-aggregator {
+  watermark="2m"
+  group-by-window="15m"
+}

--- a/kubectl-cloudflow/deploy/test_config_files/cdr-generator1.conf
+++ b/kubectl-cloudflow/deploy/test_config_files/cdr-generator1.conf
@@ -1,0 +1,1 @@
+cloudflow.streamlets.cdr-generator1.records-per-second = 8

--- a/kubectl-cloudflow/deploy/test_config_files/test1.conf
+++ b/kubectl-cloudflow/deploy/test_config_files/test1.conf
@@ -1,0 +1,9 @@
+cloudflow {
+  streamlets {
+    cdr-aggregator {
+      group-by-window = 12m
+    }
+  }
+}
+
+cloudflow.streamlets.cdr-generator1.records-per-second = 10

--- a/kubectl-cloudflow/deploy/test_config_files/test2.conf
+++ b/kubectl-cloudflow/deploy/test_config_files/test2.conf
@@ -1,0 +1,9 @@
+cloudflow {
+  streamlets {
+    cdr-aggregator {
+      watermark = 5m
+    }
+  }
+}
+
+cloudflow.streamlets.cdr-generator1.records-per-second = 5

--- a/kubectl-cloudflow/deploy/test_config_files/test3.conf
+++ b/kubectl-cloudflow/deploy/test_config_files/test3.conf
@@ -1,0 +1,11 @@
+cloudflow {
+  streamlets {
+    cdr-aggregator {
+      group-by-window = 11m
+
+      application-conf {
+        akka.loglevel = "WARNING"
+      }
+    }
+  }
+}

--- a/kubectl-cloudflow/go.mod
+++ b/kubectl-cloudflow/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/docker/docker v0.0.0-20190327063223-da823cf3a5a3
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
+	github.com/go-akka/configuration v0.0.0-20200115015912-550403a6bd87 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
@@ -33,6 +34,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
+	github.com/rayroestenburg/configuration v0.0.0-20200115015912-550403a6bd87
 	github.com/sirupsen/logrus v1.4.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/kubectl-cloudflow/go.sum
+++ b/kubectl-cloudflow/go.sum
@@ -283,7 +283,6 @@ k8s.io/api v0.0.0-20190313115550-3c12c96769cc h1:m/JS6kQd00rICnXLWlnJzMFQB4AplcU
 k8s.io/api v0.0.0-20190313115550-3c12c96769cc/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20190326224424-4ceb6b6c5db5 h1:cCw1HjzHT95HKn2M27Rwf71ZMhppuqB0LXpVCZW5D0c=
 k8s.io/apimachinery v0.0.0-20190326224424-4ceb6b6c5db5/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/apimachinery v0.17.0 h1:xRBnuie9rXcPxUkDizUsGvPf1cnlZCFu210op7J7LJo=
 k8s.io/client-go v0.0.0-20190327024830-35ae057ca185 h1:CUSpHYQlXw/SLKVu3YDhjY6dqt1JzBEH+t5jYWo7Tno=
 k8s.io/client-go v0.0.0-20190327024830-35ae057ca185/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=

--- a/kubectl-cloudflow/go.sum
+++ b/kubectl-cloudflow/go.sum
@@ -46,6 +46,8 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
+github.com/go-akka/configuration v0.0.0-20200115015912-550403a6bd87 h1:qsA6HPoRXYJ1a2fsHVUmieRTg+otMAM4wEJgSWzumL8=
+github.com/go-akka/configuration v0.0.0-20200115015912-550403a6bd87/go.mod h1:19bUnum2ZAeftfwwLZ/wRe7idyfoW2MfmXO464Hrfbw=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -151,6 +153,8 @@ github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/rayroestenburg/configuration v0.0.0-20200115015912-550403a6bd87 h1:JTGDqHa23LTUjEsJQorToCYedKxI6SM9SkhooYyKlTw=
+github.com/rayroestenburg/configuration v0.0.0-20200115015912-550403a6bd87/go.mod h1:DDz0XR3vqQNTOcn80dzCAwQdCOywD9AP+VXeWgRjEc4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
- [x] Support passing through config files, which are automatically merged in order specified (last takes most precedence)
- [x] Support application level configuration (pass through config for all streamlets)
- [x] Support streamlet specific configuration (using the application-level section, it's content is copied to the root of the conf)
- [x] Support env var replacements (env vars in the env where kubectl cloudflow is running) 
- [x] Allow config args to pass through subsystem config

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improvements to configuration system. This prepares for other planned changes, to be able eto easily configure any aspect of a cloudflow application.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, users will be able to pass config files in HOCON format to kubectl-cloudflow. configuration parameters used in the file are validated, just like the arguments are validated. It is possible to pass through config that should not be validated with configuration parameters.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested on a Cloudflow cluster, as wel as unit testing.
- [x] Add more tests
- [ ] Docs
- [ ] Docs: Describe some limitations of config file support  (looks like only a = ${b.c.d} does not work, and does not read beyond root braces, which I think is maybe correct: https://github.com/lightbend/config/blob/master/HOCON.md#omit-root-braces)
