### PR TITLE
Add the command to the scale cmd example

### DIFF
--- a/kubectl-cloudflow/cmd/scale.go
+++ b/kubectl-cloudflow/cmd/scale.go
@@ -24,7 +24,7 @@ func init() {
 	scaleCMD.cmd = &cobra.Command{
 		Use:     "scale",
 		Short:   "Scales a streamlet of a deployed Cloudflow application to the specified number of replicas.",
-		Example: "kubectl cloudflow my-app my-streamlet 2",
+		Example: "kubectl cloudflow scale my-app my-streamlet 2",
 		Run:     scaleCMD.scaleImpl,
 		Args:    validateScaleCmdArgs,
 	}


### PR DESCRIPTION
# What changes were proposed in this pull request?
Update to the command-line 'scale' example.

### Why are the changes needed?
The example excluded the 'scale' command in it's example

Previously: kubectl cloudflow my-app my-streamlet 2
After PR: kubectl cloudflow scale my-app my-streamlet 2

### Does this PR introduce any user-facing change?
Yes, better documentation ;)

### How was this patch tested?
No testing performed