### PR TITLE
add a 1.3.3 tag and create a dev version for the docs

### DIFF
--- a/docs/docs-source/docs/antora.yml
+++ b/docs/docs-source/docs/antora.yml
@@ -1,5 +1,5 @@
 name: docs
-version: current
+version: dev
 title: Cloudflow
 nav:
 - modules/ROOT/nav.adoc

--- a/docs/docs-source/site.yml
+++ b/docs/docs-source/site.yml
@@ -7,15 +7,18 @@ content:
   - url: ./../../
     start-path: docs/docs-source/docs
     branches: [master]  # versioned content - add branches here
+    tags: [v1.3.3-docs] # versioned content - add tags here
   - url: ./../../
     start-path: docs/homepage-source/docs
     branches: [master] # should always remain as master
   - url: ./../../
     start-path: docs/shared-content-source/docs
-    branches: [master] # versioned content - add branches here
+    branches: [master]  # versioned content - add branches here
+    tags: [v1.3.3-docs] # versioned content - add tags here
   - url: ./../../
     start-path: examples/snippets
-    branches: [master] # versioned content - add branches here
+    branches: [master]  # versioned content - add branches here
+    tags: [v1.3.3-docs] # versioned content - add tags here
 
 ui: 
   bundle:
@@ -31,7 +34,7 @@ asciidoc:
     # the following two attributes cause review and todo notes to display
     # review: ''
     # todo: ''
-    cloudflow-version: '1.3.3'
+    cloudflow-version: '2.0-SNAPSHOT'
     doc-title: 'Cloudflow Guide'
 
 output:

--- a/docs/shared-content-source/docs/antora.yml
+++ b/docs/shared-content-source/docs/antora.yml
@@ -1,6 +1,6 @@
 name: shared-content
 title: ""
-version: current
+version: dev
 prerelease: Beta
 
 

--- a/examples/snippets/antora.yml
+++ b/examples/snippets/antora.yml
@@ -1,4 +1,4 @@
 name: "docsnippets"
-version: current
+version: dev
 title: ""
 prerelease: Beta


### PR DESCRIPTION
This PR implements a fixed tag for the current release and a `dev` version for the _evolving_ `master`. 