### PR TITLE
Do not bring avro as transitive dependency from embedded-kafka

### DIFF
--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Library {
   val AkkaStreamKafka       = "com.typesafe.akka"     %% "akka-stream-kafka"         % Version.AlpakkaKafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
   val AkkaStreamKafkaTestkit = "com.typesafe.akka"    %% "akka-stream-kafka-testkit" % Version.AlpakkaKafka exclude("com.typesafe.akka", "akka-stream-testkit")
   val EmbeddedKafkaOrg      = "io.github.embeddedkafka"
-  val EmbeddedKafka         = EmbeddedKafkaOrg        %% "embedded-kafka"           % Version.Kafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
+  val EmbeddedKafka         = EmbeddedKafkaOrg        %% "embedded-kafka"           % Version.Kafka exclude("org.apache.avro", "avro") exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
   val Ficus                 = "com.iheart"            %% "ficus"                    % "1.4.7"
   val Config                = "com.typesafe"           % "config"                   % "1.3.4"
   val Logback               = "ch.qos.logback"         % "logback-classic"          % "1.2.3"


### PR DESCRIPTION
The other components are not compatible with avro 1.9

### What changes were proposed in this pull request?
exclude `avro` as transitive dependency from `embedded-kafka`. The referenced version is no compatible with the other components

### Why are the changes needed?
Without it, Spark streamlets fail at startup

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Manually tested on a 1.3.1-RC3 cluster.