### PR TITLE
Update Kafka version started by Strimzi

### DIFF
--- a/installer/cloudflow-environment/values.yaml
+++ b/installer/cloudflow-environment/values.yaml
@@ -26,7 +26,7 @@ kafka:
     deletePersistentVolumeClaimsOnDelete: false
     useDedicatedNodes: false
     kafka:
-      version: 2.3.0
+      version: 2.3.1
       config:
         offsets.topic.replication.factor: 3
         transaction.state.log.replication.factor: 3


### PR DESCRIPTION
The updated Strimzi operator doesn't support version 2.3.0 anymore

### What changes were proposed in this pull request?
Upgrading the version of Kafka deployed by Strimzi


### Why are the changes needed?
The new version of the Strimzi operator doesn't support Kafka version 2.3.0 anymore

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Deploying Cloudflow using the installer