### PR TITLE
Fixed potentially confusing error message after it led to misunderstanding with a user

### DIFF
--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletContext.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletContext.scala
@@ -89,7 +89,7 @@ trait StreamletContext {
       .getOrElse(throw MountedPathUnavailableException(volumeMount))
 
   case class MountedPathUnavailableException(volumeMount: VolumeMount)
-      extends Exception(s"Mount path for Volume Mount named '${volumeMount.name}' is unavailable.")
+      extends Exception(s"Mount path for volume mount named '${volumeMount.name}' is unavailable.")
 
 }
 

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletContext.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletContext.scala
@@ -95,5 +95,5 @@ trait StreamletContext {
 
 case class PortNotFoundException(port: StreamletPort, streamletDefinition: StreamletDefinition)
     extends Exception(
-      s"Streamlet port '${port.name}'' not found for application '${streamletDefinition.appId}' and streamlet '${streamletDefinition.streamletRef}'"
+      s"Streamlet port '${port.name}' not found for application '${streamletDefinition.appId}' and streamlet '${streamletDefinition.streamletRef}'"
     )

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletContext.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletContext.scala
@@ -89,11 +89,11 @@ trait StreamletContext {
       .getOrElse(throw MountedPathUnavailableException(volumeMount))
 
   case class MountedPathUnavailableException(volumeMount: VolumeMount)
-      extends Exception(s"Mount path for Volume Mount named [${volumeMount.name}] is unavailable.")
+      extends Exception(s"Mount path for Volume Mount named '${volumeMount.name}' is unavailable.")
 
 }
 
 case class PortNotFoundException(port: StreamletPort, streamletDefinition: StreamletDefinition)
     extends Exception(
-      s"Streamlet port ${port.name} not found for ${streamletDefinition.appId} and streamlet ${streamletDefinition.streamletRef}"
+      s"Streamlet port '${port.name}'' not found for application '${streamletDefinition.appId}' and streamlet '${streamletDefinition.streamletRef}'"
     )


### PR DESCRIPTION
The user got an error during blueprint validation saying "Streamlet port verbs not found for application". They had no idea what "streamlet port verbs were" so they asked support. Turns out it was an outlet called "verbs" on their streamlet that they had forgotten to declare but the lack of quotes made the sentence very hard to parse, even for me as the support engineer.

So I added some quotes.

Tested by running `sbt clean test` on the core.