### PR TITLE
Deprecate with offset ctx

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -77,6 +77,7 @@ lazy val akkastream =
     .enablePlugins(GenJavadocPlugin, JavaFormatterPlugin, ScalafmtPlugin)
     .dependsOn(streamlets)
     .settings(
+      javacOptions += "-Xlint:deprecation",
       scalafmtOnCompile := true,
       libraryDependencies ++= Vector(
             AkkaStream,
@@ -110,6 +111,7 @@ lazy val akkastreamUtil =
           )
     )
     .settings(
+      javacOptions += "-Xlint:deprecation",
       (sourceGenerators in Test) += (avroScalaGenerateSpecific in Test).taskValue
     )
 
@@ -135,6 +137,7 @@ lazy val akkastreamTestkit =
     .settings(
       (sourceDirectory in AvroConfig) := baseDirectory.value / "src/test/avro",
       (stringType in AvroConfig) := "String",
+      javacOptions += "-Xlint:deprecation",
       javacOptions += "-Xlint:unchecked"
     )
 
@@ -155,6 +158,7 @@ lazy val akkastreamTests =
           )
     )
     .settings(
+      javacOptions += "-Xlint:deprecation",
       (sourceGenerators in Test) += (avroScalaGenerateSpecific in Test).taskValue
     )
 

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
@@ -51,7 +51,7 @@ private[testkit] case class TestContext(
   override def streamletDefinition: StreamletDefinition =
     StreamletDefinition("appId", "appVersion", streamletRef, "streamletClass", List(), volumeMounts, config)
 
-  @deprecated("Use `committableSink` instead.", "1.3.4")
+  @deprecated("Use `sourceWithCommittableContext` instead.", "1.3.4")
   override def sourceWithOffsetContext[T](inlet: CodecInlet[T]): cloudflow.akkastream.scaladsl.SourceWithOffsetContext[T] =
     sourceWithContext(inlet)
 

--- a/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
+++ b/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
@@ -21,6 +21,7 @@ import akka.actor.ActorSystem;
 import akka.japi.Pair;
 import akka.kafka.ConsumerMessage;
 import akka.kafka.ConsumerMessage.CommittableOffset;
+import akka.kafka.ConsumerMessage.Committable;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;
 import akka.testkit.TestKit;
@@ -30,7 +31,8 @@ import cloudflow.akkastream.testkit.javadsl.*;
 import cloudflow.streamlets.*;
 import cloudflow.streamlets.avro.*;
 
-import org.scalatest.junit.JUnitSuite;
+// import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import org.junit.*;
 import scala.concurrent.duration.Duration;
 
@@ -147,9 +149,9 @@ public class AkkaStreamletTest extends JUnitSuite {
     public AkkaStreamletLogic createLogic() {
       return new AkkaStreamletLogic(getContext()) {
         public void run() {
-          getSourceWithOffsetContext(inlet)
-              .via(Flow.<Pair<Data, CommittableOffset>>create()) // no-op flow
-              .to(getSinkWithOffsetContext(outlet))
+          getSourceWithCommittableContext(inlet)
+              .via(Flow.<Pair<Data, Committable>>create()) // no-op flow
+              .to(getCommittableSink(outlet))
               .run(materializer());
         }
       };
@@ -219,9 +221,9 @@ public class AkkaStreamletTest extends JUnitSuite {
         public void run() {
           String configuredNameToFilterFor = streamletConfig().getString(nameFilter.getKey());
 
-          getSourceWithOffsetContext(inlet)
+          getSourceWithCommittableContext(inlet)
               .filter(data -> data.name().equals(configuredNameToFilterFor))
-              .to(getSinkWithOffsetContext(outlet))
+              .to(getCommittableSink(outlet))
               .run(materializer());
         }
       };

--- a/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
+++ b/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
@@ -31,7 +31,6 @@ import cloudflow.akkastream.testkit.javadsl.*;
 import cloudflow.streamlets.*;
 import cloudflow.streamlets.avro.*;
 
-// import org.scalatest.junit.JUnitSuite;
 import org.scalatestplus.junit.JUnitSuite;
 import org.junit.*;
 import scala.concurrent.duration.Duration;

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletSpec.scala
@@ -92,7 +92,7 @@ class AkkaStreamletSpec extends WordSpec with MustMatchers with BeforeAndAfterAl
           // The test
           streamletConfig mustBe empty
 
-          def runnableGraph = sourceWithOffsetContext(in).to(committableSink(out))
+          def runnableGraph = sourceWithCommittableContext(in).to(committableSink(out))
         }
       }
 

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/EmbeddedKafkaSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/EmbeddedKafkaSpec.scala
@@ -19,7 +19,6 @@ package cloudflow.akkastream.util.scaladsl
 import akka.actor.ActorSystem
 import akka.kafka.testkit.internal.TestFrameworkInterface
 import akka.kafka.testkit.scaladsl._
-import akka.stream.scaladsl._
 
 import org.scalatest._
 import org.scalatest.Suite

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/SplitterLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/SplitterLogic.scala
@@ -39,7 +39,7 @@ object Splitter {
    * At-least-once semantics are used.
    */
   def sink[I, L, R](
-      flow: FlowWithCommittableContext[I, JEither[L, R]],
+      flow: FlowWithContext[I, Committable, JEither[L, R], Committable, NotUsed],
       left: Sink[Pair[L, Committable], NotUsed],
       right: Sink[Pair[R, Committable], NotUsed]
   ): Sink[Pair[I, Committable], NotUsed] =
@@ -60,7 +60,7 @@ object Splitter {
    * At-least-once semantics are used.
    */
   def sink[I, L, R](
-      flow: FlowWithCommittableContext[I, JEither[L, R]],
+      flow: FlowWithContext[I, Committable, JEither[L, R], Committable, NotUsed],
       leftOutlet: CodecOutlet[L],
       rightOutlet: CodecOutlet[R],
       committerSettings: CommitterSettings,
@@ -82,7 +82,7 @@ object Splitter {
    * At-least-once semantics are used.
    */
   def sink[I, L, R](
-      flow: FlowWithCommittableContext[I, JEither[L, R]],
+      flow: FlowWithContext[I, Committable, JEither[L, R], Committable, NotUsed],
       leftOutlet: CodecOutlet[L],
       rightOutlet: CodecOutlet[R],
       context: AkkaStreamletContext
@@ -103,7 +103,7 @@ abstract class SplitterLogic[I, L, R](
     context: AkkaStreamletContext
 ) extends akkastream.util.scaladsl.SplitterLogic(in, left, right)(context) {
 
-  def createFlow(): FlowWithOffsetContext[I, JEither[L, R]]
+  def createFlow(): FlowWithContext[I, Committable, JEither[L, R], CommittableOffset, NotUsed]
   def flow: cloudflow.akkastream.scaladsl.FlowWithOffsetContext[I, Either[L, R]] =
     createFlow().map(jEither ⇒ if (jEither.isRight) Right(jEither.get()) else Left(jEither.getLeft())).asScala
   final def createFlowWithOffsetContext() = FlowWithOffsetContext.create[I]()

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/MergeLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/MergeLogic.scala
@@ -67,7 +67,7 @@ object Merger {
   def source[T](
       inlets: Seq[CodecInlet[T]]
   )(implicit context: AkkaStreamletContext): SourceWithContext[T, Committable, _] =
-    Source.fromGraph(graph(inlets.map(context.sourceWithOffsetContext(_)))).asSourceWithContext { case (_, offset) ⇒ offset }.map {
+    Source.fromGraph(graph(inlets.map(context.sourceWithCommittableContext(_)))).asSourceWithContext { case (_, offset) ⇒ offset }.map {
       case (t, _) ⇒ t
     }
   def source[T](
@@ -75,7 +75,7 @@ object Merger {
       inlets: CodecInlet[T]*
   )(implicit context: AkkaStreamletContext): SourceWithContext[T, Committable, _] =
     Source
-      .fromGraph(graph((inlet +: inlets.toList).map(context.sourceWithOffsetContext(_))))
+      .fromGraph(graph((inlet +: inlets.toList).map(context.sourceWithCommittableContext(_))))
       .asSourceWithContext { case (_, offset) ⇒ offset }
       .map { case (t, _) ⇒ t }
 }
@@ -98,7 +98,7 @@ class MergeLogic[T](
    */
   override def runnableGraph() = {
 
-    val inlets = inletPorts.map(inlet ⇒ sourceWithOffsetContext[T](inlet)).toList
+    val inlets = inletPorts.map(inlet ⇒ sourceWithCommittableContext[T](inlet)).toList
     val out    = committableSink[T](outlet)
 
     RunnableGraph.fromGraph(GraphDSL.create() { implicit builder: GraphDSL.Builder[NotUsed] ⇒

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -35,10 +35,12 @@ import cloudflow.streamlets._
  */
 trait AkkaStreamletContext extends StreamletContext {
 
-  private[akkastream] def sourceWithCommittableContext[T](inlet: CodecInlet[T]): scaladsl.SourceWithCommittableContext[T]
+  private[akkastream] def sourceWithCommittableContext[T](
+      inlet: CodecInlet[T]
+  ): cloudflow.akkastream.scaladsl.SourceWithCommittableContext[T]
 
   @deprecated("Use `sourceWithCommittableContext` instead.", "1.3.4")
-  private[akkastream] def sourceWithOffsetContext[T](inlet: CodecInlet[T]): scaladsl.SourceWithOffsetContext[T]
+  private[akkastream] def sourceWithOffsetContext[T](inlet: CodecInlet[T]): cloudflow.akkastream.scaladsl.SourceWithOffsetContext[T]
 
   private[akkastream] def plainSource[T](inlet: CodecInlet[T], resetPosition: ResetPosition): Source[T, NotUsed]
   private[akkastream] def plainSink[T](outlet: CodecOutlet[T]): Sink[T, NotUsed]

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -34,15 +34,22 @@ import cloudflow.streamlets._
  * It also provides the [[akka.actor.ActorSystem ActorSystem]] and [[akka.stream.Materializer Materializer]] that will be used to run the AkkaStreamlet.
  */
 trait AkkaStreamletContext extends StreamletContext {
+
+  private[akkastream] def sourceWithCommittableContext[T](inlet: CodecInlet[T]): scaladsl.SourceWithCommittableContext[T]
+
+  @deprecated("Use `sourceWithCommittableContext` instead.", "1.3.4")
   private[akkastream] def sourceWithOffsetContext[T](inlet: CodecInlet[T]): scaladsl.SourceWithOffsetContext[T]
+
   private[akkastream] def plainSource[T](inlet: CodecInlet[T], resetPosition: ResetPosition): Source[T, NotUsed]
   private[akkastream] def plainSink[T](outlet: CodecOutlet[T]): Sink[T, NotUsed]
 
   private[akkastream] def committableSink[T](outlet: CodecOutlet[T], committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed]
   private[akkastream] def committableSink[T](committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed]
 
+  @deprecated("Use `committableSink` instead.", "1.3.4")
   private[akkastream] def sinkWithOffsetContext[T](outlet: CodecOutlet[T],
                                                    committerSettings: CommitterSettings): Sink[(T, CommittableOffset), NotUsed]
+  @deprecated("Use `committableSink` instead.", "1.3.4")
   private[akkastream] def sinkWithOffsetContext[T](committerSettings: CommitterSettings): Sink[(T, CommittableOffset), NotUsed]
 
   /**

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -67,7 +67,8 @@ final class AkkaStreamletContextImpl(
 
   private val bootstrapServers = system.settings.config.getString("cloudflow.kafka.bootstrap-servers")
 
-  def sourceWithOffsetContext[T](inlet: CodecInlet[T]): cloudflow.akkastream.scaladsl.SourceWithOffsetContext[T] = {
+  // internal implementation that uses the CommittableOffset implementation to provide access to the underlying offsets
+  private[akkastream] def _sourceWithContext[T](inlet: CodecInlet[T]): SourceWithContext[T, CommittableOffset, _] = {
     val savepointPath = findSavepointPathForPort(inlet)
     val topic         = savepointPath.value
     val gId           = savepointPath.groupId(streamletRef, inlet)
@@ -90,6 +91,13 @@ final class AkkaStreamletContextImpl(
       .asSourceWithContext { case (_, committableOffset) ⇒ committableOffset }
       .map { case (record, _) ⇒ record }
   }
+
+  override def sourceWithCommittableContext[T](inlet: CodecInlet[T]): cloudflow.akkastream.scaladsl.SourceWithCommittableContext[T] =
+    _sourceWithContext[T](inlet)
+
+  @deprecated("Use sourceWithCommittableContext", "1.3.4")
+  override def sourceWithOffsetContext[T](inlet: CodecInlet[T]): cloudflow.akkastream.scaladsl.SourceWithOffsetContext[T] =
+    _sourceWithContext[T](inlet)
 
   def committableSink[T](outlet: CodecOutlet[T], committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed] = {
     val producerSettings = ProducerSettings(system, new ByteArraySerializer, new ByteArraySerializer)

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -68,7 +68,7 @@ final class AkkaStreamletContextImpl(
   private val bootstrapServers = system.settings.config.getString("cloudflow.kafka.bootstrap-servers")
 
   // internal implementation that uses the CommittableOffset implementation to provide access to the underlying offsets
-  private[akkastream] def _sourceWithContext[T](inlet: CodecInlet[T]): SourceWithContext[T, CommittableOffset, _] = {
+  private[akkastream] def sourceWithContext[T](inlet: CodecInlet[T]): SourceWithContext[T, CommittableOffset, _] = {
     val savepointPath = findSavepointPathForPort(inlet)
     val topic         = savepointPath.value
     val gId           = savepointPath.groupId(streamletRef, inlet)
@@ -93,11 +93,11 @@ final class AkkaStreamletContextImpl(
   }
 
   override def sourceWithCommittableContext[T](inlet: CodecInlet[T]): cloudflow.akkastream.scaladsl.SourceWithCommittableContext[T] =
-    _sourceWithContext[T](inlet)
+    sourceWithContext[T](inlet)
 
   @deprecated("Use sourceWithCommittableContext", "1.3.4")
   override def sourceWithOffsetContext[T](inlet: CodecInlet[T]): cloudflow.akkastream.scaladsl.SourceWithOffsetContext[T] =
-    _sourceWithContext[T](inlet)
+    sourceWithContext[T](inlet)
 
   def committableSink[T](outlet: CodecOutlet[T], committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed] = {
     val producerSettings = ProducerSettings(system, new ByteArraySerializer, new ByteArraySerializer)

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
@@ -29,6 +29,7 @@ import akka.kafka.ConsumerMessage._
 import com.typesafe.config.Config
 
 import cloudflow.streamlets._
+import cloudflow.akkastream.scaladsl._
 
 /**
  * Provides an entry-point for defining the behavior of an AkkaStreamlet.
@@ -111,7 +112,7 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
    * The `inlet` specifies a [[cloudflow.streamlets.Codec]] that will be used to deserialize the records read from Kafka.
    */
   @deprecated("Use sourceWithCommittableContext", "1.3.4")
-  def sourceWithOffsetContext[T](inlet: CodecInlet[T]): scaladsl.SourceWithOffsetContext[T] = context.sourceWithOffsetContext(inlet)
+  def sourceWithOffsetContext[T](inlet: CodecInlet[T]): SourceWithOffsetContext[T] = context.sourceWithOffsetContext(inlet)
 
   /**
    * This source emits `T` records together with the committable context, thus makes it possible
@@ -125,20 +126,21 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
    *
    * The `inlet` specifies a [[cloudflow.streamlets.Codec]] that is used to deserialize the records read from the underlying transport.
    */
-  def sourceWithCommittableContext[T](inlet: CodecInlet[T]): scaladsl.SourceWithCommittableContext[T] =
+  def sourceWithCommittableContext[T](inlet: CodecInlet[T]): SourceWithCommittableContext[T] =
     context.sourceWithCommittableContext(inlet)
 
   /**
    * Java API
    */
   @deprecated("Use getSourceWithCommittableContext", "1.3.4")
-  def getSourceWithOffsetContext[T](inlet: CodecInlet[T]): javadsl.SourceWithOffsetContext[T] = sourceWithOffsetContext(inlet).asJava
+  def getSourceWithOffsetContext[T](inlet: CodecInlet[T]): akka.stream.javadsl.SourceWithContext[T, CommittableOffset, _] =
+    sourceWithOffsetContext(inlet).asJava
 
   /**
    * Java API
    * @see [[sourceWithCommittableContext]]
    */
-  def getSourceWithCommittableContext[T](inlet: CodecInlet[T]): javadsl.SourceWithCommittableContext[T] =
+  def getSourceWithCommittableContext[T](inlet: CodecInlet[T]): akka.stream.javadsl.SourceWithContext[T, Committable, _] =
     context.sourceWithCommittableContext(inlet).asJava
 
   /**

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
@@ -110,18 +110,36 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
    * `sinkWithOffsetContext(outlet: CodecOutlet[T])` should be used if you want to commit the offset positions after records have been written to the specified `outlet`.
    * The `inlet` specifies a [[cloudflow.streamlets.Codec]] that will be used to deserialize the records read from Kafka.
    */
+  @deprecated("Use sourceWithCommittableContext", "1.3.4")
   def sourceWithOffsetContext[T](inlet: CodecInlet[T]): scaladsl.SourceWithOffsetContext[T] = context.sourceWithOffsetContext(inlet)
+
+  /**
+   * This source emits `T` records together with the committable context, thus makes it possible
+   * to commit offset positions to Kafka (as received through the `inlet`).
+   * This is useful when "at-least once delivery" is desired, as each message will likely be
+   * delivered one time, but in failure cases, they can be duplicated.
+   *
+   * It is intended to be used with `committableSink(outlet: CodecOutlet[T])`,
+   * which commits the offset positions that accompany the records that are read from this source
+   * after the records have been written to the specified `outlet`.
+   *
+   * The `inlet` specifies a [[cloudflow.streamlets.Codec]] that is used to deserialize the records read from the underlying transport.
+   */
+  def sourceWithCommittableContext[T](inlet: CodecInlet[T]): scaladsl.SourceWithCommittableContext[T] =
+    context.sourceWithCommittableContext(inlet)
 
   /**
    * Java API
    */
+  @deprecated("Use getSourceWithCommittableContext", "1.3.4")
   def getSourceWithOffsetContext[T](inlet: CodecInlet[T]): javadsl.SourceWithOffsetContext[T] = sourceWithOffsetContext(inlet).asJava
 
   /**
    * Java API
+   * @see [[sourceWithCommittableContext]]
    */
-  def getSourceWithCommittableContext[T](inlet: CodecInlet[T]): akka.stream.javadsl.SourceWithContext[T, Committable, _] =
-    getSourceWithOffsetContext(inlet)
+  def getSourceWithCommittableContext[T](inlet: CodecInlet[T]): javadsl.SourceWithCommittableContext[T] =
+    context.sourceWithCommittableContext(inlet).asJava
 
   /**
    * The `plainSource` emits `T` records (as received through the `inlet`).

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
@@ -23,25 +23,19 @@ import akka.kafka.ConsumerMessage._
 
 package object javadsl {
 
-  /**
-   * Java API
-   */
+  type FlowWithCommittableContext[In, Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
+
+  type SourceWithCommittableContext[T] = SourceWithContext[T, Committable, _]
+
   @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
   type FlowWithOffsetContext[In, Out] = FlowWithContext[In, CommittableOffset, Out, CommittableOffset, NotUsed]
 
-  type FlowWithCommittableContext[In, Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
-
-  /**
-   * Java API
-   */
-  type SourceWithOffsetContext[+T] = SourceWithContext[T, CommittableOffset, _]
+  @deprecated("Use `SourceWithCommittableContext` instead.", "1.3.4")
+  type SourceWithOffsetContext[T] = SourceWithContext[T, CommittableOffset, _]
 }
 
 package javadsl {
 
-  /**
-   * Java API
-   */
   @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
   object FlowWithOffsetContext {
 
@@ -52,9 +46,6 @@ package javadsl {
     def create[In]() = FlowWithContext.create[In, CommittableOffset]()
   }
 
-  /**
-   * Java API
-   */
   object FlowWithCommittableContext {
 
     /**

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
@@ -21,18 +21,6 @@ import akka.stream.javadsl._
 
 import akka.kafka.ConsumerMessage._
 
-package object javadsl {
-
-  //type FlowWithCommittableContext[In, Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
-  //type SourceWithCommittableContext[T] = SourceWithContext[T, Committable, _]
-
-  //@deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
-  //type FlowWithOffsetContext[In, Out] = FlowWithContext[In, CommittableOffset, Out, CommittableOffset, NotUsed]
-
-  //@deprecated("Use `SourceWithCommittableContext` instead.", "1.3.4")
-  //type SourceWithOffsetContext[T] = SourceWithContext[T, CommittableOffset, _]
-}
-
 package javadsl {
 
   @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
@@ -24,7 +24,6 @@ import akka.kafka.ConsumerMessage._
 package object javadsl {
 
   type FlowWithCommittableContext[In, Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
-
   type SourceWithCommittableContext[T] = SourceWithContext[T, Committable, _]
 
   @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/javadsl/package.scala
@@ -23,14 +23,14 @@ import akka.kafka.ConsumerMessage._
 
 package object javadsl {
 
-  type FlowWithCommittableContext[In, Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
-  type SourceWithCommittableContext[T] = SourceWithContext[T, Committable, _]
+  //type FlowWithCommittableContext[In, Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
+  //type SourceWithCommittableContext[T] = SourceWithContext[T, Committable, _]
 
-  @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
-  type FlowWithOffsetContext[In, Out] = FlowWithContext[In, CommittableOffset, Out, CommittableOffset, NotUsed]
+  //@deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
+  //type FlowWithOffsetContext[In, Out] = FlowWithContext[In, CommittableOffset, Out, CommittableOffset, NotUsed]
 
-  @deprecated("Use `SourceWithCommittableContext` instead.", "1.3.4")
-  type SourceWithOffsetContext[T] = SourceWithContext[T, CommittableOffset, _]
+  //@deprecated("Use `SourceWithCommittableContext` instead.", "1.3.4")
+  //type SourceWithOffsetContext[T] = SourceWithContext[T, CommittableOffset, _]
 }
 
 package javadsl {
@@ -42,7 +42,8 @@ package javadsl {
      * Creates a [[akka.stream.javadsl.FlowWithContext FlowWithContext]] that makes it possible for cloudflow to commit reads.
      */
     @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
-    def create[In]() = FlowWithContext.create[In, CommittableOffset]()
+    def create[In](): FlowWithContext[In, CommittableOffset, In, CommittableOffset, NotUsed] =
+      FlowWithContext.create[In, CommittableOffset]()
   }
 
   object FlowWithCommittableContext {
@@ -50,6 +51,7 @@ package javadsl {
     /**
      * Creates a [[akka.stream.javadsl.FlowWithContext FlowWithContext]] that makes it possible for cloudflow to commit reads.
      */
-    def create[In]() = FlowWithContext.create[In, Committable]()
+    def create[In](): FlowWithContext[In, Committable, In, Committable, NotUsed] =
+      FlowWithContext.create[In, Committable]()
   }
 }

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
@@ -18,13 +18,29 @@ package cloudflow.akkastream
 
 import akka.NotUsed
 import akka.stream.scaladsl._
-import akka.kafka.ConsumerMessage._
+import akka.kafka.ConsumerMessage.{ Committable, CommittableOffset }
 
 package object scaladsl {
-  @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
-  type FlowWithOffsetContext[-In, +Out]      = FlowWithContext[In, CommittableOffset, Out, CommittableOffset, NotUsed]
+
   type FlowWithCommittableContext[-In, +Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
 
+  type SourceWithCommittableContext[+T] = SourceWithContext[T, Committable, _]
+
+  object FlowWithCommittableContext {
+
+    /**
+     * Creates a [[akka.stream.scaladsl.FlowWithContext FlowWithContext]] that makes it possible for Cloudflow to commit reads when
+     * `StreamletLogic.atLeastOnceSource` and `StreamletLogic.atLeastOnceSink` is used.
+     */
+    def apply[In]() = FlowWithContext[In, Committable]
+  }
+
+  /** Deprecated API **/
+
+  @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
+  type FlowWithOffsetContext[-In, +Out] = FlowWithContext[In, CommittableOffset, Out, CommittableOffset, NotUsed]
+
+  @deprecated("Use `SourceWithCommittableContext` instead.", "1.3.4")
   type SourceWithOffsetContext[+T] = SourceWithContext[T, CommittableOffset, _]
 
   @deprecated("Use `FlowWithCommittableContext` instead.", "1.3.1")
@@ -38,12 +54,4 @@ package object scaladsl {
     def apply[In]() = FlowWithContext[In, CommittableOffset]
   }
 
-  object FlowWithCommittableContext {
-
-    /**
-     * Creates a [[akka.stream.scaladsl.FlowWithContext FlowWithContext]] that makes it possible for cloudflow to commit reads when
-     * `StreamletLogic.atLeastOnceSource` and `StreamletLogic.atLeastOnceSink` is used.
-     */
-    def apply[In]() = FlowWithContext[In, Committable]
-  }
 }

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
@@ -32,7 +32,7 @@ package object scaladsl {
      * Creates a [[akka.stream.scaladsl.FlowWithContext FlowWithContext]] that makes it possible for Cloudflow to commit reads when
      * `StreamletLogic.atLeastOnceSource` and `StreamletLogic.atLeastOnceSink` is used.
      */
-    def apply[In]() = FlowWithContext[In, Committable]
+    def apply[In](): FlowWithCommittableContext[In, In] = FlowWithContext[In, Committable]
   }
 
   /** Deprecated API **/

--- a/examples/call-record-aggregator/akka-java-aggregation-output/src/main/java/carly/output/AggregateRecordEgress.java
+++ b/examples/call-record-aggregator/akka-java-aggregation-output/src/main/java/carly/output/AggregateRecordEgress.java
@@ -17,7 +17,7 @@
 package carly.output;
 
 import akka.NotUsed;
-import akka.kafka.ConsumerMessage.CommittableOffset;
+import akka.kafka.ConsumerMessage.Committable;
 import akka.stream.javadsl.*;
 import cloudflow.streamlets.*;
 import cloudflow.streamlets.avro.*;
@@ -37,15 +37,15 @@ public class AggregateRecordEgress extends AkkaStreamlet {
   @Override
   public AkkaStreamletLogic createLogic() {
     return new RunnableGraphStreamletLogic(getContext()) {
+
       @Override
       public RunnableGraph<?> createRunnableGraph() {
         return getSourceWithCommittableContext(in)
-          .via(
-            FlowWithCommittableContext.<AggregatedCallStats>create()
-              .map(metric -> {
-                System.out.println(metric);
-                return metric;
-              })
+          .via(FlowWithCommittableContext.<AggregatedCallStats>create()
+                  .map(metric -> {
+                    System.out.println(metric);
+                    return metric;
+                  })
           )
           .to(getCommittableSink());
       }

--- a/examples/call-record-aggregator/akka-java-aggregation-output/src/main/java/carly/output/AggregateRecordEgress.java
+++ b/examples/call-record-aggregator/akka-java-aggregation-output/src/main/java/carly/output/AggregateRecordEgress.java
@@ -39,15 +39,15 @@ public class AggregateRecordEgress extends AkkaStreamlet {
     return new RunnableGraphStreamletLogic(getContext()) {
       @Override
       public RunnableGraph<?> createRunnableGraph() {
-        return getSourceWithOffsetContext(in)
+        return getSourceWithCommittableContext(in)
           .via(
-            FlowWithOffsetContext.<AggregatedCallStats>create()
+            FlowWithCommittableContext.<AggregatedCallStats>create()
               .map(metric -> {
                 System.out.println(metric);
                 return metric;
               })
           )
-          .to(getSinkWithOffsetContext());
+          .to(getCommittableSink());
       }
     };
   }

--- a/examples/call-record-aggregator/build.sbt
+++ b/examples/call-record-aggregator/build.sbt
@@ -82,6 +82,7 @@ lazy val commonSettings = Seq(
   organization := "com.lightbend.cloudflow",
   headerLicense := Some(HeaderLicense.ALv2("(C) 2016-2020", "Lightbend Inc. <https://www.lightbend.com>")),
   scalaVersion := "2.12.10",
+  javacOptions += "-Xlint:deprecation",
   scalacOptions ++= Seq(
     "-encoding", "UTF-8",
     "-target:jvm-1.8",

--- a/examples/call-record-aggregator/project/cloudflow-plugins.sbt
+++ b/examples/call-record-aggregator/project/cloudflow-plugins.sbt
@@ -2,5 +2,5 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")
 

--- a/examples/connected-car-cluster-sharding/akka-connected-car-streamlet/src/main/scala/connectedcar/streamlets/CarDataPrinter.scala
+++ b/examples/connected-car-cluster-sharding/akka-connected-car-streamlet/src/main/scala/connectedcar/streamlets/CarDataPrinter.scala
@@ -17,6 +17,6 @@ object CarDataPrinter extends AkkaStreamlet {
       }
 
     def runnableGraph =
-      sourceWithOffsetContext(in).via(flow).to(committableSink)
+      sourceWithCommittableContext(in).via(flow).to(committableSink)
   }
 }

--- a/examples/connected-car-cluster-sharding/akka-connected-car-streamlet/src/main/scala/connectedcar/streamlets/ConnectedCarCluster.scala
+++ b/examples/connected-car-cluster-sharding/akka-connected-car-streamlet/src/main/scala/connectedcar/streamlets/ConnectedCarCluster.scala
@@ -19,7 +19,7 @@ object ConnectedCarCluster extends AkkaStreamlet with Clustering {
   val shape = StreamletShape(in).withOutlets(out)
 
   override def createLogic = new RunnableGraphStreamletLogic() {
-    def runnableGraph = sourceWithOffsetContext(in).via(flow).to(committableSink(out))
+    def runnableGraph = sourceWithCommittableContext(in).via(flow).to(committableSink(out))
 
     val carRegion: ActorRef = ClusterSharding(context.system).start(
       typeName = "Counter",

--- a/examples/connected-car-cluster-sharding/project/cloudflow-plugins.sbt
+++ b/examples/connected-car-cluster-sharding/project/cloudflow-plugins.sbt
@@ -2,6 +2,6 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-pre-221-affe5ae")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")
 
 

--- a/examples/snippets/modules/ROOT/examples/akkastreams-java/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-java/build.sbt
@@ -24,6 +24,7 @@ lazy val sensorData =  (project in file("."))
 
       scalaVersion := "2.12.10",
       crossScalaVersions := Vector(scalaVersion.value),
+      javacOptions +="-Xlint:deprecation",
       scalacOptions ++= Seq(
         "-encoding", "UTF-8",
         "-target:jvm-1.8",

--- a/examples/snippets/modules/ROOT/examples/akkastreams-java/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-java/build.sbt
@@ -24,7 +24,7 @@ lazy val sensorData =  (project in file("."))
 
       scalaVersion := "2.12.10",
       crossScalaVersions := Vector(scalaVersion.value),
-      javacOptions +="-Xlint:deprecation",
+      javacOptions ++= Seq("-Xlint:deprecation"),
       scalacOptions ++= Seq(
         "-encoding", "UTF-8",
         "-target:jvm-1.8",

--- a/examples/snippets/modules/ROOT/examples/akkastreams-java/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-java/project/cloudflow-plugins.sbt
@@ -2,4 +2,4 @@
 //
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/snippets/modules/ROOT/examples/akkastreams-java/src/main/java/cloudflow/akkastreamsdoc/DataMerge.java
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-java/src/main/java/cloudflow/akkastreamsdoc/DataMerge.java
@@ -18,6 +18,7 @@ public class DataMerge extends AkkaStreamlet {
   public StreamletShape shape() {
     return StreamletShape.createWithInlets(inlet1, inlet2).withOutlets(outlet);
   }
+
   public RunnableGraphStreamletLogic createLogic() {
     return new RunnableGraphStreamletLogic(getContext()) {
       public RunnableGraph<?> createRunnableGraph() {

--- a/examples/snippets/modules/ROOT/examples/akkastreams-scala/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-scala/project/cloudflow-plugins.sbt
@@ -2,4 +2,4 @@
 //
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/snippets/modules/ROOT/examples/akkastreams-scala/src/main/scala/cloudflow/akkastreamsdoc/DataSplitter.scala
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-scala/src/main/scala/cloudflow/akkastreamsdoc/DataSplitter.scala
@@ -15,7 +15,7 @@ class DataSplitter extends AkkaStreamlet {
   val shape   = StreamletShape(in).withOutlets(invalid, valid)
 
   override def createLogic = new RunnableGraphStreamletLogic() {
-    def runnableGraph = sourceWithOffsetContext(in).to(Splitter.sink(flow, invalid, valid))
+    def runnableGraph = sourceWithCommittableContext(in).to(Splitter.sink(flow, invalid, valid))
     def flow =
       FlowWithCommittableContext[Data]
         .map { data ⇒

--- a/examples/snippets/modules/ROOT/examples/akkastreams-scala/src/main/scala/cloudflow/akkastreamsdoc/RecordSumFlow.scala
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-scala/src/main/scala/cloudflow/akkastreamsdoc/RecordSumFlow.scala
@@ -29,7 +29,7 @@ object RecordSumFlow extends AkkaStreamlet {
       //end::usage[]
       val flow = FlowWithCommittableContext[Metric].grouped(recordsInWindow).map(sumRecords).mapContext(_.last)
 
-      sourceWithOffsetContext(inlet)
+      sourceWithCommittableContext(inlet)
         .via(flow)
         .to(committableSink(outlet))
     }

--- a/examples/snippets/modules/ROOT/examples/akkastreams-scala/src/main/scala/com/example/MetricsEgress.scala
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-scala/src/main/scala/com/example/MetricsEgress.scala
@@ -5,8 +5,6 @@ import cloudflow.akkastream._
 import cloudflow.streamlets.avro._
 import cloudflow.akkastream.scaladsl._
 
-import akka.kafka.scaladsl.Committer
-
 import cloudflow.akkastreamsdoc.Data
 
 object MetricsEgress extends AkkaStreamlet {
@@ -15,10 +13,10 @@ object MetricsEgress extends AkkaStreamlet {
 
   final override def createLogic = new RunnableGraphStreamletLogic {
     override final def runnableGraph =
-      sourceWithOffsetContext(in)
+      sourceWithCommittableContext(in)
         .map { i ⇒
           println(s"Int: ${i.value}"); i
         }
-        .to(Committer.sinkWithOffsetContext(defaultCommitterSettings))
+        .to(committableSink(defaultCommitterSettings))
   }
 }

--- a/examples/snippets/modules/ROOT/examples/build-akka-streamlets-java/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-akka-streamlets-java/build.sbt
@@ -67,6 +67,7 @@ lazy val commonSettings = Seq(
   organization := "com.lightbend.cloudflow",
   headerLicense := Some(HeaderLicense.ALv2("(C) 2016-2020", "Lightbend Inc. <https://www.lightbend.com>")),
   scalaVersion := "2.12.10",
+  javacOptions += "-Xlint:deprecation",
   scalacOptions ++= Seq(
     "-encoding", "UTF-8",
     "-target:jvm-1.8",

--- a/examples/snippets/modules/ROOT/examples/build-akka-streamlets-java/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-akka-streamlets-java/project/cloudflow-plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/snippets/modules/ROOT/examples/build-akka-streamlets-scala/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-akka-streamlets-scala/project/cloudflow-plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/snippets/modules/ROOT/examples/build-akka-streamlets-scala/step3/src/main/scala/com/example/AtLeastOnceReportPrinter.scala
+++ b/examples/snippets/modules/ROOT/examples/build-akka-streamlets-scala/step3/src/main/scala/com/example/AtLeastOnceReportPrinter.scala
@@ -18,7 +18,7 @@ object AtLeastOnceReportPrinater extends AkkaStreamlet {
   def createLogic = new RunnableGraphStreamletLogic() {
     def format(report: Report) = s"${report.name}\n\n${report.description}"
     def runnableGraph =
-      sourceWithOffsetContext(inlet)
+      sourceWithCommittableContext(inlet)
         .map { report ⇒
           println(format(report))
           report

--- a/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/build.sbt
@@ -57,6 +57,7 @@ lazy val commonSettings = Seq(
   organization := "com.lightbend.cloudflow",
   headerLicense := Some(HeaderLicense.ALv2("(C) 2016-2020", "Lightbend Inc. <https://www.lightbend.com>")),
   scalaVersion := "2.12.10",
+  javacOptions += "-Xlint:deprecation",
   scalacOptions ++= Seq(
     "-encoding", "UTF-8",
     "-target:jvm-1.8",

--- a/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/project/cloudflow-plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/snippets/modules/ROOT/examples/build-flink-streamlets-scala/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-flink-streamlets-scala/project/cloudflow-plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/project/cloudflow-plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/project/cloudflow-plugins.sbt
@@ -3,4 +3,4 @@
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/InvalidMetricLogger.scala
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/InvalidMetricLogger.scala
@@ -33,6 +33,6 @@ class InvalidMetricLogger extends AkkaStreamlet {
       }
 
     def runnableGraph =
-      sourceWithOffsetContext(inlet).via(flow).to(committableSink)
+      sourceWithCommittableContext(inlet).via(flow).to(committableSink)
   }
 }

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/RotorSpeedFilter.scala
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/RotorSpeedFilter.scala
@@ -27,7 +27,7 @@ class RotorSpeedFilter extends AkkaStreamlet {
   val shape = StreamletShape(in, out)
 
   override def createLogic = new RunnableGraphStreamletLogic() {
-    def runnableGraph = sourceWithOffsetContext(in).via(flow).to(committableSink(out))
+    def runnableGraph = sourceWithCommittableContext(in).via(flow).to(committableSink(out))
     def flow          = FlowWithCommittableContext[Metric].filter(_.name == "rotorSpeed")
   }
 }

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/RotorspeedWindowLogger.scala
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/RotorspeedWindowLogger.scala
@@ -25,9 +25,9 @@ class RotorspeedWindowLogger extends AkkaStreamlet {
   val in    = AvroInlet[Metric]("in")
   val shape = StreamletShape(in)
   override def createLogic = new RunnableGraphStreamletLogic() {
-    def runnableGraph = sourceWithOffsetContext(in).via(flow).to(sinkWithOffsetContext)
+    def runnableGraph = sourceWithCommittableContext(in).via(flow).to(committableSink)
     def flow =
-      FlowWithOffsetContext[Metric]
+      FlowWithCommittableContext[Metric]
         .grouped(5)
         .map { rotorSpeedWindow ⇒
           val (avg, _) = rotorSpeedWindow.map(_.value).foldLeft((0.0, 1)) { case ((avg, idx), next) ⇒ (avg + (next - avg) / idx, idx + 1) }

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/SensorDataMerge.scala
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/SensorDataMerge.scala
@@ -19,13 +19,17 @@ package sensordata
 import cloudflow.streamlets._
 import cloudflow.streamlets.avro._
 import cloudflow.akkastream._
-import cloudflow.akkastream.util.scaladsl.MergeLogic
+import cloudflow.akkastream.scaladsl._
+import cloudflow.akkastream.util.scaladsl.Merger
 
 class SensorDataMerge extends AkkaStreamlet {
   val in0 = AvroInlet[SensorData]("in-0")
   val in1 = AvroInlet[SensorData]("in-1")
   val out = AvroOutlet[SensorData]("out", _.deviceId.toString)
 
-  final override val shape       = StreamletShape.withInlets(in0, in1).withOutlets(out)
-  final override def createLogic = new MergeLogic(Vector(in0, in1), out)
+  final override val shape = StreamletShape.withInlets(in0, in1).withOutlets(out)
+  final override def createLogic = new RunnableGraphStreamletLogic() {
+    def runnableGraph = Merger.source(Vector(in0, in1)).to(committableSink(out))
+  }
+
 }

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/SensorDataToMetrics.scala
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/SensorDataToMetrics.scala
@@ -35,6 +35,6 @@ class SensorDataToMetrics extends AkkaStreamlet {
         )
       }
   override def createLogic = new RunnableGraphStreamletLogic() {
-    def runnableGraph = sourceWithOffsetContext(in).via(flow).to(committableSink(out))
+    def runnableGraph = sourceWithCommittableContext(in).via(flow).to(committableSink(out))
   }
 }

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/ValidMetricLogger.scala
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/src/main/scala/sensordata/ValidMetricLogger.scala
@@ -63,7 +63,7 @@ class ValidMetricLogger extends AkkaStreamlet {
         }
 
     def runnableGraph =
-      sourceWithOffsetContext(inlet).via(flow).to(committableSink)
+      sourceWithCommittableContext(inlet).via(flow).to(committableSink)
   }
 }
 //end::all[]

--- a/examples/snippets/modules/ROOT/examples/spark-scala/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/spark-scala/project/cloudflow-plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/spark-sensors/project/cloudflow-plugins.sbt
+++ b/examples/spark-sensors/project/cloudflow-plugins.sbt
@@ -3,5 +3,5 @@
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")
 

--- a/examples/taxi-ride/logger/src/main/scala/taxiride/logger/FarePerRideLogger.scala
+++ b/examples/taxi-ride/logger/src/main/scala/taxiride/logger/FarePerRideLogger.scala
@@ -58,7 +58,7 @@ class FarePerRideLogger extends AkkaStreamlet {
         }
 
     def runnableGraph =
-      sourceWithOffsetContext(inlet)
+      sourceWithCommittableContext(inlet)
         .via(flow)
         .to(committableSink)
   }

--- a/examples/taxi-ride/project/cloudflow-plugins.sbt
+++ b/examples/taxi-ride/project/cloudflow-plugins.sbt
@@ -3,4 +3,4 @@
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/templates/single-backend-java/project/cloudflow-plugins.sbt
+++ b/examples/templates/single-backend-java/project/cloudflow-plugins.sbt
@@ -3,5 +3,5 @@
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")
 

--- a/examples/templates/single-backend-scala/project/cloudflow-plugins.sbt
+++ b/examples/templates/single-backend-scala/project/cloudflow-plugins.sbt
@@ -3,4 +3,4 @@
 resolvers += "Akka Snapshots".at("https://repo.akka.io/snapshots/")
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/templates/single-backend-scala/src/main/scala/com/example/app/ConsoleOutput.scala
+++ b/examples/templates/single-backend-scala/src/main/scala/com/example/app/ConsoleOutput.scala
@@ -38,7 +38,7 @@ class ConsoleOutput extends AkkaStreamlet {
     // check the Streamlet API of your chosen implementation to determine the entry point
     // corresponding to your chosen backend.
     def runnableGraph =
-      sourceWithOffsetContext(inlet).via(flow).to(committableSink)
+      sourceWithCommittableContext(inlet).via(flow).to(committableSink)
 
     // flow is a help function to make the structure more readable
     val flow = FlowWithCommittableContext[Data]

--- a/examples/tensorflow-akka/project/cloudflow-plugins.sbt
+++ b/examples/tensorflow-akka/project/cloudflow-plugins.sbt
@@ -4,4 +4,4 @@ resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.3")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/tensorflow-akka/src/main/scala/modelserving/wine/WineModelServer.scala
+++ b/examples/tensorflow-akka/src/main/scala/modelserving/wine/WineModelServer.scala
@@ -69,7 +69,7 @@ final class WineModelServer extends AkkaStreamlet {
       )
 
     def runnableGraph() =
-      sourceWithOffsetContext(in)
+      sourceWithCommittableContext(in)
         .via(modelScoringFlow)
         .to(committableSink(out))
   }

--- a/examples/tensorflow-akka/src/main/scala/modelserving/wine/WineResultConsoleEgress.scala
+++ b/examples/tensorflow-akka/src/main/scala/modelserving/wine/WineResultConsoleEgress.scala
@@ -36,6 +36,6 @@ final case object WineResultConsoleEgress extends AkkaStreamlet {
 
     def write(record: WineResult): Unit = println(record.toString)
 
-    def runnableGraph = sourceWithOffsetContext(in).map(write(_)).to(committableSink)
+    def runnableGraph = sourceWithCommittableContext(in).map(write(_)).to(committableSink)
   }
 }


### PR DESCRIPTION
This PR deprecates the 'withOffsetContext' set of APIs and implements a consistent "Committable" API for sources, flows, and sinks.
It also upgrades all examples to use the new API.

Closes #247 

ping @jasoncarreira - this should address the issue that you reported. Thanks for that. 