### PR TITLE
Leftover: deleting cluster-admin-binding in uninstall.

### DIFF
--- a/installer/uninstall-cloudflow.sh
+++ b/installer/uninstall-cloudflow.sh
@@ -95,7 +95,8 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
       --ignore-not-found=true
 
     echo "Removing ClusterRoleBindings..."
-    kubectl delete clusterrolebinding cloudflow-nfs-nfs-server-provisioner \
+    kubectl delete clusterrolebinding cluster-admin-binding \
+      cloudflow-nfs-nfs-server-provisioner \
       cloudflow-flink-flink-operator \
       cloudflow-sparkoperator-crb \
       cloudflow-operator-bindings \


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Error reported after uninstall.
```
Error from server (AlreadyExists): clusterrolebindings.rbac.authorization.k8s.io "cluster-admin-binding" already exists
```
Uninstall script should remove the cluster-admin-binding.
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Error message during install (install does continue)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
GKE:
```
/uninstall-cloudflow.sh
This script will remove all Cloudflow related objects from the Kubernetes cluster currently logged in to
Do you want to continue ? (y/n) y
Removing all application namespaces...

No resources found in default namespace.
Removing all Helm charts...
Detected Helm version 3
release "cloudflow" uninstalled
release "cloudflow-sparkoperator" uninstalled
release "cloudflow-strimzi" uninstalled
release "cloudflow-flink" uninstalled
Removing the Cloudflow namespace...
namespace "cloudflow" deleted
Removing CRDs...
customresourcedefinition.apiextensions.k8s.io "cloudflowapplications.cloudflow.lightbend.com" deleted
Removing ClusterRoles...
clusterrole.rbac.authorization.k8s.io "cloudflow-nfs-nfs-server-provisioner" deleted
Removing ClusterRoleBindings...
clusterrolebinding.rbac.authorization.k8s.io "cluster-admin-binding" deleted
clusterrolebinding.rbac.authorization.k8s.io "cloudflow-nfs-nfs-server-provisioner" deleted
Removing StorageClasses...
storageclass.storage.k8s.io "nfs" deleted
Done!

./install.sh gke-ray-02-04-2020-115      gke

namespace/cloudflow created
Detected Helm version 3
Testing Helm 3 installation
Helm 3 is correctly configured
Installing Cloudflow
 - cluster: gke-ray-02-04-2020-115
 - namespace: cloudflow
Initializing shared definitions for namespace: cloudflow
The cluster has enabled the mutating admission webhook.
The Flink operator is not installed, will install in 'cloudflow'
Kafka installation mode is: 'CloudflowManaged'.

Strimzi chart is not installed.
We will install the Strimzi chart and create a Kafka cluster into the namespace 'cloudflow'.
The spark operator is not installed, will install in 'cloudflow'
Creating admin cluster role binding for modifying Spark role
Installing NFS Server

Select a storage class for workloads requiring persistent volumes with access mode 'ReadWriteMany'.
Examples of these are Spark and Flink checkpointing and savepointing.

   NAME                 PROVISIONER                    SUPPORTS RW?                  DEFAULT?
1. nfs                  cluster.local/cloudflow-nfs-nfs-server-provisioner Unknown                       -
2. standard             kubernetes.io/gce-pd           Unknown                       -
> 1

Select a storage class for workloads requiring persistent volumes with access mode 'ReadWriteOnce'.
Examples of these are Kafka, Zookeeper, and Prometheus.

   NAME                 PROVISIONER                    SUPPORTS RW?                  DEFAULT?
1. nfs                  cluster.local/cloudflow-nfs-nfs-server-provisioner Unknown                       -
2. standard             kubernetes.io/gce-pd           Verified                      -
> 2

- Using storage class 'nfs' for workloads requiring persistent volumes with 'ReadWriteMany' access mode.
- Using storage class 'standard' for workloads requiring persistent volumes with 'ReadWriteOnce' access mode.

Installing Flink in cloudflow
deployment.extensions/cloudflow-flink-flink-operator labeled
Installing Strimzi
deployment.extensions/strimzi-cluster-operator labeled
Installing Spark operator
deployment.extensions/cloudflow-sparkoperator labeled
Installing Cloudflow

+------------------------------------------------------------------------------------+
|                      Installation of Cloudflow has completed                       |
+------------------------------------------------------------------------------------+
```
