### PR TITLE
Bail out early in verify if images section is empty in blueprint

### DIFF
--- a/kubectl-cloudflow/verify/verify.go
+++ b/kubectl-cloudflow/verify/verify.go
@@ -21,6 +21,10 @@ import (
 func VerifyBlueprint(content string) (Blueprint, []*docker.PulledImage, []string, error) {
 	config := configuration.ParseString(content)
 	imageRefsFromBlueprint := getImageRefsFromConfig(config)
+	if len(imageRefsFromBlueprint) == 0 {
+		return Blueprint{}, nil, nil, 
+			fmt.Errorf("This blueprint format is unsupported in CLI based verify - the [images] section seems to be missing. If you are using the old-style blueprint format, please try to verify from within Sbt")
+	}
 
 	// map imageID -> []StreamletDescriptor
 	imageDescriptorMap, pulledImages, imageDigests, fallbackAppID := getStreamletDescriptorsFromImageRefs(imageRefsFromBlueprint)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->

* If user tries to verify with old styled blueprint, bail out early


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
* Without handling of this error, it results in a panic - bad ux

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
* Yes, the user sees a better error message now

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
* Manually