### PR TITLE
Spark image for multi-image app support

### DIFF
--- a/external/multi-base-images/spark/Dockerfile
+++ b/external/multi-base-images/spark/Dockerfile
@@ -1,0 +1,85 @@
+#
+# Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM adoptopenjdk/openjdk8
+
+ARG spark_uid=185
+
+COPY jars /opt/spark/jars
+COPY bin /opt/spark/bin
+COPY sbin /opt/spark/sbin
+COPY kubernetes/dockerfiles/spark/entrypoint.sh /opt/
+COPY examples /opt/spark/examples
+COPY kubernetes/tests /opt/spark/tests
+COPY data /opt/spark/data
+COPY metrics.properties /etc/metrics/conf/metrics.properties
+COPY prometheus.yaml /etc/metrics/conf/prometheus.yaml
+COPY log4j.properties /opt/log4j.properties
+ADD spark-entrypoint.sh /opt/spark-entrypoint.sh
+
+# Before building the docker image, first build and make a Spark distribution following
+# the instructions in http://spark.apache.org/docs/latest/building-spark.html.
+# If this docker file is being used in the context of building your images from a Spark
+# distribution, the docker build command should be invoked from the top level directory
+# of the Spark distribution. E.g.:
+# docker build -t spark:latest -f kubernetes/dockerfiles/spark/Dockerfile .
+ENV TINI_VERSION v0.18.0
+RUN set -ex && \
+    apt-get update && \
+    ln -s /lib /lib64 && \
+    apt install -y bash libc6 libpam-modules krb5-user libnss3 && \
+    mkdir -p /opt/spark/work-dir && \
+    touch /opt/spark/RELEASE && \
+    rm /bin/sh && \
+    ln -sv /bin/bash /bin/sh && \
+    echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
+    chgrp root /etc/passwd && chmod ug+rw /etc/passwd && \
+    rm -rf /var/cache/apt/* && \
+    curl -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /sbin/tini && \
+    chmod +x /sbin/tini && \
+    groupadd -r cloudflow -g 185 && \
+    useradd -u 185 -r -g root -G cloudflow -m -d /home/cloudflow \
+    -s /sbin/nologin -c CloudflowUser cloudflow && \
+    mkdir -p /prometheus && \
+    curl  https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar -o /prometheus/jmx_prometheus_javaagent-0.11.0.jar && \
+    chmod ug+rwX /home/cloudflow && \
+    mkdir -p /opt/spark/conf && \
+    mv /opt/log4j.properties /opt/spark/conf/log4j.properties && \
+    chgrp -R 0 /opt/spark  && \
+    chmod -R g=u /opt/spark && \
+    chmod -R u+x /opt/spark/bin && \
+    chmod -R u+x /opt/spark/sbin && \
+    chgrp -R 0 /prometheus  && \
+    chmod -R g=u /prometheus && \
+    chgrp -R 0 /etc/metrics/conf  && \
+    chmod -R g=u /etc/metrics/conf && \
+    chown cloudflow:root /opt && \
+    chmod 775 /opt
+
+
+ENV SPARK_HOME=/opt/spark \
+    SPARK_VERSION=2.4.4
+
+WORKDIR /opt/spark/work-dir
+RUN chmod g+w /opt/spark/work-dir
+
+ENTRYPOINT [ "/opt/spark-entrypoint.sh" ]
+
+# Specify the User that the actual main process will run as
+USER ${spark_uid}

--- a/external/multi-base-images/spark/log4j.properties
+++ b/external/multi-base-images/spark/log4j.properties
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Set the default spark-shell log level to WARN. When running the spark-shell, the
+# log level for this class is used to overwrite the root logger's log level, so that
+# the user can have different defaults for the shell and regular Spark apps.
+log4j.logger.org.apache.spark.repl.Main=WARN
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.spark_project.jetty=WARN
+log4j.logger.org.spark_project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR

--- a/external/multi-base-images/spark/metrics.properties
+++ b/external/multi-base-images/spark/metrics.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+*.sink.jmx.class=org.apache.spark.metrics.sink.JmxSink
+driver.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+executor.source.jvm.class=org.apache.spark.metrics.source.JvmSource

--- a/external/multi-base-images/spark/prometheus.yaml
+++ b/external/multi-base-images/spark/prometheus.yaml
@@ -1,0 +1,171 @@
+#
+# Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+rules:
+
+  # These come from the master
+  # Example: master.aliveWorkers
+  - pattern: "metrics<name=master\\.(.*)><>Value"
+    name: spark_master_$1
+
+  # These come from the worker
+  # Example: worker.coresFree
+  - pattern: "metrics<name=worker\\.(.*)><>Value"
+    name: spark_worker_$1
+
+  # These come from the application driver
+  # Example: app-20160809000059-0000.driver.DAGScheduler.stage.failedStages
+  - pattern: "metrics<name=(.*)\\.driver\\.(DAGScheduler|BlockManager|jvm|appStatus)\\.(.*)><>Value"
+    name: spark_driver_$2_$3
+    type: GAUGE
+    labels:
+      app_id: "$1"
+
+  # These come from the application driver
+  # Counters for appStatus
+  - pattern: "metrics<name=(.*)\\.driver\\.appStatus\\.(.*)><>Count"
+    name: spark_driver_appStatus_$2_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+
+  # Gauge for appStatus
+  - pattern: "metrics<name=(.*)\\.driver\\.appStatus\\.(.*)><>Value"
+    name: spark_driver_appStatus_$2
+    type: GAUGE
+    labels:
+      app_id: "$1"
+
+  # These come from the application driver
+  # Emulate timers for DAGScheduler like messagePRocessingTime
+  - pattern: "metrics<name=(.*)\\.driver\\.DAGScheduler\\.(.*)><>Count"
+    name: spark_driver_DAGScheduler_$2_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+
+  # HiveExternalCatalog is of type counter
+  - pattern: "metrics<name=(.*)\\.driver\\.HiveExternalCatalog\\.(.*)><>Count"
+    name: spark_driver_HiveExternalCatalog_$2_total
+    type: COUNTER
+    labels:
+      app_id: "$1"
+
+  # These come from the application driver
+  # Emulate histograms for CodeGenerator
+  - pattern: "metrics<name=(.*)\\.driver\\.CodeGenerator\\.(.*)><>Count"
+    name: spark_driver_CodeGenerator_$2_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+
+  # These come from the application driver
+  # Emulate timer (keep only count attribute) plus counters for LiveListenerBus
+  - pattern: "metrics<name=(.*)\\.driver\\.LiveListenerBus\\.(.*)><>Count"
+    name: spark_driver_LiveListenerBus_$2_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+
+  # Get Gauge type metrics for LiveListenerBus
+  - pattern: "metrics<name=(.*)\\.driver\\.LiveListenerBus\\.(.*)><>Value"
+    name: spark_driver_LiveListenerBus_$2
+    type: GAUGE
+    labels:
+      app_id: "$1"
+
+  # These come from the application driver if it's a streaming application
+  # Example: app-20160809000059-0000.driver.com.example.ClassName.StreamingMetrics.streaming.lastCompletedBatch_schedulingDelay
+  - pattern: "metrics<name=(.*)\\.driver\\.(.*)\\.StreamingMetrics\\.streaming\\.(.*)><>Value"
+    name: spark_driver_streaming_$3
+    labels:
+      app_id: "$1"
+      app_name: "$2"
+
+  # These come from the application driver if it's a structured streaming application
+  # Example: app-20160809000059-0000.driver.spark.streaming.QueryName.inputRate-total
+  - pattern: "metrics<name=(.*)\\.driver\\.spark\\.streaming\\.(.*)\\.(.*)><>Value"
+    name: spark_driver_structured_streaming_$3
+    labels:
+      app_id: "$1"
+      query_name: "$2"
+
+  # These come from the application executors
+  # Example: app-20160809000059-0000.0.executor.threadpool.activeTasks (value)
+  #  app-20160809000059-0000.0.executor.JvmGCtime (counter)
+  - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.(.*)><>Value"
+    name: spark_executor_$3
+    type: GAUGE
+    labels:
+      app_id: "$1"
+      executor_id: "$2"
+
+  # Executors counters
+  - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.(.*)><>Count"
+    name: spark_executor_$3_total
+    type: COUNTER
+    labels:
+      app_id: "$1"
+      executor_id: "$2"
+
+  # These come from the application executors
+  # Example: app-20160809000059-0000.0.jvm.threadpool.activeTasks
+  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.(jvm|NettyBlockTransfer)\\.(.*)><>Value"
+    name: spark_executor_$3_$4
+    type: GAUGE
+    labels:
+      app_id: "$1"
+      executor_id: "$2"
+
+  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.HiveExternalCatalog\\.(.*)><>Count"
+    name: spark_executor_HiveExternalCatalog_$3_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+      executor_id: "$2"
+
+  # These come from the application driver
+  # Emulate histograms for CodeGenerator
+  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.CodeGenerator\\.(.*)><>Count"
+    name: spark_executor_CodeGenerator_$3_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+      executor_id: "$2"
+
+  # Kafka Consumer lag and throughput, Kafka Producer throughput metrics
+
+  - pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics,(\\s*)client-id=(\\S+),(\\s*)topic=(\\S+),(\\s*)partition=([0-9]+)(.*)><>records-lag-max"
+    name: kafka_consumer_consumer_fetch_manager_metrics_records_lag_max
+    type: GAUGE
+    labels:
+      client_id: "$2"
+      topic: "$4"
+      partition: "$6"
+  - pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics,(\\s*)client-id=(\\S+),(\\s*)topic=(\\S+)(.*)><>records-consumed-rate"
+    name: kafka_consumer_consumer_fetch_manager_metrics_records_consumed_rate
+    type: GAUGE
+    labels:
+      client_id: "$2"
+      topic: "$4"
+  - pattern: "kafka\\.producer<type=producer-topic-metrics,(\\s*)client-id=(\\S+),(\\s*)topic=(\\S+)(.*)><>record-send-rate"
+    name: kafka_producer_producer_metrics_record_send_rate
+    type: GAUGE
+    labels:
+      client_id: "$2"
+      topic: "$4"

--- a/external/multi-base-images/spark/releaseCloudflowSpark.sh
+++ b/external/multi-base-images/spark/releaseCloudflowSpark.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+SCRIPT=`basename ${BASH_SOURCE[0]}`
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
+TAG=v2.4.4
+ORIGIN_TAG=2.4.4-k8s-client-upgrade
+DOCKER_USERNAME=lightbend
+CLOUDFLOW_VERSION=1.3.1-SNAPSHOT
+SPARK_IMAGE_TAG=${CLOUDFLOW_VERSION}-cloudflow-spark-2.4.4-scala-2.12
+SPARK_OPERATOR_TAG=${CLOUDFLOW_VERSION}-cloudflow-spark-2.4.4-1.0.1-scala-2.12
+
+hub version > /dev/null 2>&1 || {
+  echo "The hub command is not installed. Please install (https://github.com/github/hub) and retry."
+  exit 1
+}
+
+set -ex
+if [ "$(uname)" == "Darwin" ]; then
+  export JAVA_HOME="$(dirname $(readlink $(which javac)))/java_home"
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  export JAVA_HOME="$(dirname $(dirname $(readlink -f $(which javac))))"
+else
+  echo "Please setup JAVA_HOME."
+  exit 1
+fi
+
+rm -rf $DIR/spark
+git clone https://github.com/lightbend/spark.git
+cd $DIR/spark
+git remote add upstream https://github.com/apache/spark.git
+git fetch --tags --all
+git checkout tags/$ORIGIN_TAG -b cloudflow-$ORIGIN_TAG
+rm -rf resource-managers/kubernetes/lightbend-build
+$DIR/spark/dev/change-scala-version.sh 2.12
+$DIR/spark/dev/make-distribution.sh --name cloudflow-2.12 --r --tgz -Psparkr -Pscala-2.12 -Phadoop-2.7 -Pkubernetes -Phive
+# remove upstream because hub will use it as the default push repo
+git remote remove upstream
+hub release create -a $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12.tgz -m "Cloudflow Spark $TAG distribution for K8s" -m "Cloudflow Spark $TAG release." cloudflow-$ORIGIN_TAG
+
+# build the Spark image
+tar -zxvf spark-${TAG:1}-bin-cloudflow-2.12.tgz
+cd $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12
+cp $DIR/metrics.properties $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12
+cp $DIR/prometheus.yaml $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12
+cp $DIR/log4j.properties $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12
+cp $DIR/spark-entrypoint.sh $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12
+docker build -f $DIR/Dockerfile -t $DOCKER_USERNAME/spark:$SPARK_IMAGE_TAG .
+
+# build the Spark operator image
+cd $DIR
+rm -rf $DIR/spark-on-k8s-operator
+git clone https://github.com/GoogleCloudPlatform/spark-on-k8s-operator.git
+cd $DIR/spark-on-k8s-operator
+git checkout f78361119976beb7a147df9cd64e1fdd317b9311 -b spark-operator-1.0.1
+# adoptjdk image comes with all packages installed and also is based on ubuntu
+sed -i -e '/RUN apk add --no-cache openssl curl tini/d' Dockerfile
+docker build --no-cache --build-arg SPARK_IMAGE=$DOCKER_USERNAME/spark:$SPARK_IMAGE_TAG -t $DOCKER_USERNAME/sparkoperator:$SPARK_OPERATOR_TAG -f Dockerfile .
+
+docker push $DOCKER_USERNAME/spark:$SPARK_IMAGE_TAG
+docker push $DOCKER_USERNAME/sparkoperator:$SPARK_OPERATOR_TAG

--- a/external/multi-base-images/spark/spark-entrypoint.sh
+++ b/external/multi-base-images/spark/spark-entrypoint.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo "spark-entrypoint.sh..."
+
+# Fail on errors
+set -e
+
+# Check whether there is a passwd entry for the container UID
+myuid=$(id -u)
+mygid=$(id -g)
+# turn off -e for getent because it will return error code in anonymous uid case
+set +e
+uidentry=$(getent passwd $myuid)
+set -e
+
+echo "myuid: $myuid"
+echo "mygid: $mygid"
+echo "uidentry: $uidentry"
+
+ if [ -n "$HADOOP_CONFIG_URL" ]; then
+   ehc=/etc/hadoop/conf
+   echo "Setting up hadoop config files core-site.xml and hdfs-site.xml in directory $ehc...."
+   mkdir -p $ehc
+   wget $HADOOP_CONFIG_URL/core-site.xml -P $ehc
+   wget $HADOOP_CONFIG_URL/hdfs-site.xml -P $ehc
+   export HADOOP_CONF_DIR=$ehc
+fi
+
+# If there is no passwd entry for the container UID, attempt to create one
+if [ -z "$uidentry" ] ; then
+    if [ -w /etc/passwd ] ; then
+        echo "Attempting to create a password entry for the container UID..."
+        echo "$myuid:x:$myuid:$mygid:anonymous uid:$SPARK_HOME:/bin/false" >> /etc/passwd
+    else
+        echo "Container ENTRYPOINT failed to add passwd entry for anonymous UID, because /etc/passwd isn't writable!"
+    fi
+fi
+
+# Add jars in /opt/cloudflow to the Spark classpath
+while read -d '' -r jarfile ; do
+    if [[ "$CLOUDFLOW_CLASSPATH" == "" ]]; then
+        CLOUDFLOW_CLASSPATH="$jarfile";
+    else
+        CLOUDFLOW_CLASSPATH="$CLOUDFLOW_CLASSPATH":"$jarfile"
+    fi
+done < <(find /opt/cloudflow ! -type d -name '*.jar' -print0 | sort -z)
+echo "CLOUDFLOW_CLASSPATH = $CLOUDFLOW_CLASSPATH"
+
+SPARK_K8S_CMD="$1"
+case "$SPARK_K8S_CMD" in
+    driver | driver-py | driver-r | executor)
+      shift 1
+      ;;
+    "")
+      ;;
+    *)
+      echo "Non-spark-on-k8s command provided, proceeding in pass-through mode..."
+      exec /sbin/tini -s -- "$@"
+      ;;
+esac
+
+echo "Using SPARK_HOME: ${SPARK_HOME}"
+
+# The following tells the JVM to add all archives in the .../jars directory.
+# See https://docs.oracle.com/javase/7/docs/technotes/tools/windows/classpath.html
+SPARK_CLASSPATH="$SPARK_CLASSPATH:${SPARK_HOME}/jars/*"
+
+env | grep SPARK_JAVA_OPT_ | sort -t_ -k4 -n | sed 's/[^=]*=\(.*\)/\1/g' > /tmp/java_opts.txt
+readarray -t SPARK_EXECUTOR_JAVA_OPTS < /tmp/java_opts.txt
+
+if [ -n "$SPARK_EXTRA_CLASSPATH" ]; then
+  SPARK_CLASSPATH="$SPARK_CLASSPATH:$SPARK_EXTRA_CLASSPATH"
+fi
+echo "SPARK_CLASSPATH = $SPARK_CLASSPATH"
+
+if [ -n "$PYSPARK_FILES" ]; then
+    PYTHONPATH="$PYTHONPATH:$PYSPARK_FILES"
+fi
+echo "PYTHONPATH = $PYTHONPATH"
+
+PYSPARK_ARGS=""
+if [ -n "$PYSPARK_APP_ARGS" ]; then
+    PYSPARK_ARGS="$PYSPARK_APP_ARGS"
+fi
+echo "PYSPARK_ARGS = $PYSPARK_ARGS"
+
+R_ARGS=""
+if [ -n "$R_APP_ARGS" ]; then
+    R_ARGS="$R_APP_ARGS"
+fi
+echo "R_ARGS = $R_ARGS"
+
+if [ "$PYSPARK_MAJOR_PYTHON_VERSION" == "2" ]; then
+    pyv="$(python -V 2>&1)"
+    export PYTHON_VERSION="${pyv:7}"
+    export PYSPARK_PYTHON="python"
+    export PYSPARK_DRIVER_PYTHON="python"
+elif [ "$PYSPARK_MAJOR_PYTHON_VERSION" == "3" ]; then
+    pyv3="$(python3 -V 2>&1)"
+    export PYTHON_VERSION="${pyv3:7}"
+    export PYSPARK_PYTHON="python3"
+    export PYSPARK_DRIVER_PYTHON="python3"
+fi
+echo "PYTHON_VERSION = $PYTHON_VERSION"
+echo "PYSPARK_PYTHON = $PYSPARK_PYTHON"
+echo "PYSPARK_DRIVER_PYTHON = $PYSPARK_DRIVER_PYTHON"
+
+case "$SPARK_K8S_CMD" in
+  driver)
+    CMD=(
+      "$SPARK_HOME/bin/spark-submit"
+      --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
+      --conf "spark.driver.extraClassPath=$CLOUDFLOW_CLASSPATH"
+      --conf "spark.kubernetes.executor.deleteOnTermination=false"
+      --deploy-mode client
+      "$@"
+    )
+    ;;
+  driver-py)
+    CMD=(
+      "$SPARK_HOME/bin/spark-submit"
+      --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
+      --conf "spark.driver.extraClassPath=$CLOUDFLOW_CLASSPATH"
+      --deploy-mode client
+      "$@" $PYSPARK_PRIMARY $PYSPARK_ARGS
+    )
+    ;;
+    driver-r)
+    CMD=(
+      "$SPARK_HOME/bin/spark-submit"
+      --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
+      --conf "spark.driver.extraClassPath=$CLOUDFLOW_CLASSPATH"
+      --deploy-mode client
+      "$@" $R_PRIMARY $R_ARGS
+    )
+    ;;
+  executor)
+    CMD=(
+      ${JAVA_HOME}/bin/java
+      "${SPARK_EXECUTOR_JAVA_OPTS[@]}"
+      -Xms$SPARK_EXECUTOR_MEMORY
+      -Xmx$SPARK_EXECUTOR_MEMORY
+      -cp "$SPARK_CLASSPATH:$CLOUDFLOW_CLASSPATH"
+      org.apache.spark.executor.CoarseGrainedExecutorBackend
+      --driver-url $SPARK_DRIVER_URL
+      --executor-id $SPARK_EXECUTOR_ID
+      --cores $SPARK_EXECUTOR_CORES
+      --app-id $SPARK_APPLICATION_ID
+      --hostname $SPARK_EXECUTOR_POD_IP
+    )
+    ;;
+
+  *)
+    echo "Unknown command: $SPARK_K8S_CMD" 1>&2
+    exit 1
+esac
+
+echo "SPARK_K8S_CMD = ${SPARK_K8S_CMD[@]}"
+
+# Execute the container CMD under tini for better hygiene
+echo "running: exec /sbin/tini -s -- ${CMD[@]}"
+exec /sbin/tini -s -- "${CMD[@]}"


### PR DESCRIPTION
### Why are the changes needed?
This adds the required build files for a new Spark image that will work with the upcoming multi-image app support feature. It is based on our Spark distribution at the Lightbend Spark fork, it is used to build the Spark Operator image and it should be ready to be used with Spark Streamlets.
Once we have multi-image support in Cloudflow then the dir under `external/spark` should be removed and `external/multi-base-images/spark` should be the build dir for Cloudflow Spark artifacts.

### Does this PR introduce any user-facing change?
No.
### How was this patch tested?
Manually. I verified the built images using the current Spark operator and also installed the new operator image using #117 and run a sample job:
```
apiVersion: "sparkoperator.k8s.io/v1beta2"
kind: SparkApplication
metadata:
  name: spark-pi
  namespace: spark
spec:
  type: Scala
  mode: cluster
  image: "skonto/spark:multi"
  imagePullPolicy: Always
  mainClass: org.apache.spark.examples.SparkPi
  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-2.4.4.jar"
  arguments:
    - "1000"
  sparkVersion: "2.4.4"
  restartPolicy:
    type: Never
  driver:
    memory: "500m"
    labels:
      version: 2.4.4
    serviceAccount: spark-sa
  executor:
    instances: 2
    memory: "500m"
    labels:
      version: 2.4.4
```
