### PR TITLE
Csp 1978 spark processor test -- workaround --

### DIFF
--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkStreamletTestkit.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkStreamletTestkit.scala
@@ -222,8 +222,17 @@ final case class SparkStreamletTestkit(session: SparkSession, config: Config = C
       duration: Duration
   ): Unit = {
     val t0             = System.currentTimeMillis()
+    def elapsedMillis  = System.currentTimeMillis() - t0
     val queryExecution = sparkStreamlet.setContext(ctx).run(ctx.config)
+    println(s"SparkStreamletTestKit: Before time checks *****************************************")
+    val currentMillis = elapsedMillis
+    val expired       = currentMillis < duration.toMillis
+    println(s"SparkStreamletTestKit: elapsed millis after run: $currentMillis")
+    println(s"SparkStreamletTestKit: are we beyond deadline? : $expired")
+    println(s"SparkStreamletTestKit: Active streams:" + session.streams.active.mkString(", "))
+    println(s"*****************************************")
     while (session.streams.active.nonEmpty && (System.currentTimeMillis() - t0) < duration.toMillis) {
+      println(s"Into while loop")
       session.streams.awaitAnyTermination(duration.toMillis)
       session.streams.resetTerminated()
     }

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -58,6 +58,9 @@ private[testkit] class TestSparkStreamletContext(override val streamletRef: Stri
     // RateSource can only work with a microBatch query because it contains no data at time zero.
     // Trigger.Once requires data at start to  work.
     val trigger = if (isRateSource(stream)) Trigger.ProcessingTime(ProcessingTimeInterval) else Trigger.Once()
+    println(s"*****************************************")
+    println(s"TestSparkStreamletContext: Using $trigger")
+    println(s"*****************************************")
     outletTaps
       .find(_.portName == outPort.name)
       .map { outletTap ⇒

--- a/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
+++ b/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
@@ -36,6 +36,9 @@ class SparkProcessorSpec extends SparkScalaTestSupport { // 1. Extend SparkScala
 
       // get data from outlet tap
       val results = out.asCollection(session)
+      println("**************")
+      println("Results from the test:" + results.mkString(","))
+      println("**************")
 
       // 8. Assert that actual matches expectation
       results must contain(Data(2, "name2"))

--- a/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
+++ b/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
@@ -32,7 +32,7 @@ class SparkProcessorSpec extends SparkScalaTestSupport { // 1. Extend SparkScala
       in.addData(data)
 
       // 7. Run the streamlet using the testkit and the setup inlet taps and outlet probes
-      testkit.run(processor, Seq(in), Seq(out), 2.seconds)
+      testkit.run(processor, Seq(in), Seq(out), 5.seconds)
 
       // get data from outlet tap
       val results = out.asCollection(session)


### PR DESCRIPTION
Increases the timeout of this test to allow for the processing to happen without stopping the test.
The root cause goes much deeper and a complete fix will follow, but this will prevent CI from failing for the moment.