### PR TITLE
Streamlets instances are using the wrong group-id.

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -140,8 +140,10 @@ lazy val akkastreamTests =
     .settings(
       scalafmtOnCompile := true,
       libraryDependencies ++= Vector(
+            AkkaStreamTestkit,
             AkkaHttpTestkit,
             AkkaHttpSprayJsonTest,
+            EmbeddedKafka % Test, 
             Logback % Test,
             ScalaTest,
             Junit

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.akkastream.util.scaladsl
+
+import scala.concurrent._
+import scala.concurrent.duration._
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.kafka.testkit.internal.TestFrameworkInterface
+import akka.kafka.testkit.scaladsl._
+import akka.stream.scaladsl._
+
+import com.typesafe.config._
+import cloudflow.akkastream._
+import cloudflow.akkastream.scaladsl._
+import cloudflow.akkastream.testdata._
+import cloudflow.streamlets._
+import cloudflow.streamlets.avro._
+
+import net.manub.embeddedkafka._
+import org.scalatest._
+import org.scalatest.Suite
+import org.scalatest.concurrent._
+import org.scalatest.time._
+
+object AkkaStreamletConsumerGroupSpec {
+  val kafkaPort = 1234
+  val zkPort    = 5678
+  val config    = ConfigFactory.parseString(s"""
+      akka {
+        stdout-loglevel = "OFF"
+        loglevel = "OFF"
+      }
+      cloudflow.kafka.bootstrap-servers = "localhost:$kafkaPort"
+      """)
+}
+
+import AkkaStreamletConsumerGroupSpec._
+
+class AkkaStreamletConsumerGroupSpec
+    extends KafkaSpec(kafkaPort, zkPort, ActorSystem("test", config))
+    with Suite
+    with WordSpecLike
+    with MustMatchers
+    with EmbeddedKafkaLike
+    with ScalaFutures
+    with TestFrameworkInterface.Scalatest { this: Suite =>
+
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(10, Seconds), interval = Span(20, Millis))
+
+  override def createKafkaConfig: EmbeddedKafkaConfig =
+    EmbeddedKafkaConfig(kafkaPort,
+                        zooKeeperPort,
+                        Map(
+                          "broker.id"                        -> "1",
+                          "num.partitions"                   -> "53",
+                          "offsets.topic.replication.factor" -> "1",
+                          "offsets.topic.num.partitions"     -> "3"
+                        ))
+
+  "Akka streamlet instances" should {
+    "consume from an outlet as a group" in {
+      val dataSize         = 1000
+      val data         = List.range(0, dataSize).map(i => Data(i, s"data"))
+      val genExecution = Generator.run(data)
+      // gen auto-completes, the source is finite.
+      genExecution.completed.futureValue
+      val probe = akka.testkit.TestProbe()
+
+      val sink        = Sink.actorRef[Data](probe.ref, Completed)
+      val instanceIds = List.range(0, 4)
+      val executions = instanceIds.map { i =>
+        val receiver = new TestReceiver(sink, i)
+        // when streamlets are scaled in a cluster, they all run with the same streamlet reference.
+        // This is why "receiver" is passed as the streamlet reference for all streamlets
+        TestReceiver.run("receiver", receiver)
+      }
+
+      val receivedData = probe.receiveN(dataSize, 10.seconds)
+      receivedData.size mustBe dataSize
+      // receiver sets name to the instance id it was created with.
+      receivedData.map { case Data(id, _) => id } must contain theSameElementsAs data.map(_.id)
+      receivedData.map { case Data(_, name) => name.toInt }.distinct.sorted must contain theSameElementsAs instanceIds
+      Future.sequence(executions.map(_.stop())).futureValue
+    }
+  }
+
+  object Completed
+  
+  val appId      = "my-app"
+  val appVersion = "abc"
+  
+  object Generator {
+    val StreamletClass = "Generator"
+    val Out            = "out"
+    val StreamletRef   = "gen"
+
+    def run(testData: List[Data]): StreamletExecution = {
+      val gen     = new Generator(testData)
+      val context = new AkkaStreamletContextImpl(definition(StreamletRef), system)
+      gen.setContext(context)
+      gen.run(context)
+    }
+
+    def definition(streamletRef: String) = StreamletDefinition(
+      appId = appId,
+      appVersion = appVersion,
+      streamletRef = StreamletRef,
+      streamletClass = StreamletClass,
+      portMapping = List(
+        ConnectedPort("out", SavepointPath(appId, streamletRef, Out))
+      ),
+      volumeMounts = List.empty[VolumeMount],
+      config = config
+    )
+  }
+
+  class Generator(testData: List[Data]) extends AkkaStreamlet {
+    import Generator._
+    // generate a known set of Data
+    val out                  = AvroOutlet[Data](Out)
+    final override val shape = StreamletShape.withOutlets(out)
+    override final def createLogic = new RunnableGraphStreamletLogic() {
+      def runnableGraph = Source(testData).to(plainSink(out))
+    }
+  }
+
+  object TestReceiver {
+    val streamletClass = "TestReceiver"
+    val out            = "out"
+
+    def run(streamletRef: String, receiver: TestReceiver): StreamletExecution = {
+      val context = new AkkaStreamletContextImpl(definition(streamletRef), system)
+      receiver.setContext(context)
+      receiver.run(context)
+    }
+
+    def definition(streamletRef: String) = StreamletDefinition(
+      appId = appId,
+      appVersion = appVersion,
+      streamletRef = streamletRef,
+      streamletClass = "TestReceiver",
+      portMapping = List(
+        ConnectedPort("in", SavepointPath(appId, Generator.StreamletRef, Generator.Out))
+      ),
+      volumeMounts = List.empty[VolumeMount],
+      config = config
+    )
+  }
+
+  class TestReceiver(sink: Sink[Data, NotUsed], instance: Int) extends AkkaStreamlet {
+    val in                   = AvroInlet[Data]("in")
+    final override val shape = StreamletShape.withInlets(in)
+
+    val flow = Flow[Data].map(_.copy(name = s"$instance"))
+
+    override final def createLogic = new RunnableGraphStreamletLogic() {
+      def runnableGraph = plainSource(in, Earliest).via(flow).to(sink)
+    }
+  }
+}

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -69,7 +69,7 @@ class AkkaStreamletConsumerGroupSpec extends EmbeddedKafkaSpec(kafkaPort, zkPort
       val outlet       = mkUniqueGenOutlet()
       val genExecution = Generator.run(data, outlet)
       // gen auto-completes, the source is finite.
-      genExecution.completed.futureValue
+      val _ = genExecution.completed.futureValue // assert that the future completed
 
       // all test receivers will write their data to a sink which is probed.
       val probe = akka.testkit.TestProbe()

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -64,7 +64,7 @@ class AkkaStreamletConsumerGroupSpec extends EmbeddedKafkaSpec(kafkaPort, zkPort
   "Akka streamlet instances" should {
     "consume from an outlet as a group for the same streamlet" in {
       // Generate some test data
-      val dataSize     = 10000
+      val dataSize     = 5000
       val data         = List.range(0, dataSize).map(i => Data(i, s"data"))
       val genExecution = Generator.run(data)
       // gen auto-completes, the source is finite.
@@ -126,8 +126,6 @@ class AkkaStreamletConsumerGroupSpec extends EmbeddedKafkaSpec(kafkaPort, zkPort
       receivedData.map { case Data(_, name) => name.toInt }.distinct.sorted must contain theSameElementsAs instanceIds
       Future.sequence(executions.map(_.stop())).futureValue
     }
-
-    //TODO add consume from outlet using different streamlets
   }
 
   object Completed

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -62,7 +62,7 @@ class AkkaStreamletConsumerGroupSpec extends EmbeddedKafkaSpec(kafkaPort, zkPort
                         ))
 
   "Akka streamlet instances" should {
-    "consume from an outlet as a group for the same streamlet" in {
+    "consume from an outlet as a group per streamlet reference" in {
       // Generate some test data
       val dataSize     = 5000
       val data         = List.range(0, dataSize).map(i => Data(i, s"data"))

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -96,7 +96,7 @@ class AkkaStreamletConsumerGroupSpec extends EmbeddedKafkaSpec(kafkaPort, zkPort
       Future.sequence(executions.map(_.stop())).futureValue
     }
 
-    "consume from an outlet grouped by streamlet reference" in {
+    "consume from an outlet separately if the streamlet name is different" in {
       // Generate some test data
       val dataSize = 500
       val data     = List.range(0, dataSize).map(i => Data(i, s"data"))

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -75,7 +75,7 @@ class AkkaStreamletConsumerGroupSpec
 
   "Akka streamlet instances" should {
     "consume from an outlet as a group" in {
-      val dataSize         = 1000
+      val dataSize     = 1000
       val data         = List.range(0, dataSize).map(i => Data(i, s"data"))
       val genExecution = Generator.run(data)
       // gen auto-completes, the source is finite.
@@ -101,10 +101,10 @@ class AkkaStreamletConsumerGroupSpec
   }
 
   object Completed
-  
+
   val appId      = "my-app"
   val appVersion = "abc"
-  
+
   object Generator {
     val StreamletClass = "Generator"
     val Out            = "out"

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/EmbeddedKafkaSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/EmbeddedKafkaSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.akkastream.util.scaladsl
+
+import akka.actor.ActorSystem
+import akka.kafka.testkit.internal.TestFrameworkInterface
+import akka.kafka.testkit.scaladsl._
+import akka.stream.scaladsl._
+
+import org.scalatest._
+import org.scalatest.Suite
+import org.scalatest.concurrent._
+
+abstract class EmbeddedKafkaSpec(kafkaPort: Int, zkPort: Int, system: ActorSystem)
+    extends KafkaSpec(kafkaPort, zkPort, system)
+    with Suite
+    with WordSpecLike
+    with MustMatchers
+    with EmbeddedKafkaLike
+    with ScalaFutures
+    with TestFrameworkInterface.Scalatest { this: Suite =>
+}

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
@@ -64,7 +64,7 @@ abstract class AkkaStreamlet extends Streamlet[AkkaStreamletContext] {
     val streamletConfig = Try {
       context.system.settings.config.getConfig("cloudflow.runner.streamlets")
     }.getOrElse(ConfigFactory.empty())
-    
+
     context.system.log.info(startRunnerMessage(blockingIODispatcherConfig, dispatcherConfig, deploymentConfig, streamletConfig))
 
     val logic = createLogic()

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -203,7 +203,7 @@ final class AkkaStreamletContextImpl(
             )
             completionPromise.trySuccess(Dun)
           case Failure(e) ⇒
-            system.log.error(e, s"Stream has failed, shutting down streamlet $streamletDefinitionMsg.")
+            system.log.error(e, s"Stream has failed. Shutting down streamlet $streamletDefinitionMsg.")
             completionPromise.tryFailure(e)
         }
       )

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -74,7 +74,7 @@ final class AkkaStreamletContextImpl(
   def sourceWithOffsetContext[T](inlet: CodecInlet[T]): cloudflow.akkastream.scaladsl.SourceWithOffsetContext[T] = {
     val savepointPath = findSavepointPathForPort(inlet)
     val topic         = savepointPath.value
-    val gId           = savepointPath.groupId(inlet)
+    val gId           = savepointPath.groupId(streamletRef, inlet)
     val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new ByteArrayDeserializer)
       .withBootstrapServers(bootstrapServers)
       .withGroupId(gId)
@@ -141,7 +141,7 @@ final class AkkaStreamletContextImpl(
     // TODO clean this up, lot of copying code, refactor.
     val savepointPath = findSavepointPathForPort(inlet)
     val topic         = savepointPath.value
-    val gId           = savepointPath.groupId(inlet)
+    val gId           = savepointPath.groupId(streamletRef, inlet)
     val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new ByteArrayDeserializer)
       .withBootstrapServers(bootstrapServers)
       .withGroupId(gId)

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -199,11 +199,11 @@ final class AkkaStreamletContextImpl(
         Sink.onComplete {
           case Success(_) ⇒
             system.log.error(
-              s"""Stream has completed, shutting down streamlet $streamletDefinitionMsg."""
+              s"Stream has completed, shutting down streamlet $streamletDefinitionMsg."
             )
             completionPromise.trySuccess(Dun)
           case Failure(e) ⇒
-            system.log.error(e, s"""Stream has failed, shutting down streamlet $streamletDefinitionMsg.""")
+            system.log.error(e, s"Stream has failed, shutting down streamlet $streamletDefinitionMsg.")
             completionPromise.tryFailure(e)
         }
       )

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -39,18 +39,14 @@ import org.apache.kafka.common.serialization._
 
 import cloudflow.streamlets._
 
-object AkkaStreamletContextImpl {
-  def apply(streamletDefinition: StreamletDefinition): AkkaStreamletContextImpl =
-    new AkkaStreamletContextImpl(streamletDefinition)
-}
-
 /**
  * Implementation of the StreamletContext trait.
  */
 final class AkkaStreamletContextImpl(
-    private[cloudflow] override val streamletDefinition: StreamletDefinition
+    private[cloudflow] override val streamletDefinition: StreamletDefinition,
+    sys: ActorSystem
 ) extends AkkaStreamletContext {
-  implicit val system: ActorSystem = ActorSystem("akka_streamlet", config)
+  implicit val system: ActorSystem = sys
 
   implicit def materializer = ActorMaterializer()(system)
 
@@ -194,17 +190,21 @@ final class AkkaStreamletContextImpl(
   def onStop(f: () ⇒ Future[Dun]): Unit =
     stoppers.getAndUpdate(old ⇒ old :+ f)
 
+  private def streamletDefinitionMsg: String = s"${streamletDefinition.streamletRef} (${streamletDefinition.streamletClass})"
+
   private def handleTermination[T]: Flow[T, T, NotUsed] =
     Flow[T]
       .via(killSwitch.flow)
       .alsoTo(
         Sink.onComplete {
           case Success(_) ⇒
-            system.log.error(s"Stream has completed unexpectedly, shutting down streamlet.")
-            completionPromise.success(Dun)
+            system.log.error(
+              s"""Stream has completed, shutting down streamlet $streamletDefinitionMsg."""
+            )
+            completionPromise.trySuccess(Dun)
           case Failure(e) ⇒
-            system.log.error(e, "Stream has failed, shutting down streamlet.")
-            completionPromise.failure(e)
+            system.log.error(e, s"""Stream has failed, shutting down streamlet $streamletDefinitionMsg.""")
+            completionPromise.tryFailure(e)
         }
       )
 

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -199,7 +199,7 @@ final class AkkaStreamletContextImpl(
         Sink.onComplete {
           case Success(_) ⇒
             system.log.error(
-              s"Stream has completed, shutting down streamlet $streamletDefinitionMsg."
+              s"Stream has completed. Shutting down streamlet $streamletDefinitionMsg."
             )
             completionPromise.trySuccess(Dun)
           case Failure(e) ⇒

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
@@ -68,7 +68,7 @@ final class KafkaSinkRef[T](
       .alsoTo(
         Sink.onComplete {
           case Success(_) ⇒
-            system.log.error(s"Stream has completed, shutting down streamlet.")
+            system.log.error(s"Stream has completed. Shutting down streamlet...")
             completionPromise.success(Dun)
           case Failure(e) ⇒
             system.log.error(e, "Stream has failed, shutting down streamlet.")

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
@@ -71,7 +71,7 @@ final class KafkaSinkRef[T](
             system.log.error(s"Stream has completed. Shutting down streamlet...")
             completionPromise.success(Dun)
           case Failure(e) ⇒
-            system.log.error(e, "Stream has failed, shutting down streamlet.")
+            system.log.error(e, "Stream has failed. Shutting down streamlet...")
             completionPromise.failure(e)
         }
       )

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
@@ -68,7 +68,7 @@ final class KafkaSinkRef[T](
       .alsoTo(
         Sink.onComplete {
           case Success(_) ⇒
-            system.log.error(s"Stream has completed unexpectedly, shutting down streamlet.")
+            system.log.error(s"Stream has completed, shutting down streamlet.")
             completionPromise.success(Dun)
           case Failure(e) ⇒
             system.log.error(e, "Stream has failed, shutting down streamlet.")

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContextImpl.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContextImpl.scala
@@ -44,7 +44,7 @@ class FlinkStreamletContextImpl(
   override def readStream[In: TypeInformation](inlet: CodecInlet[In]): DataStream[In] = {
     val savepointPath = findSavepointPathForPort(inlet)
     val srcTopic      = savepointPath.value
-    val groupId       = savepointPath.groupId(inlet)
+    val groupId       = savepointPath.groupId(streamletRef, inlet)
 
     val properties = new ju.Properties
     properties.setProperty("bootstrap.servers", config.getString("cloudflow.kafka.bootstrap-servers"))

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletDefinition.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletDefinition.scala
@@ -52,7 +52,7 @@ final case class SavepointPath(appId: String, streamletRef: String, portName: St
   def value: String = s"${appId}.${streamletRef}.${portName}"
   def groupId[T](readingStreamletRef: String, inlet: CodecInlet[T]) = {
     val base = s"$appId.$readingStreamletRef.${inlet.name}"
-    if (inlet.hasUniqueGroupId) base + randomUUID.toString
+    if (inlet.hasUniqueGroupId) s"${base}.${randomUUID.toString}"
     else base
   }
 }

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletDefinition.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletDefinition.scala
@@ -50,8 +50,8 @@ case class StreamletDefinition(appId: String,
  */
 final case class SavepointPath(appId: String, streamletRef: String, portName: String) {
   def value: String = s"${appId}.${streamletRef}.${portName}"
-  def groupId[T](inlet: CodecInlet[T]) = {
-    val base = s"$appId.$streamletRef.${inlet.name}"
+  def groupId[T](readingStreamletRef: String, inlet: CodecInlet[T]) = {
+    val base = s"$appId.$readingStreamletRef.${inlet.name}"
     if (inlet.hasUniqueGroupId) base + randomUUID.toString
     else base
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Bugfix for incorrect groupId

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Different streamlets reading from the same outlet should not be part of the same consumer group.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests have been added.