### PR TITLE
Doc versions

### DIFF
--- a/docs/docs-source/docs/modules/ROOT/nav.adoc
+++ b/docs/docs-source/docs/modules/ROOT/nav.adoc
@@ -1,5 +1,5 @@
 
-.Cloudflow Docs - version 1.3.3
+.Cloudflow Docs - version {cloudflow-version}
 
 * xref:index.adoc[Introducing Cloudflow]
 * xref:app-development-process.adoc[The Cloudflow development process]

--- a/docs/docs-source/docs/modules/ROOT/nav.adoc
+++ b/docs/docs-source/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
-.Using Open Source Cloudflow
+
+.Cloudflow Docs - version 1.3.3
 
 * xref:index.adoc[Introducing Cloudflow]
 * xref:app-development-process.adoc[The Cloudflow development process]

--- a/docs/docs-source/docs/modules/ROOT/pages/index.adoc
+++ b/docs/docs-source/docs/modules/ROOT/pages/index.adoc
@@ -34,9 +34,9 @@ At deployment time, Cloudflow uses the blueprint to deploy all its streamlets so
 [caption="Fig. 1 - "]
 image::apps-1.png[]
 
-== Open Source feature set
+== Feature set
 
-Open-source Cloudflow includes tools for developing and deploying the most complex streaming applications:
+Cloudflow includes tools for developing and deploying the most complex streaming applications:
 
 * The Cloudflow application development toolkit includes:
 ** An API definition for `Streamlet`, the core abstraction in Cloudflow.

--- a/docs/docs-source/site.yml
+++ b/docs/docs-source/site.yml
@@ -3,16 +3,19 @@ site:
   url: https://cloudflow.io 
   
 content:
-  
   sources:
   - url: ./../../
-    start-path: docs/docs-source/docs 
+    start-path: docs/docs-source/docs
+    branches: [master]  # versioned content - add branches here
   - url: ./../../
     start-path: docs/homepage-source/docs
+    branches: [master] # should always remain as master
   - url: ./../../
     start-path: docs/shared-content-source/docs
+    branches: [master] # versioned content - add branches here
   - url: ./../../
     start-path: examples/snippets
+    branches: [master] # versioned content - add branches here
 
 ui: 
   bundle:
@@ -28,7 +31,7 @@ asciidoc:
     # the following two attributes cause review and todo notes to display
     # review: ''
     # todo: ''
-    
+    cloudflow-version: '1.3.3'
     doc-title: 'Cloudflow Guide'
 
 output:

--- a/docs/docs-source/site.yml
+++ b/docs/docs-source/site.yml
@@ -3,8 +3,7 @@ site:
   url: https://cloudflow.io 
   
 content:
-  branches: 
-    - master
+  
   sources:
   - url: ./../../
     start-path: docs/docs-source/docs 

--- a/docs/shared-content-source/docs/antora.yml
+++ b/docs/shared-content-source/docs/antora.yml
@@ -1,6 +1,6 @@
 name: shared-content
 title: ""
-version: master
+version: current
 prerelease: Beta
 
 

--- a/examples/snippets/antora.yml
+++ b/examples/snippets/antora.yml
@@ -1,3 +1,3 @@
 name: "docsnippets"
 version: current
-title: Cloudflow documentation snippets
+title: ""

--- a/examples/snippets/antora.yml
+++ b/examples/snippets/antora.yml
@@ -1,3 +1,4 @@
 name: "docsnippets"
 version: current
 title: ""
+prerelease: Beta


### PR DESCRIPTION
This PR prepares the current Antora implementation to handle multiple versions of the documentation. 
The version number is now explicit and managed at the `site.yaml` file that directs the doc build.

The next step is to make a tag of this and a new commit with our `dev` branch. 