### PR TITLE
assert rows received from a trustable source

### DIFF
--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
@@ -35,13 +35,9 @@ class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
       val out = testKit.outletAsTap[CallRecord](streamlet.out)
 
       val run = testKit.run(streamlet, Seq.empty, Seq(out))
-      run.totalRows must be > 0L
-
-      // get data from outlet tap
-      val results = out.asCollection(session)
 
       // assert
-      results.size must be > 0
+      run.totalRows must be > 0L
 
     }
   }


### PR DESCRIPTION
Patch the pesky data assertion with the `rate` producer.
This approach is based on the data that we have effectively seen so far and should not fail randomly on some internal Spark process that makes the data visible on the temporary SQL table.
