### PR TITLE
change how cluster configs are read from file to solve issue #357

### DIFF
--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
@@ -51,10 +51,10 @@ abstract class AkkaStreamlet extends Streamlet[AkkaStreamletContext] {
 
       if (activateCluster && localMode) {
         val updatedStreamletDefinition = streamletDefinition.copy(config = streamletDefinition.config.withFallback(config))
-        val clusterConfig              = ConfigFactory.load("akka-cluster-local.conf")
-        val fullConfig                 = clusterConfig.withFallback(updatedStreamletDefinition.config)
+        val clusterConfig              = ConfigFactory.parseResourcesAnySyntax("akka-cluster-local.conf")
+        val fullConfig = clusterConfig.withFallback(updatedStreamletDefinition.config)
 
-        val system = ActorSystem("akka_streamlet", fullConfig)
+        val system = ActorSystem("akka_streamlet", ConfigFactory.load(fullConfig))
         new AkkaStreamletContextImpl(updatedStreamletDefinition, system)
       } else if (activateCluster) {
         val updatedStreamletDefinition = streamletDefinition.copy(config = streamletDefinition.config.withFallback(config))
@@ -62,11 +62,11 @@ abstract class AkkaStreamlet extends Streamlet[AkkaStreamletContext] {
           .parseString(
             s"""akka.discovery.kubernetes-api.pod-label-selector = "com.lightbend.cloudflow/streamlet-name=${streamletDefinition.streamletRef}""""
           )
-          .withFallback(ConfigFactory.load("akka-cluster-k8.conf"))
+          .withFallback(ConfigFactory.parseResourcesAnySyntax("akka-cluster-k8.conf"))
 
         val fullConfig = clusterConfig.withFallback(updatedStreamletDefinition.config)
 
-        val system = ActorSystem("akka_streamlet", fullConfig)
+        val system = ActorSystem("akka_streamlet", ConfigFactory.load(fullConfig))
         AkkaManagement(system).start()
         ClusterBootstrap(system).start()
         Discovery(system).loadServiceDiscovery("kubernetes-api")

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
@@ -52,7 +52,7 @@ abstract class AkkaStreamlet extends Streamlet[AkkaStreamletContext] {
       if (activateCluster && localMode) {
         val updatedStreamletDefinition = streamletDefinition.copy(config = streamletDefinition.config.withFallback(config))
         val clusterConfig              = ConfigFactory.parseResourcesAnySyntax("akka-cluster-local.conf")
-        val fullConfig = clusterConfig.withFallback(updatedStreamletDefinition.config)
+        val fullConfig                 = clusterConfig.withFallback(updatedStreamletDefinition.config)
 
         val system = ActorSystem("akka_streamlet", ConfigFactory.load(fullConfig))
         new AkkaStreamletContextImpl(updatedStreamletDefinition, system)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Modify how cluster configs are read from files to fix issue #357 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
currently configs set by a user in their application.conf can be overridden when using the clustering trait because of how clustering configs are read from the .conf files

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
This patch has been tested using the project that was experiencing the error
 https://github.com/thinkmorestupidless/sepa-pipeline