### PR TITLE
Adds support for scalafmt

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -7,10 +7,11 @@ import sbtrelease.ReleaseStateTransformations._
 
 lazy val root =
   Project(id = "root", base = file("."))
-    .enablePlugins(ScalaUnidocPlugin, JavaUnidocPlugin)
+    .enablePlugins(ScalaUnidocPlugin, JavaUnidocPlugin, ScalafmtPlugin)
     .settings(
       name := "root",
       skip in publish := true,
+      scalafmtOnCompile := true,
       commands += InternalReleaseCommand.command,
       unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(
         streamlets,
@@ -435,7 +436,7 @@ def cloudflowModule(moduleID: String): Project = {
 }
 
 // These settings are made active only when we use bintray for internal release
-// It is important that when we do final releases we need to invoke sbt as 
+// It is important that when we do final releases we need to invoke sbt as
 // `sbt -Dsbt.sbtbintray=false`
 lazy val bintraySettings =
   if (BintrayPlugin.isEnabledViaProp) {

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowSparkPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowSparkPlugin.scala
@@ -28,9 +28,10 @@ import cloudflow.sbt.CloudflowKeys._
 import CloudflowBasePlugin._
 
 object CloudflowSparkPlugin extends AutoPlugin {
-  final val SparkVersion                  = "2.4.5"
-  final val CloudflowVersion              = "1.3.1-SNAPSHOT"
-  final val CloudflowSparkDockerBaseImage = s"lightbend/spark:$CloudflowVersion-cloudflow-spark-$SparkVersion-scala-${CloudflowBasePlugin.ScalaVersion}"
+  final val SparkVersion     = "2.4.5"
+  final val CloudflowVersion = "1.3.1-SNAPSHOT"
+  final val CloudflowSparkDockerBaseImage =
+    s"lightbend/spark:$CloudflowVersion-cloudflow-spark-$SparkVersion-scala-${CloudflowBasePlugin.ScalaVersion}"
 
   override def requires = CloudflowBasePlugin
 

--- a/examples/call-record-aggregator/build.sbt
+++ b/examples/call-record-aggregator/build.sbt
@@ -3,8 +3,10 @@ import sbt.Keys._
 
 lazy val root =
   Project(id = "root", base = file("."))
+    .enablePlugins(ScalafmtPlugin)
     .settings(
       name := "root",
+      scalafmtOnCompile := true,
       skip in publish := true,
     )
     .withId("root")

--- a/examples/sensor-data-java/build.sbt
+++ b/examples/sensor-data-java/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys._
 
 lazy val sensorDataJava =  (project in file("."))
     .enablePlugins(
-       CloudflowAkkaStreamsApplicationPlugin, 
+       CloudflowAkkaStreamsApplicationPlugin,
        JavaFormatterPlugin
     )
     .settings(

--- a/examples/sensor-data-scala/build.sbt
+++ b/examples/sensor-data-scala/build.sbt
@@ -3,9 +3,10 @@ import sbt._
 import sbt.Keys._
 
 lazy val sensorData =  (project in file("."))
-    .enablePlugins(CloudflowAkkaStreamsApplicationPlugin)
+    .enablePlugins(CloudflowAkkaStreamsApplicationPlugin, ScalafmtPlugin)
     .settings(
 //end::docs-projectSetup-example[]
+      scalafmtOnCompile := true,
       libraryDependencies ++= Seq(
         "com.lightbend.akka"     %% "akka-stream-alpakka-file"  % "1.1.2",
         "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.10",

--- a/examples/spark-sensors/build.sbt
+++ b/examples/spark-sensors/build.sbt
@@ -2,8 +2,9 @@ import sbt._
 import sbt.Keys._
 
 lazy val sparkSensors = (project in file("."))
-    .enablePlugins(CloudflowSparkApplicationPlugin)
+    .enablePlugins(CloudflowSparkApplicationPlugin, ScalafmtPlugin)
     .settings(
+      scalafmtOnCompile := true,
       libraryDependencies ++= Seq(
 	      "ch.qos.logback"     %  "logback-classic"        % "1.2.3",
         "org.scalatest"      %% "scalatest"              % "3.0.8" % "test"

--- a/examples/taxi-ride/build.sbt
+++ b/examples/taxi-ride/build.sbt
@@ -4,9 +4,11 @@ import cloudflow.sbt.CommonSettingsAndTasksPlugin._
 
 lazy val root =
   Project(id = "root", base = file("."))
+    .enablePlugins(ScalafmtPlugin)
     .settings(
       name := "root",
       skip in publish := true,
+      scalafmtOnCompile := true,
     )
     .withId("root")
     .settings(commonSettings)

--- a/examples/tensorflow-akka/build.sbt
+++ b/examples/tensorflow-akka/build.sbt
@@ -3,9 +3,10 @@ import sbt._
 import sbt.Keys._
 
 lazy val tensorflowAkka =  (project in file("."))
-    .enablePlugins(CloudflowAkkaStreamsApplicationPlugin)
+    .enablePlugins(CloudflowAkkaStreamsApplicationPlugin, ScalafmtPlugin)
     .settings(
 //end::docs-projectSetup-example[]
+      scalafmtOnCompile := true,
       libraryDependencies ++= Seq(
         "ch.qos.logback"         %  "logback-classic"           % "1.2.3",
         "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.10" % "test",

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -22,7 +22,7 @@ echo "Runs 'sbt $TARGET' for core and examples"
 echo "========================================================================="
 
 cd $DIR/../core
-sbt --supershell=false $TARGET publishLocal
+sbt --supershell=false "; scalafmtCheck ; $TARGET  ; publishLocal"
 RETVAL=$?
 [ $RETVAL -ne 0 ] && echo "Failure in building of core" && exit -1
 
@@ -48,7 +48,11 @@ for prj in $PROJECTS; do
   echo "========================================================================="
 
   cd $prj
-  sbt --supershell=false $TARGET
+  if [ "$prj" = "sensor-data-java" ]; then
+    sbt --supershell=false $TARGET
+  else
+    sbt --supershell=false "; scalafmtCheck ; $TARGET"
+  fi
   RETVAL=$?
   [ $RETVAL -ne 0 ] && echo "Failure in project $prj" && exit -1
   cd ..


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enables scalafmt on compile at the core and examples sub-projects. Also adds the required logic at the github actions side to fail if format is wrong.

### Why are the changes needed?
We need to be able to fail if format is not correct at a PR stage and also check it by default when we compile the code.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
manually by having the wrong format and running the scripts/build-all.sh script.
