### PR TITLE
CI & internalRelease improvements

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,7 @@ on:
       - master
   pull_request:
 
+
 name: Build and Test
 jobs:
   build-and-test-scala:
@@ -41,6 +42,7 @@ jobs:
         export PATH="$HOME/opt/sbt/bin:$PATH"
         cd scripts
         ./build-all.sh test
+
 
   build-and-test-cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,14 +45,14 @@ jobs:
   build-and-test-cli:
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v2-beta
       with:
         go-version: 1.13.8
       id: go
-
-    - name: Check out code
-      uses: actions/checkout@v2
 
     - name: Build
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,6 +54,13 @@ jobs:
         go-version: 1.13.8
       id: go
 
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Build
       run: |
         set -e

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-test-scala:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
     - name: Setup environment
       run: |
@@ -45,14 +45,14 @@ jobs:
   build-and-test-cli:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.12
-      uses: actions/setup-go@v1
+    - name: Set up Go
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.12
+        go-version: 1.13.8
       id: go
 
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build
       run: |

--- a/core/project/InternalRelease.scala
+++ b/core/project/InternalRelease.scala
@@ -53,7 +53,7 @@ object InternalReleaseCommand {
       if (Try("git rev-parse --git-dir".!!).isSuccess) {
         val commits = "git rev-list --count HEAD".!!.trim()
         val hash = "git rev-parse --short HEAD".!!.trim()
-        s"-${commits}-${hash}"
+        s"-pre-${commits}-${hash}"
       } else {
         sys.error("The current project is not a valid Git project.")
       }


### PR DESCRIPTION
- use the latest stable Github Actions workflow step versions
- Use the latest stable version of Golang to build the CLI
- Prefix all internal builds with the word "pre", e.g. instead of building `1.3.1-127-123fb4a` it will build `1.3.1-pre-127-123fb4a`