### PR TITLE
Improve Spark test execution time

### DIFF
--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkStreamletTestkit.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkStreamletTestkit.scala
@@ -221,8 +221,12 @@ final case class SparkStreamletTestkit(session: SparkSession, config: Config = C
       sparkStreamlet: SparkStreamlet,
       duration: Duration
   ): Unit = {
+    val t0 = System.currentTimeMillis()
     val queryExecution = sparkStreamlet.setContext(ctx).run(ctx.config)
-    session.streams.awaitAnyTermination(duration.toMillis)
+    while (session.streams.active.nonEmpty && (System.currentTimeMillis()-t0)<duration.toMillis ) {
+      session.streams.awaitAnyTermination(duration.toMillis)
+      session.streams.resetTerminated()
+    }
     queryExecution.stop()
     Await.result(queryExecution.completed, duration)
   }

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkStreamletTestkit.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkStreamletTestkit.scala
@@ -221,9 +221,9 @@ final case class SparkStreamletTestkit(session: SparkSession, config: Config = C
       sparkStreamlet: SparkStreamlet,
       duration: Duration
   ): Unit = {
-    val t0 = System.currentTimeMillis()
+    val t0             = System.currentTimeMillis()
     val queryExecution = sparkStreamlet.setContext(ctx).run(ctx.config)
-    while (session.streams.active.nonEmpty && (System.currentTimeMillis()-t0)<duration.toMillis ) {
+    while (session.streams.active.nonEmpty && (System.currentTimeMillis() - t0) < duration.toMillis) {
       session.streams.awaitAnyTermination(duration.toMillis)
       session.streams.resetTerminated()
     }

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -20,12 +20,11 @@ package testkit
 import java.nio.file.attribute.FileAttribute
 
 import com.typesafe.config._
+
 import scala.reflect.runtime.universe._
-
-import org.apache.spark.sql.{ Dataset, Encoder, SparkSession }
+import org.apache.spark.sql.{Dataset, Encoder, SparkSession}
 import org.apache.spark.sql.execution.streaming.MemoryStream
-import org.apache.spark.sql.streaming.{ OutputMode, StreamingQuery }
-
+import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, Trigger}
 import cloudflow.streamlets._
 
 /**
@@ -60,6 +59,7 @@ private[testkit] class TestSparkStreamletContext(override val streamletRef: Stri
         stream.writeStream
           .outputMode(outputMode)
           .format("memory")
+          .trigger(Trigger.Once)
           .queryName(outletTap.queryName)
           .start()
       }

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -22,9 +22,9 @@ import java.nio.file.attribute.FileAttribute
 import com.typesafe.config._
 
 import scala.reflect.runtime.universe._
-import org.apache.spark.sql.{Dataset, Encoder, SparkSession}
+import org.apache.spark.sql.{ Dataset, Encoder, SparkSession }
 import org.apache.spark.sql.execution.streaming.MemoryStream
-import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, Trigger}
+import org.apache.spark.sql.streaming.{ OutputMode, StreamingQuery, Trigger }
 import cloudflow.streamlets._
 
 /**

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -23,9 +23,9 @@ import com.typesafe.config._
 
 import scala.reflect.runtime.universe._
 import scala.concurrent.duration._
-import org.apache.spark.sql.{Dataset, Encoder, SparkSession}
+import org.apache.spark.sql.{ Dataset, Encoder, SparkSession }
 import org.apache.spark.sql.execution.streaming.MemoryStream
-import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, Trigger}
+import org.apache.spark.sql.streaming.{ OutputMode, StreamingQuery, Trigger }
 import cloudflow.streamlets._
 import org.apache.spark.sql.catalyst.InternalRow
 
@@ -77,12 +77,11 @@ private[testkit] class TestSparkStreamletContext(override val streamletRef: Stri
     tmpDir.toFile.getAbsolutePath
   }
 
-
-  private def isRateSource(stream: Dataset[_]):Boolean = {
+  private def isRateSource(stream: Dataset[_]): Boolean = {
     import org.apache.spark.sql.execution.command.ExplainCommand
     val explain = ExplainCommand(stream.queryExecution.logical, true)
-    val res = session.sessionState.executePlan(explain).executedPlan.executeCollect()
-    res.exists((row:InternalRow) => row.getString(0).contains("org.apache.spark.sql.execution.streaming.sources.RateStreamProvider"))
+    val res     = session.sessionState.executePlan(explain).executedPlan.executeCollect()
+    res.exists((row: InternalRow) => row.getString(0).contains("org.apache.spark.sql.execution.streaming.sources.RateStreamProvider"))
   }
 
 }

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -55,15 +55,9 @@ private[testkit] class TestSparkStreamletContext(override val streamletRef: Stri
   override def writeStream[Out](stream: Dataset[Out],
                                 outPort: CodecOutlet[Out],
                                 outputMode: OutputMode)(implicit encoder: Encoder[Out], typeTag: TypeTag[Out]): StreamingQuery = {
-    // RateSource can only work with a microBatch query because it contains no data at time zero, where Trigger.Once works.
-    val trigger = if (isRateSource(stream)) {
-      println("Using Processing Time!")
-      Trigger.ProcessingTime(ProcessingTimeInterval)
-    } else {
-      println("Using Processing Once!")
-      Trigger.Once()
-    }
-
+    // RateSource can only work with a microBatch query because it contains no data at time zero.
+    // Trigger.Once requires data at start to  work.
+    val trigger = if (isRateSource(stream)) Trigger.ProcessingTime(ProcessingTimeInterval) else Trigger.Once()
     outletTaps
       .find(_.portName == outPort.name)
       .map { outletTap ⇒

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkEgressSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkEgressSpec.scala
@@ -28,7 +28,7 @@ import cloudflow.spark.sql.SQLImplicits._
 class SparkEgressSpec extends SparkScalaTestSupport {
 
   // We are temporarily ignoring this test, a fix is on the way.
-  "SparkEgress" ignore {
+  "SparkEgress" should {
     "materialize streaming data to sink" in {
 
       val testKit = SparkStreamletTestkit(session)

--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
@@ -27,7 +27,7 @@ import cloudflow.spark.sql.SQLImplicits._
 class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
 
   val streamlet = new CallRecordGeneratorIngress()
-  val testKit = SparkStreamletTestkit(session).withConfigParameterValues(ConfigParameterValue(streamlet.RecordsPerSecond, "50"))
+  val testKit = SparkStreamletTestkit(session).withConfigParameterValues(ConfigParameterValue(streamlet.RecordsPerSecond, "1"))
 
   "CallRecordGeneratorIngress" should {
     "produce elements to its outlet" in {
@@ -35,7 +35,7 @@ class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
       // setup outlet tap on outlet port
       val out = testKit.outletAsTap[CallRecord](streamlet.out)
 
-      testKit.run(streamlet, Seq.empty, Seq(out), 40.seconds)
+      testKit.run(streamlet, Seq.empty, Seq(out), 2.seconds)
 
       // get data from outlet tap
       val results = out.asCollection(session)


### PR DESCRIPTION
This PR fixes the race condition in the `SparkEgressEgressSpec`. The cause was that in the test, there are two queries being executed, but the wait exits after any of them finish, resulting in an unknown state for the other query.
- If it had finished as well => test pass
- If it was not finished yet => test fail

In this PR, we introduce a wait for all queries with a manual  timeout check to avoid hanging there forever in case of failures.
Also, the execution of all queries is changed to "Once", making the tests run much faster.

`sbt:cloudflow-spark-tests> test`

Before:
```
[success] Total time: 22 s, completed Feb 26, 2020 8:30:08 PM
```

After:
```
[success] Total time: 5 s, completed Feb 26, 2020 9:01:18 PM
```
