### PR TITLE
Change flink avro namespace in that taxi-ride app

### DIFF
--- a/examples/taxi-ride/datamodel/src/main/avro/taxifare.avsc
+++ b/examples/taxi-ride/datamodel/src/main/avro/taxifare.avsc
@@ -1,5 +1,5 @@
 {
-    "namespace": "taxiride.flink.avro",
+    "namespace": "taxiride.datamodel",
     "type": "record",
     "name": "TaxiFare",
     "fields":[

--- a/examples/taxi-ride/datamodel/src/main/avro/taxiride.avsc
+++ b/examples/taxi-ride/datamodel/src/main/avro/taxiride.avsc
@@ -1,5 +1,5 @@
 {
-    "namespace": "taxiride.flink.avro",
+    "namespace": "taxiride.datamodel",
     "type": "record",
     "name": "TaxiRide",
     "fields":[

--- a/examples/taxi-ride/datamodel/src/main/avro/taxiridefare.avsc
+++ b/examples/taxi-ride/datamodel/src/main/avro/taxiridefare.avsc
@@ -1,5 +1,5 @@
 {
-    "namespace": "taxiride.flink.avro",
+    "namespace": "taxiride.datamodel",
     "type": "record",
     "name": "TaxiRideFare",
     "fields":[

--- a/examples/taxi-ride/ingestor/src/main/scala/taxiride/ingestor/Generator.scala
+++ b/examples/taxi-ride/ingestor/src/main/scala/taxiride/ingestor/Generator.scala
@@ -21,7 +21,7 @@ import akka.stream.scaladsl._
 import cloudflow.streamlets.avro._
 import cloudflow.streamlets._
 import cloudflow.akkastream._
-import taxiride.flink.avro._
+import taxiride.datamodel._
 import spray.json._
 import TaxiFareJsonProtocol._
 

--- a/examples/taxi-ride/ingestor/src/main/scala/taxiride/ingestor/JsonFormats.scala
+++ b/examples/taxi-ride/ingestor/src/main/scala/taxiride/ingestor/JsonFormats.scala
@@ -17,7 +17,7 @@
 package taxiride.ingestor
 
 import spray.json._
-import taxiride.flink.avro._
+import taxiride.datamodel._
 
 object TaxiRideJsonProtocol extends DefaultJsonProtocol {
   implicit object TaxiRideJsonFormat extends RootJsonFormat[TaxiRide] {

--- a/examples/taxi-ride/ingestor/src/main/scala/taxiride/ingestor/TaxiFareIngress.scala
+++ b/examples/taxi-ride/ingestor/src/main/scala/taxiride/ingestor/TaxiFareIngress.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import cloudflow.streamlets.avro._
 import cloudflow.streamlets._
 import cloudflow.akkastream._
-import taxiride.flink.avro._
+import taxiride.datamodel._
 import TaxiFareJsonProtocol._
 import cloudflow.akkastream.util.scaladsl.HttpServerLogic
 

--- a/examples/taxi-ride/ingestor/src/main/scala/taxiride/ingestor/TaxiRideIngress.scala
+++ b/examples/taxi-ride/ingestor/src/main/scala/taxiride/ingestor/TaxiRideIngress.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import cloudflow.streamlets.avro._
 import cloudflow.streamlets._
 import cloudflow.akkastream._
-import taxiride.flink.avro._
+import taxiride.datamodel._
 import TaxiRideJsonProtocol._
 import cloudflow.akkastream.util.scaladsl.HttpServerLogic
 

--- a/examples/taxi-ride/logger/src/main/scala/taxiride/logger/FarePerRideLogger.scala
+++ b/examples/taxi-ride/logger/src/main/scala/taxiride/logger/FarePerRideLogger.scala
@@ -20,7 +20,7 @@ import cloudflow.akkastream._
 import cloudflow.akkastream.scaladsl._
 import cloudflow.streamlets._
 import cloudflow.streamlets.avro._
-import taxiride.flink.avro._
+import taxiride.datamodel._
 
 class FarePerRideLogger extends AkkaStreamlet {
   val inlet = AvroInlet[TaxiRideFare]("in")

--- a/examples/taxi-ride/processor/src/main/scala/taxiride/processor/TaxiRideProcessor.scala
+++ b/examples/taxi-ride/processor/src/main/scala/taxiride/processor/TaxiRideProcessor.scala
@@ -39,7 +39,7 @@ import org.apache.flink.util.Collector
 
 import cloudflow.streamlets.StreamletShape
 import cloudflow.streamlets.avro._
-import taxiride.flink.avro._
+import taxiride.datamodel._
 import cloudflow.flink._
 
 class TaxiRideProcessor extends FlinkStreamlet {


### PR DESCRIPTION
This PR changes the namespace of the AVRO-gen data classes as they seem to be clashing with the `flink` namespace and causing random CI build failures. 
Let's see whether this helps.