### PR TITLE
Fixed compatibility issue with OpenShift

### DIFF
--- a/installer/common/shared.sh
+++ b/installer/common/shared.sh
@@ -62,7 +62,7 @@ export zookeeperHosts=""
 
 # Spark Operator
 export sparkOperatorReleaseName="cloudflow-sparkoperator"
-export sparkOperatorChartVersion="0.6.4"
+export sparkOperatorChartVersion="0.6.7"
 export sparkOperatorImageName="lightbend/sparkoperator"
 export sparkOperatorImageVersion="1.3.1-OpenJDK-2.4.5-1.1.0-cloudflow-2.12"
 export sparkOperatorNamespace="$namespace"
@@ -192,14 +192,18 @@ export limitsCpu="2"
 
 # Installs an NFS server: $1: namespace, $2: boolean onOpenShift
 NFS_SERVER_NAME=cloudflow-nfs
-NFS_CHART_NAME=nfs-server-provisioner
+NFS_CHART_NAME=fdp-nfs
 install_nfs_server() {
-helm upgrade $NFS_SERVER_NAME stable/$NFS_CHART_NAME \
+helm upgrade $NFS_SERVER_NAME lightbend-helm-charts/$NFS_CHART_NAME \
 --install \
 --namespace "$1" \
 --timeout $HELM_TIMEOUT \
 --set serviceAccount.create=false \
---set serviceAccount.name=cloudflow-operator
+--set serviceAccount.name=cloudflow-operator \
+--set createStorage=false \
+--set onOpenShift="$2" \
+--set storageClassName=nfs-client \
+--version 0.2.0
 }
 
 EFS_SERVER_NAME=cloudflow-efs

--- a/installer/uninstall-cloudflow.sh
+++ b/installer/uninstall-cloudflow.sh
@@ -84,7 +84,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
       --ignore-not-found=true
 
     echo "Removing ClusterRoles..."
-    kubectl delete clusterrole cloudflow-nfs-nfs-server-provisioner \
+    kubectl delete clusterrole cloudflow-nfs-fdp-nfs \
       cloudflow-flink-flink-operator \
       cloudflow-sparkoperator-cr \
       strimzi-cluster-operator-global \
@@ -95,7 +95,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
       --ignore-not-found=true
 
     echo "Removing ClusterRoleBindings..."
-    kubectl delete clusterrolebinding cloudflow-nfs-nfs-server-provisioner \
+    kubectl delete clusterrolebinding cloudflow-nfs-fdp-nfs \
       cloudflow-flink-flink-operator \
       cloudflow-sparkoperator-crb \
       cloudflow-operator-bindings \
@@ -104,7 +104,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
       --ignore-not-found=true
 
     echo "Removing StorageClasses..."
-    kubectl delete sc nfs --ignore-not-found=true
+    kubectl delete sc nfs-client --ignore-not-found=true
 
     echo "Done!"
 else


### PR DESCRIPTION
1. Upgraded Spark operator chart to 0.6.7 that includes a fix for K8s 1.11.
2. Reverted back to using `fdp-nfs` chart because `stable/nfs-server-provisioner` does not work on OpenShift.
Tested on zandvoort.