### PR TITLE
Fixed Spark and Kafka status

### DIFF
--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/SavepointActions.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/SavepointActions.scala
@@ -62,11 +62,15 @@ object SavepointActions {
     deleteActions ++ createActions
   }
 
-  final case class Condition(`type`: String, status: String, lastTransitionTime: String, reason: String, message: String)
+  final case class Condition(`type`: Option[String],
+                             status: Option[String],
+                             lastTransitionTime: Option[String],
+                             reason: Option[String],
+                             message: Option[String])
 
   final case class Spec(partitions: Int, replicas: Int)
 
-  final case class Status(conditions: List[Condition], observedGeneration: Int)
+  final case class Status(conditions: Option[List[Condition]], observedGeneration: Option[Int])
 
   type Topic = CustomResource[Spec, Status]
   private implicit val ConditionFmt: Format[Condition] = Json.format[Condition]

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/SparkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/SparkRunner.scala
@@ -314,16 +314,16 @@ object SparkResource {
     }
   }
 
-  implicit val specFmt: Format[Spec]     = Json.format[Spec]
-  implicit val statusFmt: Format[Status] = Json.format[Status]
+  implicit val driverInfoFmt: Format[DriverInfo]             = Json.format[DriverInfo]
+  implicit val applicationStateFmt: Format[ApplicationState] = Json.format[ApplicationState]
+  implicit val specFmt: Format[Spec]                         = Json.format[Spec]
+  implicit val statusFmt: Format[Status]                     = Json.format[Status]
 
   final case class SpecPatch(spec: Spec) extends JsonMergePatch
 
   type CR = CustomResource[Spec, Status]
 
-  implicit val applicationStateFmt: Format[ApplicationState] = Json.format[ApplicationState]
-  implicit val driverInfoFmt: Format[DriverInfo]             = Json.format[DriverInfo]
-  implicit val specPatchFmt: Format[SpecPatch]               = Json.format[SpecPatch]
+  implicit val specPatchFmt: Format[SpecPatch] = Json.format[SpecPatch]
 
   implicit val resourceDefinition: ResourceDefinition[CustomResource[Spec, Status]] = ResourceDefinition[CR](
     group = "sparkoperator.k8s.io",

--- a/installer/common/shared.sh
+++ b/installer/common/shared.sh
@@ -198,12 +198,8 @@ helm upgrade $NFS_SERVER_NAME stable/$NFS_CHART_NAME \
 --install \
 --namespace "$1" \
 --timeout $HELM_TIMEOUT \
---set createStorage=false \
 --set serviceAccount.create=false \
---set serviceAccount.name=cloudflow-operator \
---set onOpenShift="$2" \
---set storageClassName=nfs-client \
---version 0.2.0
+--set serviceAccount.name=cloudflow-operator
 }
 
 EFS_SERVER_NAME=cloudflow-efs

--- a/installer/uninstall-cloudflow.sh
+++ b/installer/uninstall-cloudflow.sh
@@ -84,7 +84,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
       --ignore-not-found=true
 
     echo "Removing ClusterRoles..."
-    kubectl delete clusterrole cloudflow-nfs-fdp-nfs \
+    kubectl delete clusterrole cloudflow-nfs-nfs-server-provisioner \
       cloudflow-flink-flink-operator \
       cloudflow-sparkoperator-cr \
       strimzi-cluster-operator-global \
@@ -95,7 +95,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
       --ignore-not-found=true
 
     echo "Removing ClusterRoleBindings..."
-    kubectl delete clusterrolebinding cloudflow-nfs-fdp-nfs \
+    kubectl delete clusterrolebinding cloudflow-nfs-nfs-server-provisioner \
       cloudflow-flink-flink-operator \
       cloudflow-sparkoperator-crb \
       cloudflow-operator-bindings \
@@ -104,8 +104,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
       --ignore-not-found=true
 
     echo "Removing StorageClasses..."
-    kubectl delete sc nfs-client \
-      --ignore-not-found=true
+    kubectl delete sc nfs --ignore-not-found=true
 
     echo "Done!"
 else


### PR DESCRIPTION
Fixed [CSP-1917](https://lightbend.atlassian.net/browse/CSP-1917). Also incorporated some changes from https://github.com/lightbend/cloudflow/pull/146 to fix a Spark operator status bug that could potentially throw NullPointerException. Both these bugs only surfaced when scaling `call-record-aggregator`. Now I've tested this PR to make sure it's now working.
Fixed some issues with install/uninstall scripts due to recent change from fdp-nfs to an open source NFS chart.