### PR TITLE
Wip akka 2.6.4 upgrade

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -140,7 +140,7 @@ lazy val akkastreamTests =
     .settings(
       scalafmtOnCompile := true,
       libraryDependencies ++= Vector(
-            AkkaStreamTestkit,
+            AkkaStreamTestkit % Test,
             AkkaHttpTestkit,
             AkkaHttpSprayJsonTest,
             EmbeddedKafka % Test, 
@@ -361,7 +361,7 @@ lazy val operator =
             Ficus,
             Logback,
             Skuber,
-            AkkaStreamTestkit,
+            AkkaStreamTestkit % Test,
             JacksonDatabind,
             ScalaTest,
             ScalaCheck % "test",

--- a/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/HttpServerSpec.scala
+++ b/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/HttpServerSpec.scala
@@ -64,6 +64,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
         startIngress()
         val request  = HttpRequest(method, Uri(s"http://127.0.0.1:$port"), Nil, HttpEntity.Empty)
         val response = Http().singleRequest(request).futureValue
+        response.discardEntityBytes()
         response.status mustEqual StatusCodes.MethodNotAllowed
         out.probe.expectNoMessage(noMessageDuration)
       }
@@ -75,6 +76,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       val request  = Post(s"http://127.0.0.1:$port", data)
       val response = Http().singleRequest(request).futureValue
       response.status mustEqual StatusCodes.Accepted
+      response.discardEntityBytes()
       out.probe.expectMsg(("1", data))
       out.probe.expectMsg(Completed)
     }
@@ -83,6 +85,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       startIngress()
       val request  = Post(s"http://127.0.0.1:$port")
       val response = Http().singleRequest(request).futureValue
+      response.discardEntityBytes()
       response.status mustEqual StatusCodes.BadRequest
     }
 
@@ -92,6 +95,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       val request  = Put(s"http://127.0.0.1:$port", data)
       val response = Http().singleRequest(request).futureValue
       response.status mustEqual StatusCodes.OK
+      response.discardEntityBytes()
       out.probe.expectMsg(("42", data))
       out.probe.expectMsg(Completed)
 

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 // format: OFF
 object Version {
-  val Akka         = "2.5.29"
-  val AkkaHttp     = "10.1.9"
+  val Akka         = "2.6.4"
+  val AkkaHttp     = "10.1.11"
   val AlpakkaKafka = "2.0.2"
   val Scala        = "2.12.9"
   val Spark        = "2.4.5"
@@ -54,7 +54,7 @@ object Library {
   // Test Dependencies
   val AkkaHttpTestkit        = "com.typesafe.akka"   %% "akka-http-testkit"          % Version.AkkaHttp     % Test
   val AkkaHttpSprayJsonTest  = AkkaHttpSprayJson                                                            % Test
-  val AkkaStreamTestkit      = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka         % Test 
+  val AkkaStreamTestkit      = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka          
   val Avro4sTest             = "com.sksamuel.avro4s" %% "avro4s-core"                % "3.0.0"              % Test
   val AkkaTestkit            = "com.typesafe.akka"   %% "akka-testkit"               % Version.Akka
   val ScalaTest              = ScalaTestUnscoped                                                            % Test

--- a/examples/call-record-aggregator/build.sbt
+++ b/examples/call-record-aggregator/build.sbt
@@ -37,7 +37,7 @@ lazy val akkaCdrIngestor= appModule("akka-cdr-ingestor")
     .settings(
       commonSettings,
       libraryDependencies ++= Seq(
-        "com.typesafe.akka"         %% "akka-http-spray-json"   % "10.1.10",
+        "com.typesafe.akka"         %% "akka-http-spray-json"   % "10.1.11",
         "ch.qos.logback"            %  "logback-classic"        % "1.2.3",
         "org.scalatest"             %% "scalatest"              % "3.0.8"    % "test"
       )
@@ -49,7 +49,7 @@ lazy val akkaJavaAggregationOutput= appModule("akka-java-aggregation-output")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
-      "com.typesafe.akka"      %% "akka-http-spray-json"   % "10.1.10",
+      "com.typesafe.akka"      %% "akka-http-spray-json"   % "10.1.11",
       "ch.qos.logback"         %  "logback-classic"        % "1.2.3",
       "org.scalatest"          %% "scalatest"              % "3.0.8"    % "test"
     )

--- a/examples/call-record-aggregator/project/cloudflow-plugins.sbt
+++ b/examples/call-record-aggregator/project/cloudflow-plugins.sbt
@@ -2,5 +2,5 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.2-SNAPSHOT")
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

I have been playing around with some features that needed Akka 2.6 in cloudflow so I figured I would create a pull request.  Let me know if this helps out

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Resolving issue #80 by upgrading cloudflow to Akka 2.6.4


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
New versions of Akka have been released and cloud flow needs to upgrade to stay up to date and leverage new features

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
no tests added but all tests run on the project and example projects.  All example projects have also been tested using runLocal and call record aggregator has been deployed on GKE.

The operator has not been deployed and tested