### PR TITLE
Updated shortname for CloudflowApplication CRD; Fixed a build warning

### DIFF
--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/CloudflowApplication.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/CloudflowApplication.scala
@@ -98,7 +98,7 @@ object CloudflowApplication {
     kind = "CloudflowApplication",
     singular = Some("cloudflowapplication"),
     plural = Some("cloudflowapplications"),
-    shortNames = List("cloudflow"),
+    shortNames = List("cloudflowapp"),
     subresources = Some(Subresources().withStatusSubresource)
   )
 

--- a/core/cloudflow-runner/src/main/scala/cloudflow/runner/Runner.scala
+++ b/core/cloudflow-runner/src/main/scala/cloudflow/runner/Runner.scala
@@ -79,7 +79,7 @@ object Runner extends RunnerConfigResolver with StreamletLoader {
           case ex @ ExceptionAcc(exceptions) ⇒
             exceptions.foreach(ErrorEvents.report(loadedStreamlet, withPodRuntimeConfig, _))
             shutdown(loadedStreamlet, Some(ex))
-          case ex : Throwable =>
+          case ex: Throwable =>
             ErrorEvents.report(loadedStreamlet, withPodRuntimeConfig, ex)
             shutdown(loadedStreamlet, Some(ex))
         }

--- a/core/cloudflow-runner/src/main/scala/cloudflow/runner/Runner.scala
+++ b/core/cloudflow-runner/src/main/scala/cloudflow/runner/Runner.scala
@@ -79,7 +79,7 @@ object Runner extends RunnerConfigResolver with StreamletLoader {
           case ex @ ExceptionAcc(exceptions) ⇒
             exceptions.foreach(ErrorEvents.report(loadedStreamlet, withPodRuntimeConfig, _))
             shutdown(loadedStreamlet, Some(ex))
-          case ex =>
+          case ex : Throwable =>
             ErrorEvents.report(loadedStreamlet, withPodRuntimeConfig, ex)
             shutdown(loadedStreamlet, Some(ex))
         }


### PR DESCRIPTION
Note that the Throwable thing is not needed for correctness. But sbt complains about it during build. This will remove this warning.