### PR TITLE
Use default cluster version

### DIFF
--- a/installer/create-cluster-gke.sh
+++ b/installer/create-cluster-gke.sh
@@ -45,8 +45,13 @@ CLUSTER_NAME=$1
 # Versions available for new cluster masters
 # https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#versions_available_for_new_cluster_masters
 # use command `gcloud container get-server-config` to find latest supported master GKE cluster version
+
+CLUSTER_VERSION=`gcloud container get-server-config --format json | jq -r .defaultClusterVersion`
+
+echo "using default cluster version: $CLUSTER_VERSION"
+
 gcloud container clusters create $CLUSTER_NAME \
-  --cluster-version 1.13.11-gke.23  \
+  --cluster-version $CLUSTER_VERSION  \
   --image-type cos \
   --machine-type n1-standard-4 \
   --num-nodes 3 \


### PR DESCRIPTION

### What changes were proposed in this pull request?
Always use the default GKE version for the cluster installer


### Why are the changes needed?
This will prevent us from having to update the hardcoded version every time the current version is no longer supported


### Does this PR introduce any user-facing change?
Yes, user will have a better experience if google decides to intermittently changes their versions

### How was this patch tested?
Tested by running the script and creating a cluster on my GCP project
