### PR TITLE
Csp 1978 + 1987 - spark test method based on data availability

### DIFF
--- a/core/cloudflow-runner/src/main/scala/cloudflow/runner/Runner.scala
+++ b/core/cloudflow-runner/src/main/scala/cloudflow/runner/Runner.scala
@@ -94,7 +94,7 @@ object Runner extends RunnerConfigResolver with StreamletLoader {
     )
     maybeException match {
       case Some(ex) =>
-        log.error("Fatal error has occurred:", ex)
+        log.error("A fatal error has occurred. The streamlet is going to shutdown", ex)
         System.exit(-1)
       case None =>
         log.info("Streamlet terminating without failure")

--- a/core/cloudflow-runner/src/main/scala/cloudflow/runner/Runner.scala
+++ b/core/cloudflow-runner/src/main/scala/cloudflow/runner/Runner.scala
@@ -36,7 +36,8 @@ object Runner extends RunnerConfigResolver with StreamletLoader {
   sys.props.get("os.name") match {
     case Some(os) if os.startsWith("Win") ⇒
       log.error("cloudflow.runner.Runner is NOT compatible with Windows!!")
-    case None ⇒ log.warn("""sys.props.get("os.name") returned None!""")
+    case Some(os) => log.info(s"Runner running on $os")
+    case None     ⇒ log.warn("""sys.props.get("os.name") returned None!""")
   }
 
   val PVCMountPath: String               = "/mnt/spark/storage"

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkStreamletTestkit.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkStreamletTestkit.scala
@@ -226,8 +226,7 @@ final case class SparkStreamletTestkit(session: SparkSession, config: Config = C
     val queryExecution = sparkStreamlet.setContext(ctx).run(ctx.config)
     val gotData        = queryMonitor.waitForData().andThen { case _ => queryExecution.stop() }
 
-    val dataElements = Await.result(gotData, maxDuration)
-    println("data elements received:" + dataElements)
+    Await.result(gotData, maxDuration)
     queryMonitor.executionReport
   }
 }
@@ -286,7 +285,7 @@ class QueryExecutionMonitor()(implicit ec: ExecutionContext) extends StreamingQu
     val rows = queryProgress.progress.numInputRows
     dataRows = dataRows + dataRows.get(id).map(v => id -> (v + rows)).getOrElse(id -> rows)
     if (hasData & !dataAvailable.isCompleted) {
-      dataAvailable.success(dataRows.values.sum)
+      dataAvailable.trySuccess(dataRows.values.sum)
     }
   }
 

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -39,11 +39,11 @@ import org.apache.spark.sql.catalyst.InternalRow
  *              a `MemorySink`.
  *
  */
-private[testkit] class TestSparkStreamletContext(override val streamletRef: String,
-                                                 session: SparkSession,
-                                                 inletTaps: Seq[SparkInletTap[_]],
-                                                 outletTaps: Seq[SparkOutletTap[_]],
-                                                 override val config: Config = ConfigFactory.empty)
+class TestSparkStreamletContext(override val streamletRef: String,
+                                session: SparkSession,
+                                inletTaps: Seq[SparkInletTap[_]],
+                                outletTaps: Seq[SparkOutletTap[_]],
+                                override val config: Config = ConfigFactory.empty)
     extends SparkStreamletContext(StreamletDefinition("appId", "appVersion", streamletRef, "streamletClass", List(), List(), config),
                                   session) {
   val ProcessingTimeInterval = 1500.milliseconds

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -64,9 +64,6 @@ private[testkit] class TestSparkStreamletContext(override val streamletRef: Stri
     } else {
       Trigger.Once()
     }
-    println(s"*****************************************")
-    println(s"TestSparkStreamletContext: Using $trigger")
-    println(s"*****************************************")
     val streamingQuery = outletTaps
       .find(_.portName == outPort.name)
       .map { outletTap ⇒

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -53,12 +53,11 @@ class TestSparkStreamletContext(override val streamletRef: String,
       .map(_.instream.asInstanceOf[MemoryStream[In]].toDF.as[In])
       .getOrElse(throw TestContextException(inPort.name, s"Bad test context, could not find source for inlet ${inPort.name}"))
 
-  // the test write stream implementation is blocking and returns once the query has produced a result.
   override def writeStream[Out](stream: Dataset[Out],
                                 outPort: CodecOutlet[Out],
                                 outputMode: OutputMode)(implicit encoder: Encoder[Out], typeTag: TypeTag[Out]): StreamingQuery = {
     // RateSource can only work with a microBatch query because it contains no data at time zero.
-    // Trigger.Once requires data at start to  work.
+    // Trigger.Once requires data at start to work.
     val trigger = if (isRateSource(stream)) {
       Trigger.ProcessingTime(ProcessingTimeInterval)
     } else {

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.InternalRow
  *
  * `writeStream` returns a `StreamingQuery` that pushes the input `Dataset[Out]` to
  *              a `MemorySink`.
+ *
  */
 private[testkit] class TestSparkStreamletContext(override val streamletRef: String,
                                                  session: SparkSession,
@@ -52,16 +53,21 @@ private[testkit] class TestSparkStreamletContext(override val streamletRef: Stri
       .map(_.instream.asInstanceOf[MemoryStream[In]].toDF.as[In])
       .getOrElse(throw TestContextException(inPort.name, s"Bad test context, could not find source for inlet ${inPort.name}"))
 
+  // the test write stream implementation is blocking and returns once the query has produced a result.
   override def writeStream[Out](stream: Dataset[Out],
                                 outPort: CodecOutlet[Out],
                                 outputMode: OutputMode)(implicit encoder: Encoder[Out], typeTag: TypeTag[Out]): StreamingQuery = {
     // RateSource can only work with a microBatch query because it contains no data at time zero.
     // Trigger.Once requires data at start to  work.
-    val trigger = if (isRateSource(stream)) Trigger.ProcessingTime(ProcessingTimeInterval) else Trigger.Once()
+    val trigger = if (isRateSource(stream)) {
+      Trigger.ProcessingTime(ProcessingTimeInterval)
+    } else {
+      Trigger.Once()
+    }
     println(s"*****************************************")
     println(s"TestSparkStreamletContext: Using $trigger")
     println(s"*****************************************")
-    outletTaps
+    val streamingQuery = outletTaps
       .find(_.portName == outPort.name)
       .map { outletTap ⇒
         stream.writeStream
@@ -72,6 +78,7 @@ private[testkit] class TestSparkStreamletContext(override val streamletRef: Stri
           .start()
       }
       .getOrElse(throw TestContextException(outPort.name, s"Bad test context, could not find destination for outlet ${outPort.name}"))
+    streamingQuery
   }
 
   override def checkpointDir(dirName: String): String = {

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkAvroSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkAvroSpec.scala
@@ -26,7 +26,7 @@ import cloudflow.spark.testkit._
 class SparkAvroSpec extends SparkScalaTestSupport {
 
   "SparkAvroEncoder" should {
-    "preserve List structure in objects with nested collections" ignore {
+    "preserve List structure in objects with nested collections" in {
 
       val socks = Product("123456789",
                           "Socks",

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkEgressSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkEgressSpec.scala
@@ -16,7 +16,6 @@
 
 package cloudflow.spark
 
-import scala.concurrent.duration._
 import org.apache.spark.sql.{ Dataset, Encoder, SparkSession }
 import org.apache.spark.sql.streaming.{ OutputMode, Trigger }
 import cloudflow.streamlets.StreamletShape
@@ -26,8 +25,42 @@ import cloudflow.spark.testkit._
 import cloudflow.spark.sql.SQLImplicits._
 
 class SparkEgressSpec extends SparkScalaTestSupport {
+  class MySparkEgress extends SparkStreamlet {
+    val in    = AvroInlet[Data]("in")
+    val shape = StreamletShape(in)
+    override def createLogic() = new SparkStreamletLogic {
+      override def buildStreamingQueries =
+        process(readStream(in))
 
-  // We are temporarily ignoring this test, a fix is on the way.
+      private def process(inDataset: Dataset[Data]): StreamletQueryExecution = {
+        val q1 = inDataset
+          .map { d ⇒
+            d.name
+          }
+          .writeStream
+          .format("memory")
+          .option("truncate", false)
+          .queryName("allNames")
+          .outputMode(OutputMode.Append())
+          .trigger(Trigger.Once)
+          .start()
+
+        val q2 = inDataset
+          .map { d ⇒
+            d.name.toUpperCase
+          }
+          .writeStream
+          .format("memory")
+          .option("truncate", false)
+          .queryName("allNamesUpper")
+          .outputMode(OutputMode.Append())
+          .trigger(Trigger.Once)
+          .start()
+        StreamletQueryExecution(q1, q2)
+      }
+    }
+  }
+
   "SparkEgress" should {
     "materialize streaming data to sink" in {
 
@@ -36,51 +69,18 @@ class SparkEgressSpec extends SparkScalaTestSupport {
       def asCollection[T: Encoder](session: SparkSession, queryName: String): List[T] =
         session.sql(s"select * from $queryName").as[T].collect().toList
 
-      object MySparkEgress extends SparkStreamlet {
-        val in    = AvroInlet[Data]("in")
-        val shape = StreamletShape(in)
-        override def createLogic() = new SparkStreamletLogic {
-          override def buildStreamingQueries =
-            process(readStream(in))
-
-          private def process(inDataset: Dataset[Data]): StreamletQueryExecution = {
-            val q1 = inDataset
-              .map { d ⇒
-                d.name
-              }
-              .writeStream
-              .format("memory")
-              .option("truncate", false)
-              .queryName("allNames")
-              .outputMode(OutputMode.Append())
-              .trigger(Trigger.Once)
-              .start()
-
-            val q2 = inDataset
-              .map { d ⇒
-                d.name.toUpperCase
-              }
-              .writeStream
-              .format("memory")
-              .option("truncate", false)
-              .queryName("allNamesUpper")
-              .outputMode(OutputMode.Append())
-              .trigger(Trigger.Once)
-              .start()
-            StreamletQueryExecution(q1, q2)
-          }
-        }
-      }
+      val instance = new MySparkEgress()
 
       // setup inlet tap on inlet port
-      val in: SparkInletTap[Data] = testKit.inletAsTap[Data](MySparkEgress.in)
+      val in: SparkInletTap[Data] = testKit.inletAsTap[Data](instance.in)
 
       // build data and send to inlet tap
       val data = (1 to 10).map(i ⇒ Data(i, s"name$i"))
       in.addData(data)
 
-      testKit.run(MySparkEgress, Seq(in), Seq.empty, 30.seconds)
-
+      val run = testKit.run(instance, Seq(in), Seq.empty)
+      run.failures mustBe ('empty)
+      run.totalRows mustBe (20)
       val r1 = asCollection[String](session, "allNames")
       val r2 = asCollection[String](session, "allNamesUpper")
 

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkEgressSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkEgressSpec.scala
@@ -29,7 +29,7 @@ class SparkEgressSpec extends SparkScalaTestSupport {
 
   // We are temporarily ignoring this test, a fix is on the way.
   "SparkEgress" should {
-    "materialize streaming data to sink" ignore {
+    "materialize streaming data to sink" in {
 
       val testKit = SparkStreamletTestkit(session)
 

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkEgressSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkEgressSpec.scala
@@ -25,42 +25,6 @@ import cloudflow.spark.testkit._
 import cloudflow.spark.sql.SQLImplicits._
 
 class SparkEgressSpec extends SparkScalaTestSupport {
-  class MySparkEgress extends SparkStreamlet {
-    val in    = AvroInlet[Data]("in")
-    val shape = StreamletShape(in)
-    override def createLogic() = new SparkStreamletLogic {
-      override def buildStreamingQueries =
-        process(readStream(in))
-
-      private def process(inDataset: Dataset[Data]): StreamletQueryExecution = {
-        val q1 = inDataset
-          .map { d ⇒
-            d.name
-          }
-          .writeStream
-          .format("memory")
-          .option("truncate", false)
-          .queryName("allNames")
-          .outputMode(OutputMode.Append())
-          .trigger(Trigger.Once)
-          .start()
-
-        val q2 = inDataset
-          .map { d ⇒
-            d.name.toUpperCase
-          }
-          .writeStream
-          .format("memory")
-          .option("truncate", false)
-          .queryName("allNamesUpper")
-          .outputMode(OutputMode.Append())
-          .trigger(Trigger.Once)
-          .start()
-        StreamletQueryExecution(q1, q2)
-      }
-    }
-  }
-
   "SparkEgress" should {
     "materialize streaming data to sink" in {
 
@@ -87,6 +51,42 @@ class SparkEgressSpec extends SparkScalaTestSupport {
       // assert
       r1 must contain("name1")
       r2 must contain("NAME1")
+    }
+  }
+}
+
+class MySparkEgress extends SparkStreamlet {
+  val in    = AvroInlet[Data]("in")
+  val shape = StreamletShape(in)
+  override def createLogic() = new SparkStreamletLogic {
+    override def buildStreamingQueries =
+      process(readStream(in))
+
+    private def process(inDataset: Dataset[Data]): StreamletQueryExecution = {
+      val q1 = inDataset
+        .map { d ⇒
+          d.name
+        }
+        .writeStream
+        .format("memory")
+        .option("truncate", false)
+        .queryName("allNames")
+        .outputMode(OutputMode.Append())
+        .trigger(Trigger.Once)
+        .start()
+
+      val q2 = inDataset
+        .map { d ⇒
+          d.name.toUpperCase
+        }
+        .writeStream
+        .format("memory")
+        .option("truncate", false)
+        .queryName("allNamesUpper")
+        .outputMode(OutputMode.Append())
+        .trigger(Trigger.Once)
+        .start()
+      StreamletQueryExecution(q1, q2)
     }
   }
 }

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkIngressSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkIngressSpec.scala
@@ -33,7 +33,7 @@ import cloudflow.spark.sql.SQLImplicits._
 class SparkIngressSpec extends SparkScalaTestSupport {
 
   "SparkIngress" should {
-    "produce elements to its outlet" ignore {
+    "produce elements to its outlet" in {
 
       val testKit = SparkStreamletTestkit(session)
 

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkIngressSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkIngressSpec.scala
@@ -17,13 +17,9 @@
 package cloudflow.spark
 
 import scala.collection.immutable.Seq
-import scala.concurrent.duration._
-
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.streaming.OutputMode
-
 import org.apache.spark.sql.execution.streaming.MemoryStream
-
 import cloudflow.streamlets.StreamletShape
 import cloudflow.streamlets.avro._
 import cloudflow.spark.avro._
@@ -32,37 +28,41 @@ import cloudflow.spark.sql.SQLImplicits._
 
 class SparkIngressSpec extends SparkScalaTestSupport {
 
+  // create sparkStreamlet
+  class MySparkIngress extends SparkStreamlet {
+    val out   = AvroOutlet[Data]("out", d ⇒ d.id.toString)
+    val shape = StreamletShape(out)
+
+    override def createLogic() = new SparkStreamletLogic {
+      private def process: Dataset[Data] = {
+        implicit val sqlCtx = session.sqlContext
+        val data            = (1 to 10).map(i ⇒ Data(i, s"name$i"))
+        val m               = MemoryStream[Data]
+        m.addData(data)
+        m.toDF.as[Data]
+      }
+      override def buildStreamingQueries = {
+        val outStream: Dataset[Data] = process
+        require(outStream.isStreaming, "The Dataset created by an Ingress must be a Streaming Dataset")
+        val query = writeStream(outStream, out, OutputMode.Append)
+        StreamletQueryExecution(query)
+      }
+    }
+  }
+
   "SparkIngress" should {
     "produce elements to its outlet" in {
 
-      val testKit = SparkStreamletTestkit(session)
-
-      // create sparkStreamlet
-      object MySparkIngress extends SparkStreamlet {
-        val out   = AvroOutlet[Data]("out", d ⇒ d.id.toString)
-        val shape = StreamletShape(out)
-
-        override def createLogic() = new SparkStreamletLogic {
-          private def process: Dataset[Data] = {
-            implicit val sqlCtx = session.sqlContext
-            val data            = (1 to 10).map(i ⇒ Data(i, s"name$i"))
-            val m               = MemoryStream[Data]
-            m.addData(data)
-            m.toDF.as[Data]
-          }
-          override def buildStreamingQueries = {
-            val outStream: Dataset[Data] = process
-            require(outStream.isStreaming, "The Dataset created by an Ingress must be a Streaming Dataset")
-            val query = writeStream(outStream, out, OutputMode.Append)
-            StreamletQueryExecution(query)
-          }
-        }
-      }
+      val testKit  = SparkStreamletTestkit(session)
+      val instance = new MySparkIngress()
 
       // setup outlet tap on outlet port
-      val out: SparkOutletTap[Data] = testKit.outletAsTap[Data](MySparkIngress.out)
+      val out: SparkOutletTap[Data] = testKit.outletAsTap[Data](instance.out)
 
-      testKit.run(MySparkIngress, Seq.empty, Seq(out), 10.seconds)
+      val run = testKit.run(instance, Seq.empty, Seq(out))
+
+      // get processed rows from the run
+      run.totalRows must be(10)
 
       // get data from outlet tap
       val results = out.asCollection(session)

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkJoin3Spec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkJoin3Spec.scala
@@ -30,7 +30,7 @@ import cloudflow.spark.sql.SQLImplicits._
 class SparkJoin3Spec extends SparkScalaTestSupport {
 
   "SparkJoin3" should {
-    "process streaming data" ignore {
+    "process streaming data" in {
 
       val testKit = SparkStreamletTestkit(session)
 

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkJoin3Spec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkJoin3Spec.scala
@@ -26,31 +26,6 @@ import cloudflow.spark.sql.SQLImplicits._
 
 class SparkJoin3Spec extends SparkScalaTestSupport {
 
-  // create sparkStreamlet
-  class MySparkJoin3 extends SparkStreamlet {
-    // comment: all inlets could be in different formats, one proto, one avro, one csv..
-    val in0 = AvroInlet[Data]("in0")
-    val in1 = AvroInlet[Data]("in1")
-    val in2 = AvroInlet[Data]("in2")
-    val out = AvroOutlet[Simple]("out", _.name)
-
-    val shape = StreamletShape(out).withInlets(in0, in1, in2)
-
-    override def createLogic() = new SparkStreamletLogic {
-      override def buildStreamingQueries = {
-        val dataset0                   = readStream(in0)
-        val dataset1                   = readStream(in1)
-        val dataset2                   = readStream(in2)
-        val outStream: Dataset[Simple] = process(dataset0, dataset1, dataset2)
-        val query                      = writeStream(outStream, out, OutputMode.Append)
-        StreamletQueryExecution(query)
-      }
-
-      private def process(in0: Dataset[Data], in1: Dataset[Data], in2: Dataset[Data]): Dataset[Simple] =
-        in0.union(in1.union(in2)).select($"name").as[Simple]
-    }
-  }
-
   "SparkJoin3" should {
     "process streaming data" in {
 
@@ -84,5 +59,29 @@ class SparkJoin3Spec extends SparkScalaTestSupport {
       results must contain(Simple("name21"))
       (results must have).length(30)
     }
+  }
+}
+// create sparkStreamlet
+class MySparkJoin3 extends SparkStreamlet {
+  // comment: all inlets could be in different formats, one proto, one avro, one csv..
+  val in0 = AvroInlet[Data]("in0")
+  val in1 = AvroInlet[Data]("in1")
+  val in2 = AvroInlet[Data]("in2")
+  val out = AvroOutlet[Simple]("out", _.name)
+
+  val shape = StreamletShape(out).withInlets(in0, in1, in2)
+
+  override def createLogic() = new SparkStreamletLogic {
+    override def buildStreamingQueries = {
+      val dataset0                   = readStream(in0)
+      val dataset1                   = readStream(in1)
+      val dataset2                   = readStream(in2)
+      val outStream: Dataset[Simple] = process(dataset0, dataset1, dataset2)
+      val query                      = writeStream(outStream, out, OutputMode.Append)
+      StreamletQueryExecution(query)
+    }
+
+    private def process(in0: Dataset[Data], in1: Dataset[Data], in2: Dataset[Data]): Dataset[Simple] =
+      in0.union(in1.union(in2)).select($"name").as[Simple]
   }
 }

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkJoin3Spec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkJoin3Spec.scala
@@ -16,11 +16,8 @@
 
 package cloudflow.spark
 
-import scala.concurrent.duration._
-
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.streaming.OutputMode
-
 import cloudflow.streamlets.StreamletShape
 import cloudflow.streamlets.avro._
 import cloudflow.spark.avro._
@@ -29,59 +26,62 @@ import cloudflow.spark.sql.SQLImplicits._
 
 class SparkJoin3Spec extends SparkScalaTestSupport {
 
+  // create sparkStreamlet
+  class MySparkJoin3 extends SparkStreamlet {
+    // comment: all inlets could be in different formats, one proto, one avro, one csv..
+    val in0 = AvroInlet[Data]("in0")
+    val in1 = AvroInlet[Data]("in1")
+    val in2 = AvroInlet[Data]("in2")
+    val out = AvroOutlet[Simple]("out", _.name)
+
+    val shape = StreamletShape(out).withInlets(in0, in1, in2)
+
+    override def createLogic() = new SparkStreamletLogic {
+      override def buildStreamingQueries = {
+        val dataset0                   = readStream(in0)
+        val dataset1                   = readStream(in1)
+        val dataset2                   = readStream(in2)
+        val outStream: Dataset[Simple] = process(dataset0, dataset1, dataset2)
+        val query                      = writeStream(outStream, out, OutputMode.Append)
+        StreamletQueryExecution(query)
+      }
+
+      private def process(in0: Dataset[Data], in1: Dataset[Data], in2: Dataset[Data]): Dataset[Simple] =
+        in0.union(in1.union(in2)).select($"name").as[Simple]
+    }
+  }
+
   "SparkJoin3" should {
     "process streaming data" in {
 
       val testKit = SparkStreamletTestkit(session)
 
-      // create sparkStreamlet
-      object MySparkJoin3 extends SparkStreamlet {
-        // comment: all inlets could be in different formats, one proto, one avro, one csv..
-        val in0 = AvroInlet[Data]("in0")
-        val in1 = AvroInlet[Data]("in1")
-        val in2 = AvroInlet[Data]("in2")
-        val out = AvroOutlet[Simple]("out", _.name)
-
-        val shape = StreamletShape(out).withInlets(in0, in1, in2)
-
-        override def createLogic() = new SparkStreamletLogic {
-          override def buildStreamingQueries = {
-            val dataset0                   = readStream(in0)
-            val dataset1                   = readStream(in1)
-            val dataset2                   = readStream(in2)
-            val outStream: Dataset[Simple] = process(dataset0, dataset1, dataset2)
-            val query                      = writeStream(outStream, out, OutputMode.Append)
-            StreamletQueryExecution(query)
-          }
-
-          private def process(in0: Dataset[Data], in1: Dataset[Data], in2: Dataset[Data]): Dataset[Simple] =
-            in0.union(in1.union(in2)).select($"name").as[Simple]
-        }
-      }
+      val instance = new MySparkJoin3()
 
       // setup inlet tap on inlet port
-      val in0: SparkInletTap[Data] = testKit.inletAsTap[Data](MySparkJoin3.in0)
-      val in1: SparkInletTap[Data] = testKit.inletAsTap[Data](MySparkJoin3.in1)
-      val in2: SparkInletTap[Data] = testKit.inletAsTap[Data](MySparkJoin3.in2)
+      val in0: SparkInletTap[Data] = testKit.inletAsTap[Data](instance.in0)
+      val in1: SparkInletTap[Data] = testKit.inletAsTap[Data](instance.in1)
+      val in2: SparkInletTap[Data] = testKit.inletAsTap[Data](instance.in2)
 
       // setup outlet tap on outlet port
-      val out: SparkOutletTap[Simple] = testKit.outletAsTap[Simple](MySparkJoin3.out)
+      val out: SparkOutletTap[Simple] = testKit.outletAsTap[Simple](instance.out)
 
       // build data and send to inlet tap
-      val data0 = (1 to 10).map(i ⇒ Data(i, s"name$i"))
-      in0.addData(data0)
-      val data1 = (11 to 20).map(i ⇒ Data(i, s"name$i"))
-      in1.addData(data1)
-      val data2 = (21 to 30).map(i ⇒ Data(i, s"name$i"))
-      in2.addData(data2)
+      val data = (1 to 30).map(i ⇒ Data(i, s"name$i"))
+      in0.addData(data.take(10))
+      in1.addData(data.drop(10).take(10))
+      in2.addData(data.drop(20).take(10))
 
-      testKit.run(MySparkJoin3, Seq(in0, in1, in2), Seq(out), 2.seconds)
+      val run = testKit.run(instance, Seq(in0, in1, in2), Seq(out))
+      run.totalRows must be(30)
 
       // get data from outlet tap
       val results = out.asCollection(session)
 
       // assert
       results must contain(Simple("name1"))
+      results must contain(Simple("name11"))
+      results must contain(Simple("name21"))
       (results must have).length(30)
     }
   }

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkJoin3Spec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkJoin3Spec.scala
@@ -42,10 +42,10 @@ class SparkJoin3Spec extends SparkScalaTestSupport {
       val out: SparkOutletTap[Simple] = testKit.outletAsTap[Simple](instance.out)
 
       // build data and send to inlet tap
-      val data = (1 to 30).map(i ⇒ Data(i, s"name$i"))
-      in0.addData(data.take(10))
-      in1.addData(data.drop(10).take(10))
-      in2.addData(data.drop(20).take(10))
+      val List(d1, d2, d3) = (1 to 30).map(i ⇒ Data(i, s"name$i")).sliding(10, 10).toList
+      in0.addData(d1)
+      in1.addData(d2)
+      in2.addData(d3)
 
       val run = testKit.run(instance, Seq(in0, in1, in2), Seq(out))
       run.totalRows must be(30)

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkProcessorSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkProcessorSpec.scala
@@ -17,7 +17,6 @@
 package cloudflow.spark
 
 import scala.collection.immutable.Seq
-import scala.concurrent.duration._
 import org.apache.spark.sql.streaming.OutputMode
 import cloudflow.streamlets.StreamletShape
 import cloudflow.streamlets.avro._
@@ -27,26 +26,26 @@ import cloudflow.spark.sql.SQLImplicits._
 
 class SparkProcessorSpec extends SparkScalaTestSupport {
 
+  // create sparkStreamlet
+  class MySparkProcessor extends SparkStreamlet {
+    val in    = AvroInlet[Data]("in")
+    val out   = AvroOutlet[Simple]("out", _.name)
+    val shape = StreamletShape(in, out)
+
+    override def createLogic() = new SparkStreamletLogic {
+      override def buildStreamingQueries = {
+        val dataset   = readStream(in)
+        val outStream = dataset.select($"name").as[Simple]
+        val query     = writeStream(outStream, out, OutputMode.Append)
+        StreamletQueryExecution(query)
+      }
+    }
+  }
+
   "SparkProcessor" should {
     "process streaming data" in {
 
       val testKit = SparkStreamletTestkit(session)
-
-      // create sparkStreamlet
-      class MySparkProcessor extends SparkStreamlet {
-        val in    = AvroInlet[Data]("in")
-        val out   = AvroOutlet[Simple]("out", _.name)
-        val shape = StreamletShape(in, out)
-
-        override def createLogic() = new SparkStreamletLogic {
-          override def buildStreamingQueries = {
-            val dataset   = readStream(in)
-            val outStream = dataset.select($"name").as[Simple]
-            val query     = writeStream(outStream, out, OutputMode.Append)
-            StreamletQueryExecution(query)
-          }
-        }
-      }
 
       // create an instance of the streamlet under test
       val instance = new MySparkProcessor()
@@ -61,7 +60,8 @@ class SparkProcessorSpec extends SparkScalaTestSupport {
       val data = (1 to 10).map(i ⇒ Data(i, s"name$i"))
       in.addData(data)
 
-      testKit.run(instance, Seq(in), Seq(out), 2.seconds)
+      val run = testKit.run(instance, Seq(in), Seq(out))
+      run.totalRows must be(10)
 
       // get data from outlet tap
       val results = out.asCollection(session)

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkProcessorSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkProcessorSpec.scala
@@ -28,7 +28,7 @@ import cloudflow.spark.sql.SQLImplicits._
 class SparkProcessorSpec extends SparkScalaTestSupport {
 
   "SparkProcessor" should {
-    "process streaming data" ignore {
+    "process streaming data" in {
 
       val testKit = SparkStreamletTestkit(session)
 

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkStreamletConfigurationSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkStreamletConfigurationSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.spark
+
+import cloudflow.spark.avro._
+import cloudflow.spark.sql.SQLImplicits._
+import cloudflow.spark.testkit._
+import cloudflow.streamlets.{ StreamletShape, _ }
+import cloudflow.streamlets.avro._
+import org.apache.spark.sql.streaming.OutputMode
+import org.scalatest.OptionValues
+
+import scala.collection.immutable.Seq
+import scala.concurrent.duration._
+
+class SparkStreamletConfigurationSpec extends SparkScalaTestSupport with OptionValues {
+
+  "SparkStreamlet configuration support" should {
+
+    class MySparkProcessor extends SparkStreamlet {
+      val in    = AvroInlet[Data]("in")
+      val out   = AvroOutlet[Simple]("out", _.name)
+      val shape = StreamletShape(in, out)
+
+      val NameFilter =
+        StringConfigParameter("name-filter-value", "Filters out the data in the stream that matches this name.", Some("initial"))
+
+      override def configParameters = Vector(NameFilter)
+
+      override def createLogic() = new SparkStreamletLogic {
+        val nameFilter = context.streamletConfig.getString(NameFilter.key)
+
+        override def buildStreamingQueries = {
+          val outStream = readStream(in).select($"name").filter($"name" === nameFilter).as[Simple]
+          val query     = writeStream(outStream, out, OutputMode.Append)
+          query.toQueryExecution
+        }
+      }
+    }
+    val instance = new MySparkProcessor()
+
+    val sampleData = {
+      val (i, u, o) = ("initial", "updated", "other")
+      Seq(i, u, i, u, o, u, o).zipWithIndex
+        .map { case (elem, idx) => Data(idx, elem) }
+    }
+
+    "use the default value of a config parameter if the config parameter is not set" ignore {
+      val configTestKit = SparkStreamletTestkit(session)
+      // setup inlet tap on inlet port
+      val in: SparkInletTap[Data] = configTestKit.inletAsTap[Data](instance.in)
+      // setup outlet tap on outlet port
+      val out: SparkOutletTap[Simple] = configTestKit.outletAsTap[Simple](instance.out)
+      // send to inlet tap
+      in.addData(sampleData)
+      // run the stream
+      configTestKit.run(instance, in, out, 2.seconds)
+      // get data from outlet tap
+      val results = out.asCollection(session)
+      // assert
+      results mustBe Array.fill(2)(Simple("initial"))
+    }
+
+    "validate that a config parameter value can be set in a test" in {
+      val configTestKit =
+        SparkStreamletTestkit(session).withConfigParameterValues(ConfigParameterValue(instance.NameFilter, "updated"))
+
+      // setup inlet tap on inlet port
+      val in: SparkInletTap[Data] = configTestKit.inletAsTap[Data](instance.in)
+
+      // setup outlet tap on outlet port
+      val out: SparkOutletTap[Simple] = configTestKit.outletAsTap[Simple](instance.out)
+
+      // build data and send to inlet tap
+      in.addData(sampleData)
+
+      configTestKit.run(instance, in, out, 2.seconds)
+
+      // get data from outlet tap
+      val results = out.asCollection(session)
+
+      // assert
+      results mustBe Array.fill(3)(Simple("updated"))
+    }
+  }
+}

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkStreamletSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkStreamletSpec.scala
@@ -18,63 +18,93 @@ package cloudflow.spark
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
-
-import org.apache.spark.sql.streaming.OutputMode
-
+import org.apache.spark.sql.streaming.{ OutputMode, StreamingQuery }
 import cloudflow.streamlets._
 import cloudflow.spark.testkit._
-
 import cloudflow.streamlets.StreamletShape
 import cloudflow.streamlets.avro._
 import cloudflow.spark.avro._
 import cloudflow.spark.testkit._
 import cloudflow.spark.sql.SQLImplicits._
+import com.typesafe.config.ConfigFactory
+import org.scalatest.OptionValues
 
-class SparkStreamletSpec extends SparkScalaTestSupport {
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Success
 
-  "SparkStreamletSpec" should {
-    "validate that a config parameter value can be set in a test" in {
-      // create sparkStreamlet
-      object MySparkProcessor extends SparkStreamlet {
-        val in    = AvroInlet[Data]("in")
-        val out   = AvroOutlet[Simple]("out", _.name)
-        val shape = StreamletShape(in, out)
+class SparkStreamletSpec extends SparkScalaTestSupport with OptionValues {
 
-        val NameFilter = StringConfigParameter("name-filter-value", "Filters out the data in the stream that matches this name.", Some("a"))
+  "SparkStreamlet runtime" should {
+    trait QueryAccess {
+      def queries: Seq[StreamingQuery]
+      def mustFail(fail: Boolean)
+    }
+    class LeakySparkProcessor extends SparkStreamlet with QueryAccess {
+      val out1                                   = AvroOutlet[Simple]("out1")
+      val out2                                   = AvroOutlet[Simple]("out2")
+      val shape                                  = StreamletShape.withOutlets(out1, out2)
+      @volatile var queries: Seq[StreamingQuery] = Seq()
+      @volatile var shouldFail                   = false
+      override def mustFail(fail: Boolean)       = shouldFail = fail
 
-        override def configParameters = Vector(NameFilter)
+      override def createLogic() = new SparkStreamletLogic {
 
-        override def createLogic() = new SparkStreamletLogic {
-          val nameFilter = context.streamletConfig.getString(NameFilter.key)
-
-          override def buildStreamingQueries = {
-            val outStream = readStream(in).select($"name").filter($"name" === nameFilter).as[Simple]
-            val query     = writeStream(outStream, out, OutputMode.Append)
-            query.toQueryExecution
+        override def buildStreamingQueries = {
+          import org.apache.spark.sql.functions._
+          val inStream = session.readStream
+            .format("rate")
+            .load()
+            .select(concat(lit("value-"), $"value").as("name"))
+            .as[Simple]
+          val outStream1 = writeStream(inStream, out1, OutputMode.Append)
+          val mayFailStream = inStream.map { value =>
+            if (shouldFail) throw new RuntimeException("InternalFailure")
+            value
           }
+          val outStream2 = writeStream(mayFailStream, out2, OutputMode.Append)
+          queries = Seq(outStream1, outStream2)
+          println("setting up queries")
+          StreamletQueryExecution(queries)
         }
       }
-
-      val configTestKit =
-        SparkStreamletTestkit(session).withConfigParameterValues(ConfigParameterValue(MySparkProcessor.NameFilter, "name5"))
-
-      // setup inlet tap on inlet port
-      val in: SparkInletTap[Data] = configTestKit.inletAsTap[Data](MySparkProcessor.in)
-
-      // setup outlet tap on outlet port
-      val out: SparkOutletTap[Simple] = configTestKit.outletAsTap[Simple](MySparkProcessor.out)
-
-      // build data and send to inlet tap
-      val data = (1 to 10).map(i ⇒ Data(i, s"name$i"))
-      in.addData(data)
-
-      configTestKit.run(MySparkProcessor, Seq(in), Seq(out), 2.seconds)
-
-      // get data from outlet tap
-      val results = out.asCollection(session)
-
-      // assert
-      results mustBe Array(Simple("name5"))
     }
+    "stop a streamlet when any managed query stops" in {
+      val instance = new LeakySparkProcessor()
+      // setup outlet tap on outlet port
+      val testKit                      = SparkStreamletTestkit(session)
+      val out1: SparkOutletTap[Simple] = testKit.outletAsTap[Simple](instance.out1)
+      val out2: SparkOutletTap[Simple] = testKit.outletAsTap[Simple](instance.out2)
+      val ctx                          = new TestSparkStreamletContext("test-streamlet", session, Nil, Seq(out1, out2), ConfigFactory.empty())
+
+      val stopActiveQuery = Future {
+        def stopQuery(): Unit = {
+          Thread.sleep(1000)
+          instance.queries.headOption
+            .map { query =>
+              if (query.isActive) {
+                println("*************************************** Query is active")
+                query.stop
+              } else {
+                println("*************************************** Query is not active - attempt again")
+                stopQuery()
+              }
+            }
+            .getOrElse(stopQuery())
+        }
+        stopQuery()
+      }
+      val execution       = instance.setContext(ctx).run(ctx)
+      val completedStatus = execution.completed
+      Await.result(completedStatus, 30.seconds)
+      Await.result(stopActiveQuery, 30.seconds)
+      // sanity check
+      stopActiveQuery.value.value mustBe (Success())
+      // execution should have stopped right after one of the queries stopped,
+      completedStatus.value.value mustBe (Success(Dun))
+
+    }
+
   }
+
 }

--- a/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkStreamletSpec.scala
+++ b/core/cloudflow-spark-tests/src/test/scala/cloudflow/spark/SparkStreamletSpec.scala
@@ -33,7 +33,7 @@ import cloudflow.spark.sql.SQLImplicits._
 class SparkStreamletSpec extends SparkScalaTestSupport {
 
   "SparkStreamletSpec" should {
-    "validate that a config parameter value can be set in a test" ignore {
+    "validate that a config parameter value can be set in a test" in {
       // create sparkStreamlet
       object MySparkProcessor extends SparkStreamlet {
         val in    = AvroInlet[Data]("in")

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -123,7 +123,7 @@ trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable 
           }
       }
 
-      def poll(predicate: => Boolean, frequency: FiniteDuration, deadline: FiniteDuration, s: Scheduler): Future[Unit] = {
+      private def poll(predicate: => Boolean, frequency: FiniteDuration, deadline: FiniteDuration, s: Scheduler): Future[Unit] = {
         val t0 = System.currentTimeMillis()
         def _poll(): Future[Unit] =
           Future {

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -132,7 +132,7 @@ trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable 
           }
       }
 
-      private def poll2(predicate: => Boolean, frequency: FiniteDuration, deadline: FiniteDuration, s: Scheduler): Future[Unit] = {
+      private def poll(predicate: => Boolean, frequency: FiniteDuration, deadline: FiniteDuration, s: Scheduler): Future[Unit] = {
         val p: Promise[Unit] = Promise()
         val poller = s.schedule(frequency, frequency) {
           if (predicate) p.complete(Success())
@@ -145,19 +145,6 @@ trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable 
             poller.cancel()
             deadlineCheck.cancel()
         }
-      }
-
-      private def poll(predicate: => Boolean, frequency: FiniteDuration, deadline: FiniteDuration, s: Scheduler): Future[Unit] = {
-        val times = Math.ceil(deadline / frequency).toInt
-        def _poll(count: Int): Future[Unit] = (predicate, count <= 0) match {
-          case (true, _) => Future.successful(())
-          case (_, true) => Future.failed(new TimeoutException(s"Poll timed out after ${deadline.toMillis} millis"))
-          case _ =>
-            val p = Promise[Unit]()
-            s.scheduleOnce(frequency) { p.completeWith(_poll(count - 1)) }
-            p.future
-        }
-        _poll(times)
       }
     }
   }

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/Streamlet.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/Streamlet.scala
@@ -150,4 +150,5 @@ trait StreamletRuntime {
  * An exception to return when the runner returns an accumulated list of distinct
  * exceptions.
  */
-final case class ExceptionAcc(exceptions: Vector[Throwable]) extends Exception
+final case class ExceptionAcc(exceptions: Vector[Throwable])
+    extends Exception("Exceptions caught: " + exceptions.map(_.getMessage).mkString(","))

--- a/examples/call-record-aggregator/project/cloudflow-plugins.sbt
+++ b/examples/call-record-aggregator/project/cloudflow-plugins.sbt
@@ -2,5 +2,5 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")
 

--- a/examples/call-record-aggregator/spark-aggregation/src/main/scala/carly/aggregator/CallStatsAggregator.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/main/scala/carly/aggregator/CallStatsAggregator.scala
@@ -47,6 +47,7 @@ class CallStatsAggregator extends SparkStreamlet {
   override def createLogic = new SparkStreamletLogic {
     val watermark     = context.streamletConfig.getDuration(Watermark.key)
     val groupByWindow = context.streamletConfig.getDuration(GroupByWindow.key)
+//    val t0 = System.currentTimeMillis() // serialization error!
 
     //tag::docs-aggregationQuery-example[]
     override def buildStreamingQueries = {

--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
@@ -17,7 +17,6 @@
 package carly.aggregator
 
 import scala.collection.immutable.Seq
-import scala.concurrent.duration._
 
 import carly.data._
 
@@ -35,7 +34,7 @@ class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
       // setup outlet tap on outlet port
       val out = testKit.outletAsTap[CallRecord](streamlet.out)
 
-      testKit.run(streamlet, Seq.empty, Seq(out), 4500.milliseconds)
+      val run = testKit.run(streamlet, Seq.empty, Seq(out))
 
       // get data from outlet tap
       val results = out.asCollection(session)

--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
@@ -34,11 +34,14 @@ class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
       // setup outlet tap on outlet port
       val out = testKit.outletAsTap[CallRecord](streamlet.out)
 
-      // run the tests
       val run = testKit.run(streamlet, Seq.empty, Seq(out))
-
-      // verify that it produced data
       run.totalRows must be > 0L
+
+      // get data from outlet tap
+      val results = out.asCollection(session)
+
+      // assert
+      results.size must be > 0
 
     }
   }

--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
@@ -34,14 +34,11 @@ class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
       // setup outlet tap on outlet port
       val out = testKit.outletAsTap[CallRecord](streamlet.out)
 
+      // run the tests
       val run = testKit.run(streamlet, Seq.empty, Seq(out))
-      println(run)
 
-      // get data from outlet tap
-      val results = out.asCollection(session)
-
-      // assert
-      results.size must be > 0
+      // verify that it produced data
+      run.totalRows must be > 0L
 
     }
   }

--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
@@ -35,6 +35,7 @@ class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
       val out = testKit.outletAsTap[CallRecord](streamlet.out)
 
       val run = testKit.run(streamlet, Seq.empty, Seq(out))
+      println(run)
 
       // get data from outlet tap
       val results = out.asCollection(session)

--- a/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/project/cloudflow-plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3-SNAPSHOT")

--- a/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
+++ b/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
@@ -36,9 +36,9 @@ class SparkProcessorSpec extends SparkScalaTestSupport { // 1. Extend SparkScala
 
       // get data from outlet tap
       val results = out.asCollection(session)
-      println("************")
+      println("**************")
       println("Results from the test:" + results.mkString(","))
-      println("************")
+      println("**************")
 
       // 8. Assert that actual matches expectation
       results must contain(Data(2, "name2"))

--- a/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
+++ b/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
@@ -36,9 +36,9 @@ class SparkProcessorSpec extends SparkScalaTestSupport { // 1. Extend SparkScala
 
       // get data from outlet tap
       val results = out.asCollection(session)
-      println("**************")
+      println("************")
       println("Results from the test:" + results.mkString(","))
-      println("**************")
+      println("************")
 
       // 8. Assert that actual matches expectation
       results must contain(Data(2, "name2"))

--- a/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
+++ b/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/step3/src/test/scala/com/example/SparkProcessorSpec.scala
@@ -2,7 +2,6 @@ package com.example
 
 //tag::imports[]
 import scala.collection.immutable.Seq
-import scala.concurrent.duration._
 
 import cloudflow.spark.testkit._
 import cloudflow.spark.sql.SQLImplicits._
@@ -32,17 +31,15 @@ class SparkProcessorSpec extends SparkScalaTestSupport { // 1. Extend SparkScala
       in.addData(data)
 
       // 7. Run the streamlet using the testkit and the setup inlet taps and outlet probes
-      testkit.run(processor, Seq(in), Seq(out), 5.seconds)
+      val run = testkit.run(processor, Seq(in), Seq(out))
 
       // get data from outlet tap
       val results = out.asCollection(session)
-      println("**************")
-      println("Results from the test:" + results.mkString(","))
-      println("**************")
 
       // 8. Assert that actual matches expectation
       results must contain(Data(2, "name2"))
       results.size must be(5)
+      run.totalRows must be (10)
     }
   }
 }

--- a/examples/snippets/modules/ROOT/examples/spark-scala/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/spark-scala/project/cloudflow-plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.1")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")

--- a/examples/spark-sensors/project/cloudflow-plugins.sbt
+++ b/examples/spark-sensors/project/cloudflow-plugins.sbt
@@ -4,3 +4,4 @@ resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+


### PR DESCRIPTION
Introduces a new method to test Spark Streamlets where a query monitor checks for the availability of data instead of 'brute-force' waits that are tricky to time correctly on different environments.

Now, it's possible to get information about the rows processed. Also note how the API doesn't depend on a wait time anymore:

Before:
```
testKit.run(instance, Seq(in0, in1, in2), Seq(out), 10.seconds)
```
Now: 
```
val run = testKit.run(instance, Seq(in0, in1, in2), Seq(out))
...
run.totalRows must be(30)
```
This new method should be resilient against different CPU timings as the test progresses only when data becomes available (within a certain delay tolerance)

CSP-1987: In this PR, there's also a fix to the monitoring logic that checks for failed streamlets at runtime. Now, failures are correctly monitored and will trigger an immediate downing of the failed streamlet.
See `SparkStreamlet` for more details.