### PR TITLE
centralize a work dir for our internal kitchen

### DIFF
--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CRGenerationPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CRGenerationPlugin.scala
@@ -34,7 +34,6 @@ import cloudflow.blueprint.deployment.CloudflowCRFormat.cloudflowCRFormat
  * Plugin that generates the CR file for the application
  */
 object CRGenerationPlugin extends AutoPlugin {
-  final val TEMP_DIRECTORY = new File(System.getProperty("java.io.tmpdir"))
 
   override def requires =
     StreamletDescriptorsPlugin && BlueprintVerificationPlugin
@@ -53,14 +52,15 @@ object CRGenerationPlugin extends AutoPlugin {
     // these streamlet descriptors have been generated from the `build` task
     // if they have not been generated we throw an exception and ask the user
     // to run the build
-    val log = streams.value.log
+    val log     = streams.value.log
+    val workDir = cloudflowWorkDir.value
 
     val registry  = cloudflowDockerRegistry.value.get
     val namespace = cloudflowDockerRepository.value.get
 
     val streamletDescriptors = imageNamesByProject.value.foldLeft(Vector.empty[StreamletDescriptor]) {
       case (acc, (_, image)) =>
-        val file = new File(TEMP_DIRECTORY, image.asTaggedName)
+        val file = new File(workDir, image.asTaggedName)
         if (file.exists()) {
           val json = new String(IO.readBytes(file), UTF_8)
           acc ++ json.parseJson.convertTo[Map[String, StreamletDescriptor]].values

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
@@ -41,7 +41,6 @@ object CloudflowBasePlugin extends AutoPlugin {
   final val OptAppDir                        = "/opt/cloudflow/"
   final val ScalaVersion                     = "2.12"
   final val CloudflowVersion                 = "1.4.0"
-  val TEMP_DIRECTORY                         = new File(System.getProperty("java.io.tmpdir"))
 
   // NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   // The UID and GID of the `jboss` user is used in different parts of Cloudflow

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowKeys.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowKeys.scala
@@ -59,6 +59,7 @@ trait CloudflowTaskKeys {
   val runLocal        = taskKey[Unit]("Run the Cloudflow application in a local Sandbox")
   val generateCR      = taskKey[Unit]("Generate Cloudflow Application CR")
 
+  private[sbt] val cloudflowWorkDir      = taskKey[File]("The directory under /target used for internal bookkeeping")
   private[sbt] val cloudflowStageAppJars = taskKey[Unit]("Stages the jars for the application")
   private[sbt] val cloudflowStageScript  = taskKey[Unit]("Stages the launch script for the application")
 

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CommonSettingsAndTasksPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CommonSettingsAndTasksPlugin.scala
@@ -53,6 +53,7 @@ object CommonSettingsAndTasksPlugin extends AutoPlugin {
     cloudflowDockerImageName := Def.task {
           Some(DockerImageName((ThisProject / name).value.toLowerCase, (ThisProject / cloudflowBuildNumber).value.buildNumber))
         }.value,
+    cloudflowWorkDir := (ThisBuild / baseDirectory).value / "target" / ".cloudflow",
     imageNamesByProject := Def.taskDyn {
           val buildNumber = cloudflowBuildNumber.value.buildNumber
           Def.task {

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/StreamletDescriptorsPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/StreamletDescriptorsPlugin.scala
@@ -19,12 +19,10 @@ package cloudflow.sbt
 import java.io._
 
 import com.typesafe.config._
-
 import sbt._
 import sbt.Keys._
 import spray.json._
 import JsonUtils._
-
 import cloudflow.sbt.CloudflowKeys._
 import cloudflow.blueprint.StreamletDescriptorFormat._
 import cloudflow.blueprint.StreamletDescriptor
@@ -39,7 +37,6 @@ import cloudflow.blueprint.StreamletDescriptor
  * to the top level project name.
  */
 object StreamletDescriptorsPlugin extends AutoPlugin {
-  final val TEMP_DIRECTORY = new File(System.getProperty("java.io.tmpdir"))
 
   override def requires =
     CommonSettingsAndTasksPlugin && StreamletScannerPlugin
@@ -49,8 +46,9 @@ object StreamletDescriptorsPlugin extends AutoPlugin {
           Some(DockerImageName((ThisProject / name).value.toLowerCase, (ThisProject / cloudflowBuildNumber).value.buildNumber))
         }.value,
     streamletDescriptorsInProject := Def.taskDyn {
+          val workDir            = cloudflowWorkDir.value
           val detectedStreamlets = cloudflowStreamletDescriptors.value
-          val file               = new File(TEMP_DIRECTORY, cloudflowDockerImageName.value.get.asTaggedName)
+          val file               = new File(workDir, cloudflowDockerImageName.value.get.asTaggedName)
           buildStreamletDescriptors(file, detectedStreamlets, cloudflowDockerImageName.value)
         }.value
   )


### PR DESCRIPTION
This PR implements a centralized `workDir` where we can place our internal intermediate build files.