### PR TITLE
fixes for 1.3.1

### DIFF
--- a/installer/common/install-operators.sh
+++ b/installer/common/install-operators.sh
@@ -43,7 +43,7 @@ if [ "$installFlinkOperator" = true ]; then
     --set serviceAccounts.flink.name=cloudflow-app-serviceaccount \
     https://github.com/lightbend/flink-operator/releases/download/v${flinkOperatorChartVersion}/flink-operator-${flinkOperatorChartVersion}.tgz)
 
-    if [ $? -ne 0 ]; then 
+    if [ $? -ne 0 ]; then
         print_error_message "$result"
         print_error_message "installation failed"
         exit 1
@@ -53,7 +53,7 @@ if [ "$installFlinkOperator" = true ]; then
     kubectl label deployment -n "$flinkOperatorNamespace" cloudflow-flink-flink-operator installed-by=cloudflow --overwrite
 fi
 
-# Strimzi 
+# Strimzi
 if [ "$installStrimzi" = true ]; then
     echo "Installing Strimzi"
     result=$(helm upgrade "$strimziReleaseName" \
@@ -62,7 +62,7 @@ if [ "$installStrimzi" = true ]; then
     --version "$strimziVersion" \
     strimzi/strimzi-kafka-operator)
 
-    if [ $? -ne 0 ]; then 
+    if [ $? -ne 0 ]; then
         print_error_message "$result"
         print_error_message "installation failed"
         exit 1
@@ -85,12 +85,12 @@ if [ "$installSparkOperator" = true ]; then
     --set operatorVersion="$sparkOperatorImageVersion" \
     incubator/sparkoperator)
 
-    if [ $? -ne 0 ]; then 
+    if [ $? -ne 0 ]; then
         print_error_message "$result"
         print_error_message "installation failed"
         exit 1
     fi
 
     # Label the deployment so we can detect if we installed it later
-    kubectl label deployment -n "$sparkOperatorNamespace" "$sparkOperatorReleaseName"-sparkoperator installed-by=cloudflow --overwrite
+    kubectl label deployment -n "$sparkOperatorNamespace" "$sparkOperatorReleaseName" installed-by=cloudflow --overwrite
 fi

--- a/installer/common/shared.sh
+++ b/installer/common/shared.sh
@@ -45,7 +45,7 @@ export KAFKA="${KAFKA:-CloudflowManaged}"
 
 # Flink
 export flinkReleaseName="cloudflow-flink"
-export flinkOperatorChartVersion="0.8.1"
+export flinkOperatorChartVersion="0.8.2"
 export flinkOperatorNamespace=""
 export installFlinkOperator=false
 
@@ -62,7 +62,7 @@ export zookeeperHosts=""
 
 # Spark Operator
 export sparkOperatorReleaseName="cloudflow-sparkoperator"
-export sparkOperatorChartVersion="0.6.4"
+export sparkOperatorChartVersion="0.6.7"
 export sparkOperatorImageName="lightbend/sparkoperator"
 export sparkOperatorImageVersion="1.3.1-OpenJDK-2.4.5-1.1.0-cloudflow-2.12"
 export sparkOperatorNamespace="$namespace"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Updates Flink and Spark operator helm chart versions.
Fixes a bug with labeling the spark operator at installation time.
### Why are the changes needed?
We need to update to the latest to fix several bugs.
### Does this PR introduce any user-facing change?
No.
### How was this patch tested?

Tested on EKS by running successfully the following examples: a) taxi-ride-fare b) spark-sensors.

Here is the list of the installed charts on the test cluster.
```
$ helm list
NAME                   	REVISION	UPDATED                 	STATUS  	CHART                          	APP VERSION        	NAMESPACE
cloudflow              	1       	Tue Mar 10 12:00:59 2020	DEPLOYED	cloudflow-environment-1.3.1-RC4	                   	cloudflow
cloudflow-efs          	5       	Tue Mar 10 12:00:21 2020	DEPLOYED	efs-provisioner-0.11.0         	v2.4.0             	cloudflow
cloudflow-flink        	1       	Tue Mar 10 12:00:32 2020	DEPLOYED	flink-operator-0.8.2           	0.4.0              	cloudflow
cloudflow-sparkoperator	1       	Tue Mar 10 12:00:51 2020	DEPLOYED	sparkoperator-0.6.7            	v1beta2-1.1.0-2.4.5	cloudflow
cloudflow-strimzi      	1       	Tue Mar 10 12:00:43 2020	DEPLOYED	strimzi-kafka-operator-0.16.2  	0.16.2             	cloudflow
```
