### PR TITLE
Update `cloudflow status` parsing logic

### DIFF
--- a/integration-tests/itest/deploy_test.go
+++ b/integration-tests/itest/deploy_test.go
@@ -2,7 +2,6 @@ package main_test
 
 import (
 	"log"
-	"time"
 
 	"github.com/lightbend/cloudflow/integration-test/itest/cli"
 	"github.com/lightbend/cloudflow/integration-test/itest/kubectl"
@@ -64,11 +63,14 @@ var _ = Describe("Application deployment", func() {
 
 		It("should get to a 'running' status, eventually", func(done Done) {
 
-			// this wait is needed to let the application deploy and get to a stable state
-			// a bug in the `cloudflow status` call.
-			// see also: https://github.com/lightbend/cloudflow/issues/201
-			waitTime, _ := time.ParseDuration(InitialWaitTime)
-			time.Sleep(waitTime)
+			status, err := cli.PollUntilAppStatusIs(swissKnifeApp, "Running")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal("Running"))
+			close(done)
+		}, LongTimeout)
+
+		It("should have all pods in a 'running' status, eventually", func(done Done) {
 
 			status, err := cli.PollUntilPodsStatusIs(swissKnifeApp, "Running")
 


### PR DESCRIPTION
Updates the parsing logic in the CLI supporting code to comply with the latest version of `kubectl cloudflow`
Run against GKE (default k8s v1.14)
```
Application deployment
/home/maasg/light/cloudflow/cloudflow/integration-tests/itest/deploy_test.go:32
  A deployed application can be undeployed
  /home/maasg/light/cloudflow/cloudflow/integration-tests/itest/deploy_test.go:177
    should undeploy the test app
    /home/maasg/light/cloudflow/cloudflow/integration-tests/itest/deploy_test.go:178
------------------------------

Ran 17 of 17 Specs in 579.370 seconds
SUCCESS! -- 17 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```