### PR TITLE
use single shot execution to avoid waiting until timeout

### DIFF
--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkEgressSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkEgressSpec.scala
@@ -17,10 +17,8 @@
 package cloudflow.spark
 
 import scala.concurrent.duration._
-
-import org.apache.spark.sql.{ Dataset, Encoder, SparkSession }
-import org.apache.spark.sql.streaming.OutputMode
-
+import org.apache.spark.sql.{Dataset, Encoder, SparkSession}
+import org.apache.spark.sql.streaming.{OutputMode, Trigger}
 import cloudflow.streamlets.StreamletShape
 import cloudflow.streamlets.avro._
 import cloudflow.spark.avro._
@@ -54,6 +52,7 @@ class SparkEgressSpec extends SparkScalaTestSupport {
               .option("truncate", false)
               .queryName("allNames")
               .outputMode(OutputMode.Append())
+              .trigger(Trigger.Once)
               .start()
 
             val q2 = inDataset
@@ -65,6 +64,7 @@ class SparkEgressSpec extends SparkScalaTestSupport {
               .option("truncate", false)
               .queryName("allNamesUpper")
               .outputMode(OutputMode.Append())
+              .trigger(Trigger.Once)
               .start()
             StreamletQueryExecution(q1, q2)
           }


### PR DESCRIPTION
This PR is an attempt to improve the flaky Spark tests that often fails our CI builds.
Using the single execution mode (`Trigger.Once`), we allow the query to stop early and prevent the long 30s wait.