### PR TITLE
Dependency override for akka-http to take care of older version in skuber

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -359,6 +359,10 @@ lazy val operator =
 
       publishArtifact in (Compile, packageDoc) := false,
       publishArtifact in (Compile, packageSrc) := false,
+      // skuber version 2.4.0 depends on akka-http 10.1.9 : hence overriding
+      // with akka-http 10.1.11 to use akka 2.6.3
+      // remove this override once skuber is updated
+      dependencyOverrides += AkkaHttp,
 
       buildOptions in docker := BuildOptions(
         cache = true,


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
* Dependency override for `akka-http` for skuber

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
* skuber uses an older version of `akka-http` which is not compatible with akka `2.6.3`. Hence need this dependency override

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
* fixes a problem of crashing operator

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
* manually tested on a GKE cluster