### PR TITLE
Stop gap fix, so Flink streamlets work

### DIFF
--- a/kubectl-cloudflow/cmd/deploy.go
+++ b/kubectl-cloudflow/cmd/deploy.go
@@ -180,8 +180,12 @@ func (opts *deployOptions) deployImpl(cmd *cobra.Command, args []string) {
 	}
 	ownerReference = storedCR.GenerateOwnerReference()
 
-	streamletNameSecretMap = deploy.UpdateSecretsWithOwnerReference(ownerReference, streamletNameSecretMap)
-	createOrUpdateStreamletSecrets(k8sClient, namespace, streamletNameSecretMap)
+  // TODO: Temporarily disabled updating ownerReferences on secret
+  // It currently breaks Flink streamlets with config parameters.
+  // Disableling it so Cloudflow works while investigating of the problem.
+
+	//streamletNameSecretMap = deploy.UpdateSecretsWithOwnerReference(ownerReference, streamletNameSecretMap)
+	//createOrUpdateStreamletSecrets(k8sClient, namespace, streamletNameSecretMap)
 
 	serviceAccount.ObjectMeta.OwnerReferences = []metav1.OwnerReference{ownerReference}
 	if _, err := createOrUpdateServiceAccount(k8sClient, namespace, serviceAccount); err != nil {


### PR DESCRIPTION
Disabling setting ownerReferences on secret, until we have a fix for it.

### What changes were proposed in this pull request?
Disabling setting ownerReferences on secret, during deployment

### Why are the changes needed?
The example app taxi-rides fails to correctly initialize without the fix.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Deploying taxi-rides example app. Seeing data being processed by the Flink streamlet.
