### PR TITLE
increase timeout to patch this for now

### DIFF
--- a/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
+++ b/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
@@ -32,7 +32,7 @@ class SparkProcessorSpec extends SparkScalaTestSupport { // 1. Extend SparkScala
       in.addData(data)
 
       // 7. Run the streamlet using the testkit and the setup inlet taps and outlet probes
-      testkit.run(processor, Seq(in), Seq(out), 2.seconds)
+      testkit.run(processor, Seq(in), Seq(out), 5.seconds)
 
       // get data from outlet tap
       val results = out.asCollection(session)


### PR DESCRIPTION
Increases the timeout of this test to allow for the processing to happen without stopping the test.
The root cause goes much deeper and a complete fix will follow, but this will prevent CI from failing for the moment.