### PR TITLE
Enable scalafmt on compile

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,12 +7,13 @@ on:
       - master
   pull_request:
 
+
 name: Build and Test
 jobs:
   build-and-test-scala:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
     - name: Setup environment
       run: |
@@ -42,17 +43,25 @@ jobs:
         cd scripts
         ./build-all.sh test
 
+
   build-and-test-cli:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.12
-      uses: actions/setup-go@v1
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2-beta
       with:
-        go-version: 1.12
+        go-version: 1.13.8
       id: go
 
-    - name: Check out code
-      uses: actions/checkout@v1
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Build
       run: |

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -114,8 +114,8 @@ lazy val akkastreamTestkit =
         AkkaStreamContrib,
         Ficus,
         Logback % Test,
-        AkkaStreamKafkaTestkit,
         AkkaStreamTestkit,
+        AkkaStreamKafkaTestkit,
         AkkaTestkit,
         ScalaTest,
         Junit
@@ -341,11 +341,11 @@ lazy val operator =
         Ficus,
         Logback,
         Skuber,
-        AkkaStreamTestkit,
-	JacksonDatabind,
+	      JacksonDatabind,
         ScalaTest,
-        ScalaCheck              % "test",
-        Avro4sJson              % "test",
+        AkkaStreamTestkit % "test",
+        ScalaCheck        % "test",
+        Avro4sJson        % "test",
       )
     )
     .settings(

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -359,6 +359,10 @@ lazy val operator =
 
       publishArtifact in (Compile, packageDoc) := false,
       publishArtifact in (Compile, packageSrc) := false,
+      // skuber version 2.4.0 depends on akka-http 10.1.9 : hence overriding
+      // with akka-http 10.1.11 to use akka 2.6.3
+      // remove this override once skuber is updated
+      dependencyOverrides += AkkaHttp,
 
       buildOptions in docker := BuildOptions(
         cache = true,

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -7,9 +7,10 @@ import sbtrelease.ReleaseStateTransformations._
 
 lazy val root =
   Project(id = "root", base = file("."))
-    .enablePlugins(ScalaUnidocPlugin, JavaUnidocPlugin)
+    .enablePlugins(ScalaUnidocPlugin, JavaUnidocPlugin, ScalafmtPlugin)
     .settings(
       name := "root",
+      scalafmtOnCompile := true,
       skip in publish := true,
       commands += InternalReleaseCommand.command,
       unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/BaseAkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/BaseAkkaStreamletTestKit.scala
@@ -21,7 +21,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import akka.actor._
-import akka.stream._
 import com.typesafe.config._
 
 import cloudflow.akkastream._
@@ -34,7 +33,6 @@ import cloudflow.streamlets._
 // Thanks to @debasish for the tip about F-bounded types in combination with self-types.
 private[testkit] abstract class BaseAkkaStreamletTestKit[Repr <: BaseAkkaStreamletTestKit[Repr]] { this: Repr ⇒
   def system: ActorSystem
-  def mat: Option[ActorMaterializer]
   def config: Config
 
   private val defaultStreamletRefName = "streamlet-under-test"

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
@@ -40,12 +40,11 @@ private[testkit] case class TestContext(
     outletTaps: List[OutletTap[_]],
     override val config: Config = ConfigFactory.empty()
 ) extends AkkaStreamletContext {
-  //TODO reuse more from StreamletContextImpl
-  implicit def materializer     = ActorMaterializer()(system)
   private val readyPromise      = Promise[Dun]()
   private val completionPromise = Promise[Dun]()
   private val completionFuture  = completionPromise.future
   val killSwitch                = KillSwitches.shared(streamletRef)
+  implicit val sys              = system
 
   override def streamletDefinition: StreamletDefinition =
     StreamletDefinition("appId", "appVersion", streamletRef, "streamletClass", List(), List(), config)

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
@@ -22,7 +22,6 @@ import collection.JavaConverters._
 import akka.NotUsed
 import akka.actor._
 import akka.japi.Pair
-import akka.stream._
 import akka.stream.javadsl._
 import com.typesafe.config._
 
@@ -32,8 +31,8 @@ import cloudflow.streamlets._
 import cloudflow.akkastream.testkit._
 
 object AkkaStreamletTestKit {
-  def create(sys: ActorSystem, mat: ActorMaterializer): AkkaStreamletTestKit                 = AkkaStreamletTestKit(sys, Some(mat))
-  def create(sys: ActorSystem, mat: ActorMaterializer, config: Config): AkkaStreamletTestKit = AkkaStreamletTestKit(sys, Some(mat), config)
+  def create(sys: ActorSystem): AkkaStreamletTestKit                 = AkkaStreamletTestKit(sys)
+  def create(sys: ActorSystem, config: Config): AkkaStreamletTestKit = AkkaStreamletTestKit(sys, config)
 }
 
 /**
@@ -77,9 +76,7 @@ object AkkaStreamletTestKit {
  * TestKitExtension.Settings.TestTimeFactor settable via akka.conf entry "akka.test.timefactor".
  *
  */
-final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
-                                                        mat: Option[ActorMaterializer] = None,
-                                                        config: Config = ConfigFactory.empty())
+final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem, config: Config = ConfigFactory.empty())
     extends BaseAkkaStreamletTestKit[AkkaStreamletTestKit] {
 
   def withConfig(c: Config): AkkaStreamletTestKit = this.copy(config = c)
@@ -88,7 +85,7 @@ final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
    *
    */
   def makeInletAsTap[T](inlet: CodecInlet[T]): QueueInletTap[T] =
-    QueueInletTap[T](inlet)(mat.getOrElse(ActorMaterializer()(system)))
+    QueueInletTap[T](inlet)(system)
 
   /**
    *

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/InletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/InletTap.scala
@@ -17,6 +17,7 @@
 package cloudflow.akkastream.testkit.javadsl
 
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage._
 import akka.stream._
 import akka.stream.scaladsl._
@@ -33,7 +34,7 @@ case class SourceInletTap[T] private[testkit] (inlet: CodecInlet[T], src: akka.s
   private[testkit] val source = src.asScala
 }
 
-case class QueueInletTap[T](inlet: CodecInlet[T])(implicit mat: ActorMaterializer) extends InletTap[T] {
+case class QueueInletTap[T](inlet: CodecInlet[T])(implicit system: ActorSystem) extends InletTap[T] {
   private val bufferSize = 1024
   private val hub        = BroadcastHub.sink[T](bufferSize)
 

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/OutletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/OutletTap.scala
@@ -27,6 +27,8 @@ import akka.testkit.javadsl.{ TestKit ⇒ JTestKit }
 import cloudflow.streamlets._
 import cloudflow.akkastream.testkit.PartitionedValue
 
+case class Failed(e: Throwable)
+
 case class SinkOutletTap[T](outlet: CodecOutlet[T], val snk: akka.stream.javadsl.Sink[Pair[String, T], NotUsed]) extends OutletTap[T] {
   private[testkit] val sink: Sink[PartitionedValue[T], Future[Done]] =
     Flow[PartitionedValue[T]]
@@ -48,7 +50,7 @@ case class ProbeOutletTap[T](outlet: CodecOutlet[T])(implicit system: ActorSyste
       .alsoTo(
         Flow[PartitionedValue[T]]
           .map(pv ⇒ Pair(pv.key, pv.value))
-          .to(Sink.actorRef[Pair[String, T]](probe.getTestActor, Completed))
+          .to(Sink.actorRef[Pair[String, T]](probe.getTestActor, Completed, Failed))
       )
       .toMat(Sink.ignore)(Keep.right)
 }

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/AkkaStreamletTestKit.scala
@@ -18,7 +18,6 @@ package cloudflow.akkastream.testkit.scaladsl
 
 import akka.NotUsed
 import akka.actor._
-import akka.stream._
 import akka.stream.scaladsl._
 import com.typesafe.config._
 
@@ -27,8 +26,8 @@ import cloudflow.streamlets._
 import cloudflow.akkastream.testkit._
 
 object AkkaStreamletTestKit {
-  def apply(sys: ActorSystem, mat: ActorMaterializer): AkkaStreamletTestKit                 = AkkaStreamletTestKit(sys, Some(mat))
-  def apply(sys: ActorSystem, mat: ActorMaterializer, config: Config): AkkaStreamletTestKit = AkkaStreamletTestKit(sys, Some(mat), config)
+  def apply(sys: ActorSystem): AkkaStreamletTestKit                 = new AkkaStreamletTestKit(sys)
+  def apply(sys: ActorSystem, config: Config): AkkaStreamletTestKit = new AkkaStreamletTestKit(sys, config)
 }
 
 /**
@@ -70,9 +69,7 @@ object AkkaStreamletTestKit {
  * TestKitExtension.Settings.TestTimeFactor settable via akka.conf entry "akka.test.timefactor".
  *
  */
-final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
-                                                        mat: Option[ActorMaterializer] = None,
-                                                        config: Config = ConfigFactory.empty())
+final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem, config: Config = ConfigFactory.empty())
     extends BaseAkkaStreamletTestKit[AkkaStreamletTestKit] {
 
   def withConfig(c: Config): AkkaStreamletTestKit = this.copy(config = c)
@@ -81,7 +78,7 @@ final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
    *
    */
   def inletAsTap[T](inlet: CodecInlet[T]): QueueInletTap[T] =
-    QueueInletTap[T](inlet)(mat.getOrElse(ActorMaterializer()(system)))
+    QueueInletTap[T](inlet)(system)
 
   /**
    *

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/InletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/InletTap.scala
@@ -17,6 +17,7 @@
 package cloudflow.akkastream.testkit.scaladsl
 
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage._
 import akka.stream._
 import akka.stream.scaladsl._
@@ -28,7 +29,7 @@ case class SourceInletTap[T](inlet: CodecInlet[T], source: Source[(T, Committabl
   def portName = inlet.name
 }
 
-case class QueueInletTap[T](inlet: CodecInlet[T])(implicit mat: ActorMaterializer) extends InletTap[T] {
+case class QueueInletTap[T](inlet: CodecInlet[T])(implicit system: ActorSystem) extends InletTap[T] {
   private val bufferSize        = 1024
   private val hub               = BroadcastHub.sink[T](bufferSize)
   private val qSource           = Source.queue[T](bufferSize, OverflowStrategy.backpressure)

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/OutletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/OutletTap.scala
@@ -26,6 +26,8 @@ import akka.testkit.TestKit
 import cloudflow.streamlets._
 import cloudflow.akkastream.testkit.PartitionedValue
 
+case class Failed(e: Throwable)
+
 case class SinkOutletTap[T](outlet: CodecOutlet[T], val snk: Sink[(String, T), NotUsed]) extends OutletTap[T] {
   private[testkit] val sink: Sink[PartitionedValue[T], Future[Done]] =
     Flow[PartitionedValue[T]]
@@ -47,7 +49,7 @@ case class ProbeOutletTap[T](outlet: CodecOutlet[T])(implicit system: ActorSyste
       .alsoTo(
         Flow[PartitionedValue[T]]
           .map(pv ⇒ (pv.key, pv.value))
-          .to(Sink.actorRef[Tuple2[String, T]](probe.testActor, Completed))
+          .to(Sink.actorRef[Tuple2[String, T]](probe.testActor, Completed, Failed))
       )
       .toMat(Sink.ignore)(Keep.right)
 }

--- a/core/cloudflow-akka-testkit/src/test/java/cloudflow/akkastream/testkit/JavaDslTest.java
+++ b/core/cloudflow-akka-testkit/src/test/java/cloudflow/akkastream/testkit/JavaDslTest.java
@@ -24,17 +24,14 @@ import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
 import akka.testkit.TestKit;
 
 public abstract class JavaDslTest extends JUnitSuite {
-  static ActorMaterializer mat;
   static ActorSystem system;
 
   @BeforeClass
   public static void setUp() throws Exception {
     system = ActorSystem.create();
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass

--- a/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
+++ b/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
@@ -22,7 +22,6 @@ import akka.actor.ActorSystem;
 import akka.japi.Pair;
 import akka.kafka.ConsumerMessage.Committable;
 import akka.kafka.ConsumerMessage.CommittableOffset;
-import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;
 import akka.testkit.TestKit;
 import cloudflow.akkastream.*;
@@ -35,13 +34,11 @@ import org.scalatest.junit.JUnitSuite;
 import org.junit.*;
 
 public class AkkaStreamletTest extends JUnitSuite {
-  static ActorMaterializer mat;
   static ActorSystem system;
 
   @BeforeClass
   public static void setUp() throws Exception {
     system = ActorSystem.create();
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
@@ -53,7 +50,7 @@ public class AkkaStreamletTest extends JUnitSuite {
   @Test
   public void anAkkaStreamletShouldProcessDataWhenItIsRun() {
     TestProcessor streamlet = new TestProcessor();
-    AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system, mat);
+    AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system);
 
     QueueInletTap<Data> in = testkit.makeInletAsTap(streamlet.inlet);
     ProbeOutletTap<Data> out = testkit.makeOutletAsTap(streamlet.outlet);
@@ -77,7 +74,7 @@ public class AkkaStreamletTest extends JUnitSuite {
   public void anAkkaStreamletShouldBeAbleToDefineAndUseConfigurationParameters() {
     TestConfigParametersProcessor streamlet = new TestConfigParametersProcessor();
     AkkaStreamletTestKit testkit =
-        AkkaStreamletTestKit.create(system, mat)
+        AkkaStreamletTestKit.create(system)
             .withConfigParameterValues(ConfigParameterValue.create(nameFilter, "b"));
 
     QueueInletTap<Data> in = testkit.makeInletAsTap(streamlet.inlet);
@@ -111,7 +108,7 @@ public class AkkaStreamletTest extends JUnitSuite {
           getSourceWithOffsetContext(inlet)
               .via(Flow.<Pair<Data, CommittableOffset>>create()) // no-op flow
               .to(getSinkWithOffsetContext(outlet))
-              .run(materializer());
+              .run(system());
         }
       };
     }
@@ -141,7 +138,7 @@ public class AkkaStreamletTest extends JUnitSuite {
           getSourceWithOffsetContext(inlet)
               .filter(data -> data.name().equals(configuredNameToFilterFor))
               .to(getSinkWithOffsetContext(outlet))
-              .run(materializer());
+              .run(system());
         }
       };
     }

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletSpec.scala
@@ -21,7 +21,6 @@ import scala.concurrent.duration._
 
 import akka.NotUsed
 import akka.actor._
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.testkit._
 
@@ -37,13 +36,12 @@ import cloudflow.akkastream.testkit.scaladsl._
 class AkkaStreamletSpec extends WordSpec with MustMatchers with BeforeAndAfterAll {
 
   private implicit val system = ActorSystem("AkkaStreamletSpec")
-  private implicit val mat    = ActorMaterializer()
   val timeout                 = 10.seconds.dilated
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)
 
   "An AkkaStreamlet" should {
-    val testkit = AkkaStreamletTestKit(system, mat)
+    val testkit = AkkaStreamletTestKit(system)
 
     "Allow for querying of configuration parameters" in {
       object ConfigTestProcessor extends AkkaStreamlet {
@@ -64,7 +62,7 @@ class AkkaStreamletSpec extends WordSpec with MustMatchers with BeforeAndAfterAl
       }
 
       val configTestKit =
-        AkkaStreamletTestKit(system, mat)
+        AkkaStreamletTestKit(system)
           .withConfigParameterValues(ConfigParameterValue(ConfigTestProcessor.NameFilter, "b"))
 
       val data   = Vector(Data(1, "a"), Data(2, "b"), Data(3, "c"))
@@ -93,7 +91,7 @@ class AkkaStreamletSpec extends WordSpec with MustMatchers with BeforeAndAfterAl
         }
       }
 
-      val configTestKit = AkkaStreamletTestKit(system, mat)
+      val configTestKit = AkkaStreamletTestKit(system)
 
       val data   = Vector(Data(1, "a"), Data(2, "b"), Data(3, "c"))
       val source = Source(data)

--- a/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/HttpServerSpec.scala
+++ b/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/HttpServerSpec.scala
@@ -18,7 +18,6 @@ package cloudflow.akkastream.util.scaladsl
 
 import scala.concurrent.duration._
 import akka.actor._
-import akka.stream.ActorMaterializer
 import akka.http.scaladsl._
 import akka.http.scaladsl.client.RequestBuilding._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -46,7 +45,6 @@ import cloudflow.akkastream.testkit.scaladsl._
 class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll {
 
   private implicit val system = ActorSystem("HttpServerSpec")
-  private implicit val mat    = ActorMaterializer()
 
   import system.dispatcher
 
@@ -65,6 +63,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
         val request  = HttpRequest(method, Uri(s"http://127.0.0.1:$port"), Nil, HttpEntity.Empty)
         val response = Http().singleRequest(request).futureValue
         response.status mustEqual StatusCodes.MethodNotAllowed
+        response.entity.discardBytes()
         out.probe.expectNoMessage(noMessageDuration)
       }
     }
@@ -75,6 +74,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       val request  = Post(s"http://127.0.0.1:$port", data)
       val response = Http().singleRequest(request).futureValue
       response.status mustEqual StatusCodes.Accepted
+      response.entity.discardBytes()
       out.probe.expectMsg(("1", data))
       out.probe.expectMsg(Completed)
     }
@@ -84,6 +84,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       val request  = Post(s"http://127.0.0.1:$port")
       val response = Http().singleRequest(request).futureValue
       response.status mustEqual StatusCodes.BadRequest
+      response.entity.discardBytes()
     }
 
     "accept data using a custom route" in {
@@ -91,6 +92,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       val data     = Data(42, "a")
       val request  = Put(s"http://127.0.0.1:$port", data)
       val response = Http().singleRequest(request).futureValue
+      response.entity.discardBytes()
       response.status mustEqual StatusCodes.OK
       out.probe.expectMsg(("42", data))
       out.probe.expectMsg(Completed)
@@ -99,6 +101,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       val badRequest  = Put(s"http://127.0.0.1:$port", badData)
       val badResponse = Http().singleRequest(badRequest).futureValue
       badResponse.status mustEqual StatusCodes.BadRequest
+      badResponse.entity.discardBytes()
       out.probe.expectNoMessage(noMessageDuration)
     }
 
@@ -142,7 +145,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
   }
 
   def startIngress(ingress: AkkaStreamlet = createDefaultIngress): Unit = {
-    val testkit = AkkaStreamletTestKit(system, mat)
+    val testkit = AkkaStreamletTestKit(system)
 
     out = testkit.outletAsTap(outlet)
     port = getFreePort()

--- a/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/MergeSpec.scala
+++ b/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/MergeSpec.scala
@@ -19,7 +19,6 @@ package cloudflow.akkastream.util.scaladsl
 import scala.collection.JavaConverters._
 
 import akka.actor._
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.testkit._
 import org.scalatest._
@@ -31,17 +30,17 @@ import cloudflow.akkastream._
 import cloudflow.akkastream.scaladsl._
 import cloudflow.akkastream.testdata._
 import cloudflow.akkastream.testkit.scaladsl._
+
 class MergeSpec extends WordSpec with MustMatchers with ScalaFutures with BeforeAndAfterAll {
 
   private implicit val system = ActorSystem("MergeSpec")
-  private implicit val mat    = ActorMaterializer()
 
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)
 
   "An MergeStreamlet" should {
 
-    val testkit = AkkaStreamletTestKit(system, mat)
+    val testkit = AkkaStreamletTestKit(system)
     def createScalaMergeStreamlet(inletCount: Int): TestMerge =
       new ScalaTestMerge(inletCount)
 

--- a/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/SplitterSpec.scala
+++ b/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/SplitterSpec.scala
@@ -17,7 +17,6 @@
 package cloudflow.akkastream.util.scaladsl
 
 import akka.actor._
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.testkit._
 import org.scalatest._
@@ -32,7 +31,6 @@ import cloudflow.akkastream.testdata._
 
 class SplitterSpec extends WordSpec with MustMatchers with ScalaFutures with BeforeAndAfterAll {
   private implicit val system = ActorSystem("SplitterSpec")
-  private implicit val mat    = ActorMaterializer()
 
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)
@@ -55,7 +53,7 @@ class SplitterSpec extends WordSpec with MustMatchers with ScalaFutures with Bef
 
   "A Splitter" should {
     "split incoming data according to a splitter flow" in {
-      val testkit = AkkaStreamletTestKit(system, mat)
+      val testkit = AkkaStreamletTestKit(system)
       val source  = Source(Vector(Data(1, "a"), Data(2, "b")))
 
       val in    = testkit.inletFromSource(MyPartitioner.in, source)

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -22,7 +22,6 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage.{ Committable, CommittableOffset }
 import akka.kafka.CommitterSettings
-import akka.stream._
 import akka.stream.scaladsl._
 import cloudflow.streamlets._
 
@@ -57,11 +56,6 @@ trait AkkaStreamletContext extends StreamletContext {
    * The system in which the AkkaStreamlet will be run.
    */
   implicit def system: ActorSystem
-
-  /**
-   * The Materializer used when the AkkaStreamlet is run.
-   */
-  implicit def materializer: Materializer
 
   private[akkastream] def streamletExecution: StreamletExecution
 

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -56,8 +56,6 @@ final class AkkaStreamletContextImpl(
 ) extends AkkaStreamletContext {
   implicit val system: ActorSystem = ActorSystem("akka_streamlet", config)
 
-  implicit def materializer = ActorMaterializer()(system)
-
   override def config: Config = streamletDefinition.config
 
   private val readyPromise      = Promise[Dun]()

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
@@ -20,7 +20,6 @@ import java.nio.file.Path
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream._
 import akka.stream.scaladsl._
 
 import akka.kafka._
@@ -59,7 +58,7 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
    * Java API
    * Launch the execution of the graph.
    */
-  final def runGraph[T](graph: akka.stream.javadsl.RunnableGraph[T]): T = graph.run(materializer)
+  final def runGraph[T](graph: akka.stream.javadsl.RunnableGraph[T]): T = graph.run(system)
 
   /**
    * Signals that the streamlet is ready to process data.
@@ -78,16 +77,6 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
    * Java API
    */
   def getSystem() = system
-
-  /**
-   * The Materializer that will be used for materializing akka stream graphs.
-   */
-  implicit final val materializer: Materializer = context.materializer
-
-  /**
-   * Java API
-   */
-  def getMaterializer() = materializer
 
   /**
    * The default ExecutionContext of the ActorSystem (the system dispatcher).

--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/ApplicationDescriptorSpec.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/ApplicationDescriptorSpec.scala
@@ -20,8 +20,6 @@ import com.typesafe.config._
 import org.scalatest._
 
 import cloudflow.blueprint._
-import spray.json._
-import ApplicationDescriptorJsonFormat._
 
 class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherValues with OptionValues with GivenWhenThen {
   case class Foo(name: String)

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/HealthChecks.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/HealthChecks.scala
@@ -22,10 +22,9 @@ import akka.actor._
 import akka.http.scaladsl._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
-import akka.stream._
 
 object HealthChecks {
-  def serve(settings: Settings)(implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext) =
+  def serve(settings: Settings)(implicit system: ActorSystem, ec: ExecutionContext) =
     Http()
       .bindAndHandle(
         route,

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
@@ -36,7 +36,6 @@ object Main extends {
     implicit val system = ActorSystem()
 
     try {
-      implicit val mat = createMaterializer()
       implicit val ec  = system.dispatcher
       val settings     = Settings(system)
       implicit val ctx = settings.deploymentContext
@@ -95,13 +94,6 @@ object Main extends {
   }
 
   private def exitWithFailure() = System.exit(-1)
-
-  private def createMaterializer()(implicit system: ActorSystem) = {
-    val decider: Supervision.Decider = {
-      case _ ⇒ Supervision.Stop
-    }
-    ActorMaterializer(ActorMaterializerSettings(system).withSupervisionStrategy(decider))
-  }
 
   private def installCRD(client: skuber.api.client.KubernetesClient)(implicit ec: ExecutionContext): Unit = {
     val crdTimeout = 20.seconds

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
@@ -323,21 +323,20 @@ object FlinkResource {
   implicit val namePathSecretTypeFmt: Format[NamePathSecretType] = Json.format[NamePathSecretType]
   implicit val resourceRequsetsFmt: Format[ResourceRequests]     = Json.format[ResourceRequests]
   implicit val resourceLimitsFmt: Format[ResourceLimits]         = Json.format[ResourceLimits]
-  implicit val resourcesFmt: Format[Resources]                   = Json.format[Resources]
   implicit val envConfigFmt: Format[EnvConfig]                   = Json.format[EnvConfig]
+  implicit val resourcesFmt: Format[Resources]                   = Json.format[Resources]
 
   implicit val jobManagerFmt: Format[JobManagerConfig]   = Json.format[JobManagerConfig]
+  implicit val jobManagerInfoFmt: Format[JobManagerInfo] = Json.format[JobManagerInfo]
   implicit val taskManagerFmt: Format[TaskManagerConfig] = Json.format[TaskManagerConfig]
 
-  implicit val specFmt: Format[Spec]     = Json.format[Spec]
-  implicit val statusFmt: Format[Status] = Json.format[Status]
+  implicit val applicationStateFmt: Format[ApplicationState] = Json.format[ApplicationState]
+  implicit val specFmt: Format[Spec]                         = Json.format[Spec]
+  implicit val statusFmt: Format[Status]                     = Json.format[Status]
 
   final case class EnvConfig(env: List[EnvVar] = Nil)
 
   type CR = CustomResource[Spec, Status]
-
-  implicit val applicationStateFmt: Format[ApplicationState] = Json.format[ApplicationState]
-  implicit val jobManagerInfoFmt: Format[JobManagerInfo]     = Json.format[JobManagerInfo]
 
   implicit val resourceDefinition: ResourceDefinition[CustomResource[Spec, Status]] = ResourceDefinition[CR](
     group = "flink.k8s.io",

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/SparkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/SparkRunner.scala
@@ -313,16 +313,16 @@ object SparkResource {
     }
   }
 
-  implicit val specFmt: Format[Spec]     = Json.format[Spec]
-  implicit val statusFmt: Format[Status] = Json.format[Status]
+  implicit val driverInfoFmt: Format[DriverInfo]             = Json.format[DriverInfo]
+  implicit val applicationStateFmt: Format[ApplicationState] = Json.format[ApplicationState]
+  implicit val specFmt: Format[Spec]                         = Json.format[Spec]
+  implicit val statusFmt: Format[Status]                     = Json.format[Status]
 
   final case class SpecPatch(spec: Spec) extends JsonMergePatch
 
   type CR = CustomResource[Spec, Status]
 
-  implicit val applicationStateFmt: Format[ApplicationState] = Json.format[ApplicationState]
-  implicit val driverInfoFmt: Format[DriverInfo]             = Json.format[DriverInfo]
-  implicit val specPatchFmt: Format[SpecPatch]               = Json.format[SpecPatch]
+  implicit val specPatchFmt: Format[SpecPatch] = Json.format[SpecPatch]
 
   implicit val resourceDefinition: ResourceDefinition[CustomResource[Spec, Status]] = ResourceDefinition[CR](
     group = "sparkoperator.k8s.io",

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/EndpointActionsSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/EndpointActionsSpec.scala
@@ -20,7 +20,6 @@ package action
 import org.scalatest._
 
 import skuber._
-import skuber.ext.Ingress
 
 import cloudflow.blueprint._
 

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -96,7 +96,7 @@ trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable 
 
       // schedule a function to check periodically if any of the queries
       // raised an exception
-      val done = system.scheduler.schedule(InitialDelay, MonitorFrequency) {
+      val runnable: Runnable = () => {
         val failed = streamletQueryExecution.queries.filter(_.exception.nonEmpty)
         if (failed.nonEmpty) {
           // if any of the queries has an exception, stop them all
@@ -106,8 +106,9 @@ trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable 
           // stop all query execution
           streamletQueryExecution.stop()
 
-        } else ()
+        }
       }
+      val done = system.scheduler.scheduleWithFixedDelay(InitialDelay, MonitorFrequency)(runnable)
 
       // this future will be successful when any of the queries face an exception
       // or is stopped. The runner needs to await on this future and exit only when it

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 // format: OFF
 object Version {
-  val Akka         = "2.5.24"
-  val AkkaHttp     = "10.1.9"
+  val Akka         = "2.6.3"
+  val AkkaHttp     = "10.1.11"
   val AlpakkaKafka = "2.0.2"
   val Scala        = "2.12.9"
   val Spark        = "2.4.5"
@@ -13,48 +13,48 @@ object Version {
 
 object Library {
   // External Libraries
-  val AkkaHttp              = "com.typesafe.akka"     %% "akka-http"                 % Version.AkkaHttp
-  val AkkaHttpJackson       = "com.typesafe.akka"     %% "akka-http-jackson"         % Version.AkkaHttp
-  val AkkaHttpSprayJson     = "com.typesafe.akka"     %% "akka-http-spray-json"      % Version.AkkaHttp
-  val AkkaStream            = "com.typesafe.akka"     %% "akka-stream"               % Version.Akka
-  val AkkaSlf4j             = "com.typesafe.akka"     %% "akka-slf4j"                % Version.Akka
-  val AkkaStreamContrib     = "com.typesafe.akka"     %% "akka-stream-contrib"       % "0.10"
-  val AkkaStreamKafka       = "com.typesafe.akka"     %% "akka-stream-kafka"         % Version.AlpakkaKafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
-  val AkkaStreamKafkaTestkit = "com.typesafe.akka"    %% "akka-stream-kafka-testkit" % Version.AlpakkaKafka exclude("com.typesafe.akka", "akka-stream-testkit")
-  val EmbeddedKafkaOrg      = "io.github.embeddedkafka"
-  val EmbeddedKafka         = EmbeddedKafkaOrg        %% "embedded-kafka"           % Version.Kafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
-  val Ficus                 = "com.iheart"            %% "ficus"                    % "1.4.7"
-  val Config                = "com.typesafe"           % "config"                   % "1.3.4"
-  val Logback               = "ch.qos.logback"         % "logback-classic"          % "1.2.3"
+  val AkkaHttp               = "com.typesafe.akka"     %% "akka-http"                 % Version.AkkaHttp
+  val AkkaHttpJackson        = "com.typesafe.akka"     %% "akka-http-jackson"         % Version.AkkaHttp
+  val AkkaHttpSprayJson      = "com.typesafe.akka"     %% "akka-http-spray-json"      % Version.AkkaHttp
+  val AkkaStream             = "com.typesafe.akka"     %% "akka-stream"               % Version.Akka
+  val AkkaSlf4j              = "com.typesafe.akka"     %% "akka-slf4j"                % Version.Akka
+  val AkkaStreamContrib      = "com.typesafe.akka"     %% "akka-stream-contrib"       % "0.11"
+  val AkkaStreamKafka        = "com.typesafe.akka"     %% "akka-stream-kafka"         % Version.AlpakkaKafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
+  val AkkaStreamKafkaTestkit = "com.typesafe.akka"    %% "akka-stream-kafka-testkit" % Version.AlpakkaKafka intransitive()
+  val AkkaStreamTestkit      = "com.typesafe.akka"    %% "akka-stream-testkit"        % Version.Akka 
+  val EmbeddedKafkaOrg       = "io.github.embeddedkafka"
+  val EmbeddedKafka          = EmbeddedKafkaOrg        %% "embedded-kafka"           % Version.Kafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
+  val Ficus                  = "com.iheart"            %% "ficus"                    % "1.4.7"
+  val Config                 = "com.typesafe"           % "config"                   % "1.3.4"
+  val Logback                = "ch.qos.logback"         % "logback-classic"          % "1.2.3"
 
-  val SprayJson             = "io.spray"              %% "spray-json"               % "1.3.5"
-  val Bijection             = "com.twitter"           %% "bijection-avro"           % "0.9.6"
+  val SprayJson              = "io.spray"              %% "spray-json"               % "1.3.5"
+  val Bijection              = "com.twitter"           %% "bijection-avro"           % "0.9.6"
 
-  val JacksonScalaModule    = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9"
-  val JacksonDatabind       = "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9"
+  val JacksonScalaModule     = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9"
+  val JacksonDatabind        = "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9"
 
-  val Skuber                = "io.skuber"             %% "skuber"                   % "2.4.0" exclude("com.fasterxml.jackson.core","jackson-databind")
+  val Skuber                 = "io.skuber"             %% "skuber"                   % "2.4.0" exclude("com.fasterxml.jackson.core","jackson-databind")
 
-  val Spark                 = "org.apache.spark"      %% "spark-core"               % Version.Spark
-  val SparkMllib            = "org.apache.spark"      %% "spark-mllib"              % Version.Spark
-  val SparkSql              = "org.apache.spark"      %% "spark-sql"                % Version.Spark
-  val SparkSqlKafka         = "org.apache.spark"      %% "spark-sql-kafka-0-10"     % Version.Spark
-  val SparkStreaming        = "org.apache.spark"      %% "spark-streaming"          % Version.Spark
-  val ScalaTestUnscoped     = "org.scalatest"         %% "scalatest"                % "3.0.8"
+  val Spark                  = "org.apache.spark"      %% "spark-core"               % Version.Spark
+  val SparkMllib             = "org.apache.spark"      %% "spark-mllib"              % Version.Spark
+  val SparkSql               = "org.apache.spark"      %% "spark-sql"                % Version.Spark
+  val SparkSqlKafka          = "org.apache.spark"      %% "spark-sql-kafka-0-10"     % Version.Spark
+  val SparkStreaming         = "org.apache.spark"      %% "spark-streaming"          % Version.Spark
+  val ScalaTestUnscoped      = "org.scalatest"         %% "scalatest"                % "3.0.8"
 
-  val Flink                 = "org.apache.flink"      %% "flink-scala"              % Version.Flink
-  val FlinkStreaming        = "org.apache.flink"      %% "flink-streaming-scala"    % Version.Flink
-  val FlinkAvro             = "org.apache.flink"       % "flink-avro"               % Version.Flink
-  val FlinkKafka            = "org.apache.flink"      %% "flink-connector-kafka"    % Version.Flink
+  val Flink                  = "org.apache.flink"      %% "flink-scala"              % Version.Flink
+  val FlinkStreaming         = "org.apache.flink"      %% "flink-streaming-scala"    % Version.Flink
+  val FlinkAvro              = "org.apache.flink"       % "flink-avro"               % Version.Flink
+  val FlinkKafka             = "org.apache.flink"      %% "flink-connector-kafka"    % Version.Flink
 
-  val FastClasspathScanner  = "io.github.lukehutch"   %  "fast-classpath-scanner"   % "2.21"
-  val ScalaCheck            = "org.scalacheck"        %% "scalacheck"               % "1.14.0"
-  val Avro4sJson            = "com.sksamuel.avro4s"   %% "avro4s-json"              % "3.0.0"
+  val FastClasspathScanner   = "io.github.lukehutch"   %  "fast-classpath-scanner"   % "2.21"
+  val ScalaCheck             = "org.scalacheck"        %% "scalacheck"               % "1.14.0"
+  val Avro4sJson             = "com.sksamuel.avro4s"   %% "avro4s-json"              % "3.0.0"
 
   // Test Dependencies
   val AkkaHttpTestkit        = "com.typesafe.akka"   %% "akka-http-testkit"          % Version.AkkaHttp     % Test
   val AkkaHttpSprayJsonTest  = AkkaHttpSprayJson                                                            % Test
-  val AkkaStreamTestkit      = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka         % Test 
   val Avro4sTest             = "com.sksamuel.avro4s" %% "avro4s-core"                % "3.0.0"              % Test
   val AkkaTestkit            = "com.typesafe.akka"   %% "akka-testkit"               % Version.Akka
   val ScalaTest              = ScalaTestUnscoped                                                            % Test

--- a/core/project/InternalRelease.scala
+++ b/core/project/InternalRelease.scala
@@ -53,7 +53,7 @@ object InternalReleaseCommand {
       if (Try("git rev-parse --git-dir".!!).isSuccess) {
         val commits = "git rev-list --count HEAD".!!.trim()
         val hash = "git rev-parse --short HEAD".!!.trim()
-        s"-${commits}-${hash}"
+        s"-pre-${commits}-${hash}"
       } else {
         sys.error("The current project is not a valid Git project.")
       }

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowSparkPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowSparkPlugin.scala
@@ -28,9 +28,10 @@ import cloudflow.sbt.CloudflowKeys._
 import CloudflowBasePlugin._
 
 object CloudflowSparkPlugin extends AutoPlugin {
-  final val SparkVersion                  = "2.4.5"
-  final val CloudflowVersion              = "1.3.1-SNAPSHOT"
-  final val CloudflowSparkDockerBaseImage = s"lightbend/spark:$CloudflowVersion-cloudflow-spark-$SparkVersion-scala-${CloudflowBasePlugin.ScalaVersion}"
+  final val SparkVersion     = "2.4.5"
+  final val CloudflowVersion = "1.3.1-SNAPSHOT"
+  final val CloudflowSparkDockerBaseImage =
+    s"lightbend/spark:$CloudflowVersion-cloudflow-spark-$SparkVersion-scala-${CloudflowBasePlugin.ScalaVersion}"
 
   override def requires = CloudflowBasePlugin
 

--- a/core/sbt-cloudflow/src/test/scala/cloudflow/sbt/StreamletScannerSpec.scala
+++ b/core/sbt-cloudflow/src/test/scala/cloudflow/sbt/StreamletScannerSpec.scala
@@ -26,7 +26,7 @@ final class StreamletScannerSpec extends WordSpec with TryValues with OptionValu
     val classLoader       = this.getClass.getClassLoader
     val results           = StreamletScanner.scan(classLoader)
     val (valid, invalid)  = results.partition { case (_, triedDiscoveredStreamlet) ⇒ triedDiscoveredStreamlet.isSuccess }
-    val validStreamlets   = valid.map { case (k, Success(discovered)) ⇒ (k, discovered) }
+    val validStreamlets   = valid.collect { case (k, Success(discovered)) ⇒ (k, discovered) }
     val invalidStreamlets = invalid.toMap
 
     // These are all valid streamlets defined in TestStreamlets.scala

--- a/examples/call-record-aggregator/akka-cdr-ingestor/src/test/scala/carly/ingestor/CallRecordMergeSpec.scala
+++ b/examples/call-record-aggregator/akka-cdr-ingestor/src/test/scala/carly/ingestor/CallRecordMergeSpec.scala
@@ -20,7 +20,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 import akka.actor._
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.testkit._
 import org.scalatest._
@@ -32,19 +31,17 @@ import carly.data._
 class CallRecordMergeSpec extends WordSpec with MustMatchers with ScalaFutures with BeforeAndAfterAll {
 
   private implicit val system = ActorSystem("CallRecordMergeSpec")
-  private implicit val mat = ActorMaterializer()
 
-  override def afterAll: Unit = {
+  override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)
-  }
 
   "A CallRecordMerge" should {
     "merge incoming data" in {
-      val testkit = AkkaStreamletTestKit(system, mat)
+      val testkit   = AkkaStreamletTestKit(system)
       val streamlet = new CallRecordMerge
 
       val instant = Instant.now.toEpochMilli / 1000
-      val past = Instant.now.minus(5000, ChronoUnit.DAYS).toEpochMilli / 1000
+      val past    = Instant.now.minus(5000, ChronoUnit.DAYS).toEpochMilli / 1000
 
       val cr1 = CallRecord("user-1", "user-2", "f", 10L, instant)
       val cr2 = CallRecord("user-1", "user-2", "f", 15L, instant)
@@ -54,27 +51,32 @@ class CallRecordMergeSpec extends WordSpec with MustMatchers with ScalaFutures w
       val source1 = Source(Vector(cr2))
       val source2 = Source(Vector(cr3))
 
-      val in0 = testkit.inletFromSource(streamlet.in0, source0)
-      val in1 = testkit.inletFromSource(streamlet.in1, source1)
-      val in2 = testkit.inletFromSource(streamlet.in2, source2)
-      val left = testkit.outletAsTap(streamlet.left)
+      val in0   = testkit.inletFromSource(streamlet.in0, source0)
+      val in1   = testkit.inletFromSource(streamlet.in1, source1)
+      val in2   = testkit.inletFromSource(streamlet.in2, source2)
+      val left  = testkit.outletAsTap(streamlet.left)
       val right = testkit.outletAsTap(streamlet.right)
 
-      testkit.run(streamlet, List(in0, in1, in2), List(left, right), () ⇒ {
-        right.probe.expectMsg(("user-1", cr1))
-        right.probe.expectMsg(("user-1", cr2))
-        right.probe.expectMsg(("user-1", cr3))
-      })
+      testkit.run(
+        streamlet,
+        List(in0, in1, in2),
+        List(left, right),
+        () ⇒ {
+          right.probe.expectMsg(("user-1", cr1))
+          right.probe.expectMsg(("user-1", cr2))
+          right.probe.expectMsg(("user-1", cr3))
+        }
+      )
 
       right.probe.expectMsg(Completed)
     }
 
     "split incoming data into valid call records and those outside the time range" in {
-      val testkit = AkkaStreamletTestKit(system, mat)
+      val testkit   = AkkaStreamletTestKit(system)
       val streamlet = new CallRecordMerge()
 
       val instant = Instant.now.toEpochMilli / 1000
-      val past = Instant.now.minus(5000, ChronoUnit.DAYS).toEpochMilli / 1000
+      val past    = Instant.now.minus(5000, ChronoUnit.DAYS).toEpochMilli / 1000
 
       val cr1 = CallRecord("user-1", "user-2", "f", 10L, instant)
       val cr2 = CallRecord("user-1", "user-2", "f", 15L, instant)
@@ -90,20 +92,24 @@ class CallRecordMergeSpec extends WordSpec with MustMatchers with ScalaFutures w
       val in1 = testkit.inletFromSource(streamlet.in1, source1)
       val in2 = testkit.inletFromSource(streamlet.in2, source2)
 
-      val left = testkit.outletAsTap(streamlet.left)
+      val left  = testkit.outletAsTap(streamlet.left)
       val right = testkit.outletAsTap(streamlet.right)
 
-      testkit.run(streamlet, List(in0, in1, in2), List(left, right), () ⇒ {
-        right.probe.expectMsg(("user-1", cr1))
-        right.probe.expectMsg(("user-1", cr2))
-        right.probe.expectMsg(("user-1", cr3))
-        left.probe.expectMsg((cr4.toString, InvalidRecord(cr4.toString, "Timestamp outside range!")))
-        left.probe.expectMsg((cr5.toString, InvalidRecord(cr5.toString, "Timestamp outside range!")))
-      })
+      testkit.run(
+        streamlet,
+        List(in0, in1, in2),
+        List(left, right),
+        () ⇒ {
+          right.probe.expectMsg(("user-1", cr1))
+          right.probe.expectMsg(("user-1", cr2))
+          right.probe.expectMsg(("user-1", cr3))
+          left.probe.expectMsg((cr4.toString, InvalidRecord(cr4.toString, "Timestamp outside range!")))
+          left.probe.expectMsg((cr5.toString, InvalidRecord(cr5.toString, "Timestamp outside range!")))
+        }
+      )
 
       left.probe.expectMsg(Completed)
       right.probe.expectMsg(Completed)
     }
   }
 }
-

--- a/examples/call-record-aggregator/build.sbt
+++ b/examples/call-record-aggregator/build.sbt
@@ -3,9 +3,11 @@ import sbt.Keys._
 
 lazy val root =
   Project(id = "root", base = file("."))
+    .enablePlugins(ScalafmtPlugin)
     .settings(
       name := "root",
       skip in publish := true,
+      scalafmtOnCompile := true,
     )
     .withId("root")
     .settings(commonSettings)

--- a/examples/call-record-aggregator/project/cloudflow-plugins.sbt
+++ b/examples/call-record-aggregator/project/cloudflow-plugins.sbt
@@ -2,5 +2,5 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-103-4e41ad2")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-134-3336886")
 

--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
@@ -27,7 +27,7 @@ import cloudflow.spark.sql.SQLImplicits._
 class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
 
   val streamlet = new CallRecordGeneratorIngress()
-  val testKit = SparkStreamletTestkit(session).withConfigParameterValues(ConfigParameterValue(streamlet.RecordsPerSecond, "50"))
+  val testKit   = SparkStreamletTestkit(session).withConfigParameterValues(ConfigParameterValue(streamlet.RecordsPerSecond, "50"))
 
   "CallRecordGeneratorIngress" should {
     "produce elements to its outlet" in {
@@ -46,4 +46,3 @@ class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
     }
   }
 }
-

--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallStatsAggregatorSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallStatsAggregatorSpec.scala
@@ -31,9 +31,8 @@ import cloudflow.spark.sql.SQLImplicits._
 class CallStatsAggregatorSpec extends SparkScalaTestSupport {
 
   val streamlet = new CallStatsAggregator()
-  val testKit = SparkStreamletTestkit(session).withConfigParameterValues(
-    ConfigParameterValue(streamlet.GroupByWindow, "1 minute"),
-    ConfigParameterValue(streamlet.Watermark, "1 minute"))
+  val testKit = SparkStreamletTestkit(session).withConfigParameterValues(ConfigParameterValue(streamlet.GroupByWindow, "1 minute"),
+                                                                         ConfigParameterValue(streamlet.Watermark, "1 minute"))
 
   "CallStatsAggregator" should {
     "produce elements to its outlet" in {
@@ -67,4 +66,3 @@ class CallStatsAggregatorSpec extends SparkScalaTestSupport {
     }
   }
 }
-

--- a/examples/sensor-data-java/build.sbt
+++ b/examples/sensor-data-java/build.sbt
@@ -9,7 +9,7 @@ lazy val sensorDataJava =  (project in file("."))
     .settings(
       libraryDependencies ++= Seq(
         "com.lightbend.akka"     %% "akka-stream-alpakka-file"  % "1.1.2",
-        "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.10",
+        "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.11",
         "ch.qos.logback"         %  "logback-classic"           % "1.2.3",
         "org.scalatest"          %% "scalatest"                 % "3.0.8"    % "test",
         "junit"                  % "junit"                      % "4.12"     % "test"

--- a/examples/sensor-data-java/build.sbt
+++ b/examples/sensor-data-java/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys._
 
 lazy val sensorDataJava =  (project in file("."))
     .enablePlugins(
-       CloudflowAkkaStreamsApplicationPlugin, 
+       CloudflowAkkaStreamsApplicationPlugin,
        JavaFormatterPlugin
     )
     .settings(

--- a/examples/sensor-data-java/project/cloudflow-plugins.sbt
+++ b/examples/sensor-data-java/project/cloudflow-plugins.sbt
@@ -3,4 +3,4 @@
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-103-4e41ad2")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-134-3336886")

--- a/examples/sensor-data-java/src/test/java/sensordata/MetricsValidationTest.java
+++ b/examples/sensor-data-java/src/test/java/sensordata/MetricsValidationTest.java
@@ -8,7 +8,6 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.japi.Pair;
 import akka.kafka.ConsumerMessage.CommittableOffset;
-import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.*;
 import akka.stream.javadsl.Flow;
 import akka.testkit.TestKit;
@@ -22,18 +21,16 @@ import cloudflow.streamlets.avro.*;
 import cloudflow.streamlets.descriptors.*;
 
 import org.apache.avro.Schema;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import org.junit.*;
 import static org.junit.Assert.*;
 
 public class MetricsValidationTest extends JUnitSuite {
-  static ActorMaterializer mat;
   static ActorSystem system;
 
   @BeforeClass
   public static void setUp() throws Exception {
     system = ActorSystem.create();
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
@@ -45,7 +42,7 @@ public class MetricsValidationTest extends JUnitSuite {
   @Test
   public void shouldProcessInvalidMetric() {
     MetricsValidation streamlet = new MetricsValidation();
-    AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system, mat);
+    AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system);
 
     QueueInletTap<Metric> in = testkit.makeInletAsTap(streamlet.inlet);
     ProbeOutletTap<Metric> valid = testkit.makeOutletAsTap(streamlet.validOutlet);

--- a/examples/sensor-data-scala/build.sbt
+++ b/examples/sensor-data-scala/build.sbt
@@ -3,8 +3,9 @@ import sbt._
 import sbt.Keys._
 
 lazy val sensorData =  (project in file("."))
-    .enablePlugins(CloudflowAkkaStreamsApplicationPlugin)
+    .enablePlugins(CloudflowAkkaStreamsApplicationPlugin, ScalafmtPlugin)
     .settings(
+      scalafmtOnCompile := true,
 //end::docs-projectSetup-example[]
       libraryDependencies ++= Seq(
         "com.lightbend.akka"     %% "akka-stream-alpakka-file"  % "1.1.2",

--- a/examples/sensor-data-scala/project/cloudflow-plugins.sbt
+++ b/examples/sensor-data-scala/project/cloudflow-plugins.sbt
@@ -3,4 +3,4 @@
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-103-4e41ad2")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-134-3336886")

--- a/examples/sensor-data-scala/src/main/scala/sensordata/RotorspeedWindowLogger.scala
+++ b/examples/sensor-data-scala/src/main/scala/sensordata/RotorspeedWindowLogger.scala
@@ -25,9 +25,9 @@ class RotorspeedWindowLogger extends AkkaStreamlet {
   val in    = AvroInlet[Metric]("in")
   val shape = StreamletShape(in)
   override def createLogic = new RunnableGraphStreamletLogic() {
-    def runnableGraph = sourceWithOffsetContext(in).via(flow).to(sinkWithOffsetContext)
+    def runnableGraph = sourceWithOffsetContext(in).via(flow).to(committableSink)
     def flow =
-      FlowWithOffsetContext[Metric]
+      FlowWithCommittableContext[Metric]
         .grouped(5)
         .map { rotorSpeedWindow ⇒
           val (avg, _) = rotorSpeedWindow.map(_.value).foldLeft((0.0, 1)) { case ((avg, idx), next) ⇒ (avg + (next - avg) / idx, idx + 1) }

--- a/examples/sensor-data-scala/src/main/scala/sensordata/SensorDataMerge.scala
+++ b/examples/sensor-data-scala/src/main/scala/sensordata/SensorDataMerge.scala
@@ -27,7 +27,7 @@ class SensorDataMerge extends AkkaStreamlet {
   val in1 = AvroInlet[SensorData]("in-1")
   val out = AvroOutlet[SensorData]("out", _.deviceId.toString)
 
-  final override val shape       = StreamletShape.withInlets(in0, in1).withOutlets(out)
+  final override val shape = StreamletShape.withInlets(in0, in1).withOutlets(out)
   final override def createLogic = new RunnableGraphStreamletLogic() {
     def runnableGraph = Merger.source(in0, in1).to(committableSink(out))
   }

--- a/examples/sensor-data-scala/src/main/scala/sensordata/SensorDataMerge.scala
+++ b/examples/sensor-data-scala/src/main/scala/sensordata/SensorDataMerge.scala
@@ -19,7 +19,8 @@ package sensordata
 import cloudflow.streamlets._
 import cloudflow.streamlets.avro._
 import cloudflow.akkastream._
-import cloudflow.akkastream.util.scaladsl.MergeLogic
+import cloudflow.akkastream.scaladsl._
+import cloudflow.akkastream.util.scaladsl.Merger
 
 class SensorDataMerge extends AkkaStreamlet {
   val in0 = AvroInlet[SensorData]("in-0")
@@ -27,5 +28,7 @@ class SensorDataMerge extends AkkaStreamlet {
   val out = AvroOutlet[SensorData]("out", _.deviceId.toString)
 
   final override val shape       = StreamletShape.withInlets(in0, in1).withOutlets(out)
-  final override def createLogic = new MergeLogic(Vector(in0, in1), out)
+  final override def createLogic = new RunnableGraphStreamletLogic() {
+    def runnableGraph = Merger.source(in0, in1).to(committableSink(out))
+  }
 }

--- a/examples/spark-sensors/build.sbt
+++ b/examples/spark-sensors/build.sbt
@@ -2,8 +2,9 @@ import sbt._
 import sbt.Keys._
 
 lazy val sparkSensors = (project in file("."))
-    .enablePlugins(CloudflowSparkApplicationPlugin)
+    .enablePlugins(CloudflowSparkApplicationPlugin, ScalafmtPlugin)
     .settings(
+      scalafmtOnCompile := true,
       libraryDependencies ++= Seq(
 	      "ch.qos.logback"     %  "logback-classic"        % "1.2.3",
         "org.scalatest"      %% "scalatest"              % "3.0.8" % "test"

--- a/examples/spark-sensors/project/cloudflow-plugins.sbt
+++ b/examples/spark-sensors/project/cloudflow-plugins.sbt
@@ -3,4 +3,4 @@
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-103-4e41ad2")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-134-3336886")

--- a/examples/taxi-ride/build.sbt
+++ b/examples/taxi-ride/build.sbt
@@ -4,9 +4,11 @@ import cloudflow.sbt.CommonSettingsAndTasksPlugin._
 
 lazy val root =
   Project(id = "root", base = file("."))
+    .enablePlugins(ScalafmtPlugin)
     .settings(
       name := "root",
       skip in publish := true,
+      scalafmtOnCompile := true,
     )
     .withId("root")
     .settings(commonSettings)

--- a/examples/taxi-ride/project/cloudflow-plugins.sbt
+++ b/examples/taxi-ride/project/cloudflow-plugins.sbt
@@ -3,4 +3,4 @@
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-103-4e41ad2")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-134-3336886")

--- a/examples/tensorflow-akka/build.sbt
+++ b/examples/tensorflow-akka/build.sbt
@@ -3,8 +3,9 @@ import sbt._
 import sbt.Keys._
 
 lazy val tensorflowAkka =  (project in file("."))
-    .enablePlugins(CloudflowAkkaStreamsApplicationPlugin)
+    .enablePlugins(CloudflowAkkaStreamsApplicationPlugin, ScalafmtPlugin)
     .settings(
+      scalafmtOnCompile := true,
 //end::docs-projectSetup-example[]
       libraryDependencies ++= Seq(
         "ch.qos.logback"         %  "logback-classic"           % "1.2.3",

--- a/examples/tensorflow-akka/project/cloudflow-plugins.sbt
+++ b/examples/tensorflow-akka/project/cloudflow-plugins.sbt
@@ -4,4 +4,4 @@ resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-103-4e41ad2")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1-134-3336886")

--- a/external/base-image/README.md
+++ b/external/base-image/README.md
@@ -5,7 +5,7 @@ The included Dockerfile builds a single image that can used in either a Flink st
 #### Building the image
 
 ```bash
-$ docker build -t lightbend/cloudflow-base:1.3.0-spark-2.4.4-flink-1.9.2-scala-2.12 .
+$ docker build -t lightbend/cloudflow-base:1.3.0-spark-2.4.5-flink-1.10.0-scala-2.12 .
 ```
 
 Which can be pushed to a remote repository.
@@ -13,6 +13,6 @@ Which can be pushed to a remote repository.
 Note that the tag of the final image is composed of the following components:
 
 1. Cloudflow version: `1.3.0`
-2. Spark version: `2.4.4`
-3. Flink version: `1.9.2`
+2. Spark version: `2.4.5`
+3. Flink version: `1.10.0`
 4. Scala version: `2.12`

--- a/external/multi-base-images/spark/releaseCloudflowSpark.sh
+++ b/external/multi-base-images/spark/releaseCloudflowSpark.sh
@@ -19,8 +19,8 @@
 #
 SCRIPT=`basename ${BASH_SOURCE[0]}`
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
-TAG=v2.4.4
-ORIGIN_TAG=2.4.4-k8s-client-upgrade
+TAG=v2.4.5
+ORIGIN_TAG=custom-2.4.5
 DOCKER_USERNAME=lightbend
 CLOUDFLOW_VERSION=1.3.1-SNAPSHOT
 SPARK_IMAGE_TAG=${CLOUDFLOW_VERSION}-cloudflow-spark-2.4.5-scala-2.12

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -22,7 +22,7 @@ echo "Runs 'sbt $TARGET' for core and examples"
 echo "========================================================================="
 
 cd $DIR/../core
-sbt --supershell=false $TARGET publishLocal
+sbt --supershell=false "; scalafmtCheck ; $TARGET  ; publishLocal"
 RETVAL=$?
 [ $RETVAL -ne 0 ] && echo "Failure in building of core" && exit -1
 
@@ -48,7 +48,13 @@ for prj in $PROJECTS; do
   echo "========================================================================="
 
   cd $prj
-  sbt --supershell=false $TARGET
+
+  if [ "$prj" = "sensor-data-java" ]; then
+    sbt --supershell=false $TARGET
+  else
+    sbt --supershell=false "; scalafmtCheck ; $TARGET"
+  fi
+
   RETVAL=$?
   [ $RETVAL -ne 0 ] && echo "Failure in project $prj" && exit -1
   cd ..


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enables scalafmt on compile at the core and examples sub-projects. Also adds the required logic at the github actions side to fail if format is wrong.

### Why are the changes needed?
We need to be able to fail if format is not correct at a PR stage and also check it by default when we compile the code.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
manually by having the wrong format and running the `scripts/build-all.sh` script.