### PR TITLE
Enabled status subresource for KafkaTopic CRD

### DIFF
--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/SavepointActions.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/SavepointActions.scala
@@ -23,6 +23,7 @@ import play.api.libs.json.Format
 import play.api.libs.json.Json
 
 import skuber._
+import skuber.ResourceSpecification.Subresources
 
 import cloudflow.blueprint.deployment._
 
@@ -67,8 +68,11 @@ object SavepointActions {
   private implicit val Definition = ResourceDefinition[CustomResource[Spec, Status]](
     group = "kafka.strimzi.io",
     version = "v1beta1",
-    kind = "KafkaTopic"
+    kind = "KafkaTopic",
+    subresources = Some(Subresources().withStatusSubresource)
   )
+
+  implicit val statusSubEnabled = CustomResource.statusMethodsEnabler[Topic]
 
   def deleteAction(labels: CloudflowLabels)(savepoint: Savepoint)(implicit ctx: DeploymentContext) =
     Action.delete(resource(savepoint, labels))

--- a/external/multi-base-images/spark/Dockerfile
+++ b/external/multi-base-images/spark/Dockerfile
@@ -74,7 +74,7 @@ RUN set -ex && \
 
 
 ENV SPARK_HOME=/opt/spark \
-    SPARK_VERSION=2.4.4
+    SPARK_VERSION=2.4.5
 
 WORKDIR /opt/spark/work-dir
 RUN chmod g+w /opt/spark/work-dir


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable status subresource support for KafkaTopic CRD. Also fixed a vestigial reference to Spark 2.4.4.

### Why are the changes needed?
Without this change, call-record-aggregator will fail with the following error:
```
akka.http.scaladsl.server.RejectionError: ValidationRejection({"obj.status.actualPartitions":[{"msg":["error.path.missing"],"args":[]}],"obj.status.actualReplicas":[{"msg":["error.path.missing"],"args":[]}]},Some(skuber.json.PlayJsonSupportForAkkaHttp$PlayJsonError: {"obj.status.actualPartitions":[{"msg":["error.path.missing"],"args":[]}],"obj.status.actualReplicas":[{"msg":["error.path.missing"],"args":[]}]})) at skuber.json.PlayJsonSupportForAkkaHttp.$anonfun$unmarshaller$1(PlayJsonSupportForAkkaHttp.scala:79) at play.api.libs.json.JsError.recoverTotal(JsResult.scala:91) at skuber.json.PlayJsonSupportForAkkaHttp.read$1(PlayJsonSupportForAkkaHttp.scala:76) at skuber.json.PlayJsonSupportForAkkaHttp.$anonfun$unmarshaller$2(PlayJsonSupportForAkkaHttp.scala:83) at akka.http.scaladsl.util.FastFuture$.$anonfun$map$1(FastFuture.scala:23) at akka.http.scaladsl.util.FastFuture$.strictTransform$1(FastFuture.scala:41) at akka.http.scaladsl.util.FastFuture$.transformWith$extension1(FastFuture.scala:45) at akka.http.scaladsl.util.FastFuture$.map$extension(FastFuture.scala:23) at akka.http.scaladsl.unmarshalling.Unmarshaller.$anonfun$map$3(Unmarshaller.scala:26) at akka.http.scaladsl.unmarshalling.Unmarshaller.$anonfun$transform$3(Unmarshaller.scala:23) at akka.http.scaladsl.unmarshalling.Unmarshaller$$anon$1.apply(Unmarshaller.scala:58) at akka.http.scaladsl.unmarshalling.LowerPriorityGenericUnmarshallers.$anonfun$messageUnmarshallerFromEntityUnmarshaller$3(GenericUnmarshallers.scala:25) at akka.http.scaladsl.unmarshalling.Unmarshaller$$anon$1.apply(Unmarshaller.scala:58) at akka.http.scaladsl.unmarshalling.Unmarshal.to(Unmarshal.scala:25) at skuber.api.client.impl.KubernetesClientImpl.$anonfun$toKubernetesResponse$1(KubernetesClientImpl.scala:651) at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307) at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41) at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64) at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55) at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:92) at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23) at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85) at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:92) at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:47) at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:47) at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289) at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056) at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692) at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```
This was due to a recent upgrade of Strimzi version from 0.14.0 to 0.16.2 in Cloudflow. The change was introduced in Strimzi this this PR: https://github.com/strimzi/strimzi-kafka-operator/pull/1865. 

### Does this PR introduce any user-facing change?
Yes. It fixed an error when running call-record-aggregator.

### How was this patch tested?
Tested with call-record-aggregator app.
