### PR TITLE
Increase memory limits of the Spark Driver

### DIFF
--- a/core/cloudflow-operator/src/main/resources/application.conf
+++ b/core/cloudflow-operator/src/main/resources/application.conf
@@ -81,7 +81,7 @@ cloudflow {
       }
 
       spark-runner-driver {
-        requests-memory = "512M"
+        requests-memory = "1024M"
         requests-memory = ${?SPARK_DRIVER_REQUESTS_MEMORY}
 
         # memory-overhead is the amount of off-heap memory to allocate in cluster mode, in MiB unless otherwise specified.


### PR DESCRIPTION
As a temporary workaround for the crash issues with the call-record-aggregator/aggregator streamlet, I propose an increase of the spark driver memory size.
This change seems to provide enough room for the driver to work properly even under pressure.
All observations are captured here: https://docs.google.com/presentation/d/1gxNG_5qXK_hOYN30EMkrWkqw_Q3f00ltqz4NpU--J1o/edit?usp=sharing
A new load test is running to validate the setting. In the short time that's been running, it seems to be working fine.