### PR TITLE
Tune Spark interval value and test timeout to prevent failures across machines

### DIFF
--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -45,7 +45,7 @@ private[testkit] class TestSparkStreamletContext(override val streamletRef: Stri
                                                  override val config: Config = ConfigFactory.empty)
     extends SparkStreamletContext(StreamletDefinition("appId", "appVersion", streamletRef, "streamletClass", List(), List(), config),
                                   session) {
-  val ProcessingTimeInterval = 1.second
+  val ProcessingTimeInterval = 100.milliseconds
   override def readStream[In](inPort: CodecInlet[In])(implicit encoder: Encoder[In], typeTag: TypeTag[In]): Dataset[In] =
     inletTaps
       .find(_.portName == inPort.name)

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -45,7 +45,7 @@ private[testkit] class TestSparkStreamletContext(override val streamletRef: Stri
                                                  override val config: Config = ConfigFactory.empty)
     extends SparkStreamletContext(StreamletDefinition("appId", "appVersion", streamletRef, "streamletClass", List(), List(), config),
                                   session) {
-  val ProcessingTimeInterval = 100.milliseconds
+  val ProcessingTimeInterval = 1500.milliseconds
   override def readStream[In](inPort: CodecInlet[In])(implicit encoder: Encoder[In], typeTag: TypeTag[In]): Dataset[In] =
     inletTaps
       .find(_.portName == inPort.name)

--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
@@ -35,7 +35,7 @@ class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
       // setup outlet tap on outlet port
       val out = testKit.outletAsTap[CallRecord](streamlet.out)
 
-      testKit.run(streamlet, Seq.empty, Seq(out), 2.seconds)
+      testKit.run(streamlet, Seq.empty, Seq(out), 4500.milliseconds)
 
       // get data from outlet tap
       val results = out.asCollection(session)


### PR DESCRIPTION
This PR uses a less strict time budget for the Spark test that is using the `rate` producer.
Increases the fixed interval and gives a total time of 3x intervals for the test to produce a result.
This should prevent failure in most cases (except *very* slow machines)