### PR TITLE
Updated to akka 2.6.5, akka http to 10.1.11, akka-stream-contrib to 0…

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -365,17 +365,17 @@ lazy val operator =
     .settings(
       scalafmtOnCompile := true,
       libraryDependencies ++= Vector(
-            AkkaSlf4j,
-            AkkaStream,
-            Ficus,
-            Logback,
-            Skuber,
-            AkkaStreamTestkit,
-            JacksonDatabind,
-            ScalaTest,
-            ScalaCheck % "test",
-            Avro4sJson % "test"
-          )
+        AkkaSlf4j,
+        AkkaStream,
+        Ficus,
+        Logback,
+        Skuber,
+	      JacksonDatabind,
+        ScalaTest,
+        AkkaStreamTestkit % "test",
+        ScalaCheck        % "test",
+        Avro4sJson        % "test",
+      )
     )
     .settings(
       scalaVersion := "2.12.9",
@@ -385,6 +385,10 @@ lazy val operator =
       mainClass in Compile := Some("cloudflow.operator.Main"),
       publishArtifact in (Compile, packageDoc) := false,
       publishArtifact in (Compile, packageSrc) := false,
+      // skuber version 2.4.0 depends on akka-http 10.1.9 : hence overriding
+      // with akka-http 10.1.11 to use akka 2.6
+      // remove this override once skuber is updated
+      dependencyOverrides += AkkaHttp,
       buildOptions in docker := BuildOptions(
             cache = true,
             removeIntermediateContainers = BuildOptions.Remove.OnSuccess,

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -372,7 +372,6 @@ lazy val operator =
         Ficus,
         Logback,
         Skuber,
-	      JacksonDatabind,
         ScalaTest,
         AkkaStreamTestkit % "test",
         ScalaCheck        % "test",

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -322,7 +322,9 @@ lazy val plugin =
 lazy val runner =
   cloudflowModule("cloudflow-runner")
     .enablePlugins(BuildInfoPlugin, ScalafmtPlugin)
-    .dependsOn(streamlets, blueprint, events)
+    //TODO removed events for Flink Akka 2.6 conflict, will need to find a way to put it back.
+    .dependsOn(streamlets, blueprint, //events
+    )
     .settings(
       scalafmtOnCompile := true,
       libraryDependencies ++= Vector(

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -149,7 +149,6 @@ lazy val akkastreamTests =
     .settings(
       scalafmtOnCompile := true,
       libraryDependencies ++= Vector(
-            AkkaStreamTestkit,
             AkkaHttpTestkit,
             AkkaHttpSprayJsonTest,
             EmbeddedKafka % Test, 
@@ -373,7 +372,7 @@ lazy val operator =
         Skuber,
 	      JacksonDatabind,
         ScalaTest,
-        AkkaStreamTestkit,
+        AkkaStreamTestkit % "test",
         ScalaCheck        % "test",
         Avro4sJson        % "test",
       )

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -104,6 +104,7 @@ lazy val akkastreamUtil =
             AkkaHttpJackson,
             AkkaStreamContrib,
             AkkaHttpTestkit,
+            AkkaStreamTestkit,
             Logback % Test,
             AkkaHttpSprayJsonTest,
             Junit,
@@ -372,7 +373,7 @@ lazy val operator =
         Skuber,
 	      JacksonDatabind,
         ScalaTest,
-        AkkaStreamTestkit % "test",
+        AkkaStreamTestkit,
         ScalaCheck        % "test",
         Avro4sJson        % "test",
       )

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/BaseAkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/BaseAkkaStreamletTestKit.scala
@@ -21,7 +21,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import akka.actor._
-import akka.stream._
 import com.typesafe.config._
 
 import cloudflow.akkastream._
@@ -34,7 +33,6 @@ import cloudflow.streamlets._
 // Thanks to @debasish for the tip about F-bounded types in combination with self-types.
 private[testkit] abstract class BaseAkkaStreamletTestKit[Repr <: BaseAkkaStreamletTestKit[Repr]] { this: Repr ⇒
   def system: ActorSystem
-  def mat: Option[ActorMaterializer]
   def volumeMounts: List[VolumeMount]
   def config: Config
 

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
@@ -41,12 +41,11 @@ private[testkit] case class TestContext(
     volumeMounts: List[VolumeMount],
     override val config: Config = ConfigFactory.empty()
 ) extends AkkaStreamletContext {
-  //TODO reuse more from StreamletContextImpl
-  implicit def materializer     = ActorMaterializer()(system)
   private val readyPromise      = Promise[Dun]()
   private val completionPromise = Promise[Dun]()
   private val completionFuture  = completionPromise.future
   val killSwitch                = KillSwitches.shared(streamletRef)
+  implicit val sys              = system
 
   override def streamletDefinition: StreamletDefinition =
     StreamletDefinition("appId", "appVersion", streamletRef, "streamletClass", List(), volumeMounts, config)

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
@@ -76,10 +76,10 @@ object AkkaStreamletTestKit {
  * TestKitExtension.Settings.TestTimeFactor settable via akka.conf entry "akka.test.timefactor".
  *
  */
-final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem, 
-                                                        volumeMounts: List[VolumeMount] = List.empty,
-                                                        config: Config = ConfigFactory.empty())
-    extends BaseAkkaStreamletTestKit[AkkaStreamletTestKit] {
+final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
+                                                        config: Config = ConfigFactory.empty(),
+                                                        volumeMounts: List[VolumeMount] = List.empty
+) extends BaseAkkaStreamletTestKit[AkkaStreamletTestKit] {
 
   def withConfig(c: Config): AkkaStreamletTestKit = this.copy(config = c)
 

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
@@ -22,7 +22,6 @@ import collection.JavaConverters._
 import akka.NotUsed
 import akka.actor._
 import akka.japi.Pair
-import akka.stream._
 import akka.stream.javadsl._
 import com.typesafe.config._
 import cloudflow.akkastream._
@@ -32,9 +31,8 @@ import cloudflow.akkastream.testkit._
 import scala.annotation.varargs
 
 object AkkaStreamletTestKit {
-  def create(sys: ActorSystem, mat: ActorMaterializer): AkkaStreamletTestKit = AkkaStreamletTestKit(sys, Some(mat))
-  def create(sys: ActorSystem, mat: ActorMaterializer, config: Config): AkkaStreamletTestKit =
-    AkkaStreamletTestKit(sys, Some(mat), List.empty, config)
+  def create(sys: ActorSystem): AkkaStreamletTestKit                 = AkkaStreamletTestKit(sys)
+  def create(sys: ActorSystem, config: Config): AkkaStreamletTestKit = AkkaStreamletTestKit(sys, config)
 }
 
 /**
@@ -78,8 +76,7 @@ object AkkaStreamletTestKit {
  * TestKitExtension.Settings.TestTimeFactor settable via akka.conf entry "akka.test.timefactor".
  *
  */
-final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
-                                                        mat: Option[ActorMaterializer] = None,
+final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem, 
                                                         volumeMounts: List[VolumeMount] = List.empty,
                                                         config: Config = ConfigFactory.empty())
     extends BaseAkkaStreamletTestKit[AkkaStreamletTestKit] {
@@ -94,7 +91,7 @@ final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
    *
    */
   def makeInletAsTap[T](inlet: CodecInlet[T]): QueueInletTap[T] =
-    QueueInletTap[T](inlet)(mat.getOrElse(ActorMaterializer()(system)))
+    QueueInletTap[T](inlet)(system)
 
   /**
    *

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
@@ -78,8 +78,8 @@ object AkkaStreamletTestKit {
  */
 final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
                                                         config: Config = ConfigFactory.empty(),
-                                                        volumeMounts: List[VolumeMount] = List.empty
-) extends BaseAkkaStreamletTestKit[AkkaStreamletTestKit] {
+                                                        volumeMounts: List[VolumeMount] = List.empty)
+    extends BaseAkkaStreamletTestKit[AkkaStreamletTestKit] {
 
   def withConfig(c: Config): AkkaStreamletTestKit = this.copy(config = c)
 

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
@@ -42,7 +42,7 @@ object AkkaStreamletTestKit {
  *
  * {{{
  * // instantiate the testkit
- * AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system, mat);
+ * AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system);
  *
  * // setup inlet and outlet
  * SimpleFlowProcessor sfp = new SimpleFlowProcessor();
@@ -111,7 +111,7 @@ final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
    * Example (see the full example above, on the class level:
    *
    * {{{
-   * AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system, mat);
+   * AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system);
    * SimpleFlowProcessor sfp = new SimpleFlowProcessor();
    * ProbeOutletTap<Data> out = testkit.makeOutletAsTap(sfp.shape().outlet());
    *

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/InletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/InletTap.scala
@@ -17,6 +17,7 @@
 package cloudflow.akkastream.testkit.javadsl
 
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage._
 import akka.stream._
 import akka.stream.scaladsl._
@@ -33,7 +34,7 @@ case class SourceInletTap[T] private[testkit] (inlet: CodecInlet[T], src: akka.s
   private[testkit] val source = src.asScala
 }
 
-case class QueueInletTap[T](inlet: CodecInlet[T])(implicit mat: ActorMaterializer) extends InletTap[T] {
+case class QueueInletTap[T](inlet: CodecInlet[T])(implicit system: ActorSystem) extends InletTap[T] {
   private val bufferSize = 1024
   private val hub        = BroadcastHub.sink[T](bufferSize)
 

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/OutletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/OutletTap.scala
@@ -27,6 +27,8 @@ import akka.testkit.javadsl.{ TestKit ⇒ JTestKit }
 import cloudflow.streamlets._
 import cloudflow.akkastream.testkit.PartitionedValue
 
+case class Failed(e: Throwable)
+
 case class SinkOutletTap[T](outlet: CodecOutlet[T], val snk: akka.stream.javadsl.Sink[Pair[String, T], NotUsed]) extends OutletTap[T] {
   private[testkit] val sink: Sink[PartitionedValue[T], Future[Done]] =
     Flow[PartitionedValue[T]]
@@ -48,7 +50,7 @@ case class ProbeOutletTap[T](outlet: CodecOutlet[T])(implicit system: ActorSyste
       .alsoTo(
         Flow[PartitionedValue[T]]
           .map(pv ⇒ Pair(pv.key, pv.value))
-          .to(Sink.actorRef[Pair[String, T]](probe.getTestActor, Completed))
+          .to(Sink.actorRef[Pair[String, T]](probe.getTestActor, Completed, Failed))
       )
       .toMat(Sink.ignore)(Keep.right)
 }

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/AkkaStreamletTestKit.scala
@@ -37,7 +37,7 @@ object AkkaStreamletTestKit {
  *
  * {{{
  * // instantiate the testkit
- * val testkit = AkkaStreamletTestKit(system, mat)
+ * val testkit = AkkaStreamletTestKit(system)
  *
  * // setup inlet and outlet
  * val in = testkit.inletAsQueue(SimpleFlowProcessor.shape.inlet)
@@ -103,7 +103,7 @@ final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
    * Example (see the full example above, on the class level:
    *
    * {{{
-   * val testkit = AkkaStreamletTestKit(system, mat)
+   * val testkit = AkkaStreamletTestKit(system)
    * val out = testkit.outletAsProbe(SimpleFlowProcessor.shape.outlet)
    *
    * ...

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/AkkaStreamletTestKit.scala
@@ -18,7 +18,6 @@ package cloudflow.akkastream.testkit.scaladsl
 
 import akka.NotUsed
 import akka.actor._
-import akka.stream._
 import akka.stream.scaladsl._
 import com.typesafe.config._
 
@@ -27,9 +26,8 @@ import cloudflow.streamlets._
 import cloudflow.akkastream.testkit._
 
 object AkkaStreamletTestKit {
-  def apply(sys: ActorSystem, mat: ActorMaterializer): AkkaStreamletTestKit = AkkaStreamletTestKit(sys, Some(mat))
-  def apply(sys: ActorSystem, mat: ActorMaterializer, config: Config): AkkaStreamletTestKit =
-    AkkaStreamletTestKit(sys, Some(mat), List.empty, config)
+  def apply(sys: ActorSystem): AkkaStreamletTestKit                 = new AkkaStreamletTestKit(sys)
+  def apply(sys: ActorSystem, config: Config): AkkaStreamletTestKit = new AkkaStreamletTestKit(sys, config)
 }
 
 /**
@@ -71,8 +69,7 @@ object AkkaStreamletTestKit {
  * TestKitExtension.Settings.TestTimeFactor settable via akka.conf entry "akka.test.timefactor".
  *
  */
-final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
-                                                        mat: Option[ActorMaterializer] = None,
+final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem, 
                                                         volumeMounts: List[VolumeMount] = List.empty,
                                                         config: Config = ConfigFactory.empty())
     extends BaseAkkaStreamletTestKit[AkkaStreamletTestKit] {
@@ -86,7 +83,7 @@ final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
    *
    */
   def inletAsTap[T](inlet: CodecInlet[T]): QueueInletTap[T] =
-    QueueInletTap[T](inlet)(mat.getOrElse(ActorMaterializer()(system)))
+    QueueInletTap[T](inlet)(system)
 
   /**
    *

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/AkkaStreamletTestKit.scala
@@ -69,9 +69,9 @@ object AkkaStreamletTestKit {
  * TestKitExtension.Settings.TestTimeFactor settable via akka.conf entry "akka.test.timefactor".
  *
  */
-final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem, 
-                                                        volumeMounts: List[VolumeMount] = List.empty,
-                                                        config: Config = ConfigFactory.empty())
+final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
+                                                        config: Config = ConfigFactory.empty(),
+                                                        volumeMounts: List[VolumeMount] = List.empty)
     extends BaseAkkaStreamletTestKit[AkkaStreamletTestKit] {
 
   def withConfig(c: Config): AkkaStreamletTestKit = this.copy(config = c)

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/InletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/InletTap.scala
@@ -17,6 +17,7 @@
 package cloudflow.akkastream.testkit.scaladsl
 
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage._
 import akka.stream._
 import akka.stream.scaladsl._
@@ -28,7 +29,7 @@ case class SourceInletTap[T](inlet: CodecInlet[T], source: Source[(T, Committabl
   def portName = inlet.name
 }
 
-case class QueueInletTap[T](inlet: CodecInlet[T])(implicit mat: ActorMaterializer) extends InletTap[T] {
+case class QueueInletTap[T](inlet: CodecInlet[T])(implicit system: ActorSystem) extends InletTap[T] {
   private val bufferSize        = 1024
   private val hub               = BroadcastHub.sink[T](bufferSize)
   private val qSource           = Source.queue[T](bufferSize, OverflowStrategy.backpressure)

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/OutletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/OutletTap.scala
@@ -26,6 +26,8 @@ import akka.testkit.TestKit
 import cloudflow.streamlets._
 import cloudflow.akkastream.testkit.PartitionedValue
 
+case class Failed(e: Throwable)
+
 case class SinkOutletTap[T](outlet: CodecOutlet[T], val snk: Sink[(String, T), NotUsed]) extends OutletTap[T] {
   private[testkit] val sink: Sink[PartitionedValue[T], Future[Done]] =
     Flow[PartitionedValue[T]]
@@ -47,7 +49,7 @@ case class ProbeOutletTap[T](outlet: CodecOutlet[T])(implicit system: ActorSyste
       .alsoTo(
         Flow[PartitionedValue[T]]
           .map(pv ⇒ (pv.key, pv.value))
-          .to(Sink.actorRef[Tuple2[String, T]](probe.testActor, Completed))
+          .to(Sink.actorRef[Tuple2[String, T]](probe.testActor, Completed, Failed))
       )
       .toMat(Sink.ignore)(Keep.right)
 }

--- a/core/cloudflow-akka-testkit/src/test/java/cloudflow/akkastream/testkit/JavaDslTest.java
+++ b/core/cloudflow-akka-testkit/src/test/java/cloudflow/akkastream/testkit/JavaDslTest.java
@@ -24,17 +24,14 @@ import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
 import akka.testkit.TestKit;
 
 public abstract class JavaDslTest extends JUnitSuite {
-  static ActorMaterializer mat;
   static ActorSystem system;
 
   @BeforeClass
   public static void setUp() throws Exception {
     system = ActorSystem.create();
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass

--- a/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
+++ b/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
@@ -22,7 +22,6 @@ import akka.japi.Pair;
 import akka.kafka.ConsumerMessage;
 import akka.kafka.ConsumerMessage.CommittableOffset;
 import akka.kafka.ConsumerMessage.Committable;
-import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;
 import akka.testkit.TestKit;
 import cloudflow.akkastream.*;
@@ -42,13 +41,11 @@ import java.nio.file.StandardOpenOption;
 import java.util.UUID;
 
 public class AkkaStreamletTest extends JUnitSuite {
-  static ActorMaterializer mat;
   static ActorSystem system;
 
   @BeforeClass
   public static void setUp() throws Exception {
     system = ActorSystem.create();
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
@@ -60,7 +57,7 @@ public class AkkaStreamletTest extends JUnitSuite {
   @Test
   public void anAkkaStreamletShouldProcessDataWhenItIsRun() {
     TestProcessor streamlet = new TestProcessor();
-    AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system, mat);
+    AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system);
 
     QueueInletTap<Data> in = testkit.makeInletAsTap(streamlet.inlet);
     ProbeOutletTap<Data> out = testkit.makeOutletAsTap(streamlet.outlet);
@@ -84,7 +81,7 @@ public class AkkaStreamletTest extends JUnitSuite {
   public void anAkkaStreamletShouldBeAbleToDefineAndUseConfigurationParameters() {
     TestConfigParametersProcessor streamlet = new TestConfigParametersProcessor();
     AkkaStreamletTestKit testkit =
-        AkkaStreamletTestKit.create(system, mat)
+        AkkaStreamletTestKit.create(system)
             .withConfigParameterValues(ConfigParameterValue.create(nameFilter, "b"));
 
     QueueInletTap<Data> in = testkit.makeInletAsTap(streamlet.inlet);
@@ -193,7 +190,7 @@ public class AkkaStreamletTest extends JUnitSuite {
                             return dataIn;
                           }))
               .to(getCommittableSink(outlet))
-              .run(materializer());
+              .run(system());
         }
       };
     }
@@ -223,7 +220,7 @@ public class AkkaStreamletTest extends JUnitSuite {
           getSourceWithCommittableContext(inlet)
               .filter(data -> data.name().equals(configuredNameToFilterFor))
               .to(getCommittableSink(outlet))
-              .run(materializer());
+              .run(system());
         }
       };
     }

--- a/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
+++ b/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/javadsl/AkkaStreamletTest.java
@@ -107,7 +107,7 @@ public class AkkaStreamletTest extends JUnitSuite {
     Path mountPath = Files.createTempFile("test", UUID.randomUUID().toString());
     FileWritingProcessor streamlet = new FileWritingProcessor(volumeMountName);
     AkkaStreamletTestKit testkit =
-        AkkaStreamletTestKit.create(system, mat)
+        AkkaStreamletTestKit.create(system)
             .withVolumeMounts(
                 VolumeMount.createReadWriteMany(volumeMountName, mountPath.toString()));
 
@@ -148,7 +148,7 @@ public class AkkaStreamletTest extends JUnitSuite {
           getSourceWithCommittableContext(inlet)
               .via(Flow.<Pair<Data, Committable>>create()) // no-op flow
               .to(getCommittableSink(outlet))
-              .run(materializer());
+              .run(system());
         }
       };
     }

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletSpec.scala
@@ -133,7 +133,7 @@ class AkkaStreamletSpec extends WordSpec with MustMatchers with BeforeAndAfterAl
       Files.write(filePath, expectedDataOut.name.getBytes())
 
       val volumeMountTestKit =
-        AkkaStreamletTestKit(system, mat).withVolumeMounts(VolumeMount(volumeMountName, filePath.toAbsolutePath.toString, ReadOnlyMany))
+        AkkaStreamletTestKit(system).withVolumeMounts(VolumeMount(volumeMountName, filePath.toAbsolutePath.toString, ReadOnlyMany))
       val out = volumeMountTestKit.outletAsTap(VolumeMountTestProcessor.out)
 
       volumeMountTestKit.run(

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletSpec.scala
@@ -24,7 +24,6 @@ import scala.concurrent.duration._
 
 import akka.NotUsed
 import akka.actor._
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.testkit._
 
@@ -40,13 +39,12 @@ import cloudflow.akkastream.testkit.scaladsl._
 class AkkaStreamletSpec extends WordSpec with MustMatchers with BeforeAndAfterAll {
 
   private implicit val system = ActorSystem("AkkaStreamletSpec")
-  private implicit val mat    = ActorMaterializer()
   val timeout                 = 10.seconds.dilated
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)
 
   "An AkkaStreamlet" should {
-    val testkit = AkkaStreamletTestKit(system, mat)
+    val testkit = AkkaStreamletTestKit(system)
 
     "Allow for querying of configuration parameters" in {
       object ConfigTestProcessor extends AkkaStreamlet {
@@ -67,7 +65,7 @@ class AkkaStreamletSpec extends WordSpec with MustMatchers with BeforeAndAfterAl
       }
 
       val configTestKit =
-        AkkaStreamletTestKit(system, mat)
+        AkkaStreamletTestKit(system)
           .withConfigParameterValues(ConfigParameterValue(ConfigTestProcessor.NameFilter, "b"))
 
       val data   = Vector(Data(1, "a"), Data(2, "b"), Data(3, "c"))
@@ -96,7 +94,7 @@ class AkkaStreamletSpec extends WordSpec with MustMatchers with BeforeAndAfterAl
         }
       }
 
-      val configTestKit = AkkaStreamletTestKit(system, mat)
+      val configTestKit = AkkaStreamletTestKit(system)
 
       val data   = Vector(Data(1, "a"), Data(2, "b"), Data(3, "c"))
       val source = Source(data)

--- a/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/HttpServerSpec.scala
+++ b/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/HttpServerSpec.scala
@@ -18,7 +18,6 @@ package cloudflow.akkastream.util.scaladsl
 
 import scala.concurrent.duration._
 import akka.actor._
-import akka.stream.ActorMaterializer
 import akka.http.scaladsl._
 import akka.http.scaladsl.client.RequestBuilding._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -46,7 +45,6 @@ import cloudflow.akkastream.testkit.scaladsl._
 class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll {
 
   private implicit val system = ActorSystem("HttpServerSpec")
-  private implicit val mat    = ActorMaterializer()
 
   import system.dispatcher
 
@@ -65,6 +63,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
         val request  = HttpRequest(method, Uri(s"http://127.0.0.1:$port"), Nil, HttpEntity.Empty)
         val response = Http().singleRequest(request).futureValue
         response.status mustEqual StatusCodes.MethodNotAllowed
+        response.entity.discardBytes()
         out.probe.expectNoMessage(noMessageDuration)
       }
     }
@@ -75,6 +74,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       val request  = Post(s"http://127.0.0.1:$port", data)
       val response = Http().singleRequest(request).futureValue
       response.status mustEqual StatusCodes.Accepted
+      response.entity.discardBytes()
       out.probe.expectMsg(("1", data))
       out.probe.expectMsg(Completed)
     }
@@ -84,6 +84,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       val request  = Post(s"http://127.0.0.1:$port")
       val response = Http().singleRequest(request).futureValue
       response.status mustEqual StatusCodes.BadRequest
+      response.entity.discardBytes()
     }
 
     "accept data using a custom route" in {
@@ -91,6 +92,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       val data     = Data(42, "a")
       val request  = Put(s"http://127.0.0.1:$port", data)
       val response = Http().singleRequest(request).futureValue
+      response.entity.discardBytes()
       response.status mustEqual StatusCodes.OK
       out.probe.expectMsg(("42", data))
       out.probe.expectMsg(Completed)
@@ -99,6 +101,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
       val badRequest  = Put(s"http://127.0.0.1:$port", badData)
       val badResponse = Http().singleRequest(badRequest).futureValue
       badResponse.status mustEqual StatusCodes.BadRequest
+      badResponse.entity.discardBytes()
       out.probe.expectNoMessage(noMessageDuration)
     }
 
@@ -143,7 +146,7 @@ class HttpServerSpec extends WordSpec with MustMatchers with ScalaFutures with B
   }
 
   def startIngress(ingress: AkkaStreamlet = createDefaultIngress): Unit = {
-    val testkit = AkkaStreamletTestKit(system, mat)
+    val testkit = AkkaStreamletTestKit(system)
 
     out = testkit.outletAsTap(outlet)
     port = getFreePort()

--- a/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/MergeSpec.scala
+++ b/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/MergeSpec.scala
@@ -19,7 +19,6 @@ package cloudflow.akkastream.util.scaladsl
 import scala.collection.JavaConverters._
 
 import akka.actor._
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.testkit._
 import org.scalatest._
@@ -31,17 +30,17 @@ import cloudflow.akkastream._
 import cloudflow.akkastream.scaladsl._
 import cloudflow.akkastream.testdata._
 import cloudflow.akkastream.testkit.scaladsl._
+
 class MergeSpec extends WordSpec with MustMatchers with ScalaFutures with BeforeAndAfterAll {
 
   private implicit val system = ActorSystem("MergeSpec")
-  private implicit val mat    = ActorMaterializer()
 
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)
 
   "An MergeStreamlet" should {
 
-    val testkit = AkkaStreamletTestKit(system, mat)
+    val testkit = AkkaStreamletTestKit(system)
     def createScalaMergeStreamlet(inletCount: Int): TestMerge =
       new ScalaTestMerge(inletCount)
 

--- a/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/SplitterSpec.scala
+++ b/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/SplitterSpec.scala
@@ -17,7 +17,6 @@
 package cloudflow.akkastream.util.scaladsl
 
 import akka.actor._
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.testkit._
 import org.scalatest._
@@ -32,7 +31,6 @@ import cloudflow.akkastream.testdata._
 
 class SplitterSpec extends WordSpec with MustMatchers with ScalaFutures with BeforeAndAfterAll {
   private implicit val system = ActorSystem("SplitterSpec")
-  private implicit val mat    = ActorMaterializer()
 
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)
@@ -55,7 +53,7 @@ class SplitterSpec extends WordSpec with MustMatchers with ScalaFutures with Bef
 
   "A Splitter" should {
     "split incoming data according to a splitter flow" in {
-      val testkit = AkkaStreamletTestKit(system, mat)
+      val testkit = AkkaStreamletTestKit(system)
       val source  = Source(Vector(Data(1, "a"), Data(2, "b")))
 
       val in    = testkit.inletFromSource(MyPartitioner.in, source)

--- a/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/SplitterSpec.scala
+++ b/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/SplitterSpec.scala
@@ -47,7 +47,7 @@ class SplitterSpec extends WordSpec with MustMatchers with ScalaFutures with Bef
       }
 
       def runnableGraph =
-        sourceWithOffsetContext(in).to(Splitter.sink(flow, left, right))
+        sourceWithCommittableContext(in).to(Splitter.sink(flow, left, right))
     }
   }
 

--- a/core/cloudflow-akka/src/main/resources/akka-cluster-k8.conf
+++ b/core/cloudflow-akka/src/main/resources/akka-cluster-k8.conf
@@ -29,16 +29,16 @@ akka {
   }
 
   remote {
-    netty.tcp {
-      hostname = ""
-      port = 2551
-      bind-hostname = "0.0.0.0"
-      bind-port = 2551
+    artery {
+      transport = tcp # See Selecting a transport below
+      canonical.hostname = ""
+      canonical.port = 25520
+      bind.hostname = "0.0.0.0"
+      bind.port = 25520
     }
   }
 
   discovery {
     method = kubernetes-api
   }
-
 }

--- a/core/cloudflow-akka/src/main/resources/akka-cluster-k8.conf
+++ b/core/cloudflow-akka/src/main/resources/akka-cluster-k8.conf
@@ -31,7 +31,7 @@ akka {
   remote {
     artery {
       transport = tcp # See Selecting a transport below
-      canonical.hostname = ""
+      canonical.hostname = "<getHostAddress>"
       canonical.port = 25520
       bind.hostname = "0.0.0.0"
       bind.port = 25520

--- a/core/cloudflow-akka/src/main/resources/akka-cluster-local.conf
+++ b/core/cloudflow-akka/src/main/resources/akka-cluster-local.conf
@@ -12,12 +12,14 @@ akka {
     log-info = on
     shutdown-after-unsuccessful-join-seed-nodes = 60s
 
-    seed-nodes = ["akka.tcp://akka_streamlet@"${akka.remote.netty.tcp.hostname}":"${akka.remote.netty.tcp.port}]
+    seed-nodes = ["akka://akka_streamlet@"${akka.remote.artery.canonical.hostname}":"${akka.remote.artery.canonical.port}]
   }
 
   remote {
-    netty.tcp {
-      hostname = "127.0.0.1"
+    artery {
+      transport = tcp # See Selecting a transport below
+      canonical.hostname = "127.0.0.1"
+      canonical.port = 25520
     }
   }
 }

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -22,7 +22,6 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage.{ Committable, CommittableOffset }
 import akka.kafka.CommitterSettings
-import akka.stream._
 import akka.stream.scaladsl._
 import cloudflow.streamlets._
 
@@ -66,11 +65,6 @@ trait AkkaStreamletContext extends StreamletContext {
    * The system in which the AkkaStreamlet will be run.
    */
   implicit def system: ActorSystem
-
-  /**
-   * The Materializer used when the AkkaStreamlet is run.
-   */
-  implicit def materializer: Materializer
 
   private[akkastream] def streamletExecution: StreamletExecution
 

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -47,8 +47,6 @@ final class AkkaStreamletContextImpl(
 ) extends AkkaStreamletContext {
   implicit val system: ActorSystem = sys
 
-  implicit def materializer = ActorMaterializer()(system)
-
   override def config: Config = streamletDefinition.config
 
   private val readyPromise      = Promise[Dun]()

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
@@ -20,7 +20,6 @@ import java.nio.file.Path
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream._
 import akka.stream.scaladsl._
 
 import akka.kafka._
@@ -60,7 +59,7 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
    * Java API
    * Launch the execution of the graph.
    */
-  final def runGraph[T](graph: akka.stream.javadsl.RunnableGraph[T]): T = graph.run(materializer)
+  final def runGraph[T](graph: akka.stream.javadsl.RunnableGraph[T]): T = graph.run(system)
 
   /**
    * Signals that the streamlet is ready to process data.
@@ -79,16 +78,6 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
    * Java API
    */
   def getSystem() = system
-
-  /**
-   * The Materializer that will be used for materializing akka stream graphs.
-   */
-  implicit final val materializer: Materializer = context.materializer
-
-  /**
-   * Java API
-   */
-  def getMaterializer() = materializer
 
   /**
    * The default ExecutionContext of the ActorSystem (the system dispatcher).

--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/ApplicationDescriptorSpec.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/ApplicationDescriptorSpec.scala
@@ -1,4 +1,20 @@
- /*
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
  * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/ApplicationDescriptorSpec.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/ApplicationDescriptorSpec.scala
@@ -1,20 +1,4 @@
-/*
- * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
+ /*
  * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/HealthChecks.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/HealthChecks.scala
@@ -22,10 +22,9 @@ import akka.actor._
 import akka.http.scaladsl._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
-import akka.stream._
 
 object HealthChecks {
-  def serve(settings: Settings)(implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext) =
+  def serve(settings: Settings)(implicit system: ActorSystem, ec: ExecutionContext) =
     Http()
       .bindAndHandle(
         route,

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
@@ -39,7 +39,6 @@ object Main extends {
     implicit val system = ActorSystem()
 
     try {
-      implicit val mat = createMaterializer()
       implicit val ec  = system.dispatcher
       val settings     = Settings(system)
       implicit val ctx = settings.deploymentContext
@@ -105,13 +104,6 @@ object Main extends {
   }
 
   private def exitWithFailure() = System.exit(-1)
-
-  private def createMaterializer()(implicit system: ActorSystem) = {
-    val decider: Supervision.Decider = {
-      case _ ⇒ Supervision.Stop
-    }
-    ActorMaterializer(ActorMaterializerSettings(system).withSupervisionStrategy(decider))
-  }
 
   private def installCRD(client: skuber.api.client.KubernetesClient)(implicit ec: ExecutionContext): Unit = {
     val crdTimeout = 20.seconds

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Operator.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Operator.scala
@@ -54,6 +54,12 @@ object Operator {
 
   val MaxObjectBufSize = 8 * 1024 * 1024
 
+  val decider: Supervision.Decider = {
+    case _ ⇒ Supervision.Stop
+  }
+
+  val StreamAttributes = ActorAttributes.supervisionStrategy(decider)
+
   def handleAppEvents(
       client: KubernetesClient
   )(implicit system: ActorSystem, mat: Materializer, ec: ExecutionContext, ctx: DeploymentContext) = {
@@ -144,7 +150,7 @@ object Operator {
     val eventsResult = getCurrentEvents[O](client, options)
 
     Source
-      .fromFuture(eventsResult)
+      .future(eventsResult)
       .mapConcat(identity)
       .concat(
         client
@@ -180,7 +186,7 @@ object Operator {
       unexpectedCompletionMsg: String,
       errorMsg: String
   )(implicit system: ActorSystem, mat: Materializer, ec: ExecutionContext) =
-    graph.run.onComplete {
+    graph.withAttributes(StreamAttributes).run.onComplete {
       case Success(_) ⇒
         system.log.warning(unexpectedCompletionMsg)
         system.registerOnTermination(exitWithFailure)

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
@@ -320,10 +320,11 @@ object FlinkResource {
   implicit val namePathSecretTypeFmt: Format[NamePathSecretType] = Json.format[NamePathSecretType]
   implicit val resourceRequsetsFmt: Format[ResourceRequests]     = Json.format[ResourceRequests]
   implicit val resourceLimitsFmt: Format[ResourceLimits]         = Json.format[ResourceLimits]
-  implicit val resourcesFmt: Format[Resources]                   = Json.format[Resources]
   implicit val envConfigFmt: Format[EnvConfig]                   = Json.format[EnvConfig]
+  implicit val resourcesFmt: Format[Resources]                   = Json.format[Resources]
 
   implicit val jobManagerFmt: Format[JobManagerConfig]   = Json.format[JobManagerConfig]
+  implicit val jobManagerInfoFmt: Format[JobManagerInfo] = Json.format[JobManagerInfo]
   implicit val taskManagerFmt: Format[TaskManagerConfig] = Json.format[TaskManagerConfig]
 
   implicit val specFmt: Format[Spec]                         = Json.format[Spec]

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
@@ -329,7 +329,6 @@ object FlinkResource {
 
   implicit val specFmt: Format[Spec]                         = Json.format[Spec]
   implicit val applicationStateFmt: Format[ApplicationState] = Json.format[ApplicationState]
-  implicit val jobManagerInfoFmt: Format[JobManagerInfo]     = Json.format[JobManagerInfo]
   implicit val statusFmt: Format[Status]                     = Json.format[Status]
 
   final case class EnvConfig(env: Option[List[EnvVar]])

--- a/core/cloudflow-runner/src/main/scala/cloudflow/runner/Runner.scala
+++ b/core/cloudflow-runner/src/main/scala/cloudflow/runner/Runner.scala
@@ -25,7 +25,8 @@ import org.slf4j.LoggerFactory
 import com.typesafe.config.Config
 import cloudflow.streamlets._
 import RunnerOps._
-import cloudflow.events.errors.ErrorEvents
+// TODO removed for Flink Akka 2.6 conflict. Need to find another way to do this.
+//import cloudflow.events.errors.ErrorEvents
 
 /**
  * Runner for cluster deployments. Assumes Linux-style paths!
@@ -77,10 +78,12 @@ object Runner extends RunnerConfigResolver with StreamletLoader {
           shutdown(loadedStreamlet)
         } catch {
           case ex @ ExceptionAcc(exceptions) ⇒
-            exceptions.foreach(ErrorEvents.report(loadedStreamlet, withPodRuntimeConfig, _))
+            // TODO removed for Flink Akka conflict. Need to think of another way to do this.
+            // exceptions.foreach(ErrorEvents.report(loadedStreamlet, withPodRuntimeConfig, _))
             shutdown(loadedStreamlet, Some(ex))
           case ex: Throwable =>
-            ErrorEvents.report(loadedStreamlet, withPodRuntimeConfig, ex)
+            //TODO removed for Flink Akka. Need to think of another way to do this.
+            // ErrorEvents.report(loadedStreamlet, withPodRuntimeConfig, ex)
             shutdown(loadedStreamlet, Some(ex))
         }
       case Failure(ex) ⇒ throw new Exception(ex)

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -38,8 +38,7 @@ object Library {
   val SprayJson              = "io.spray"              %% "spray-json"               % "1.3.5"
   val Bijection              = "com.twitter"           %% "bijection-avro"           % "0.9.6"
 
-  val JacksonScalaModule    = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.0"
-  val JacksonDatabind       = "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9.1"
+  val JacksonScalaModule    = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.4"
 
   val Skuber                 = "io.skuber"             %% "skuber"                   % "2.4.0" exclude("com.fasterxml.jackson.core","jackson-databind")
 

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -22,6 +22,8 @@ object Library {
   val AkkaStreamContrib     = "com.typesafe.akka"     %% "akka-stream-contrib"       % "0.10"
   val AkkaStreamKafka       = "com.typesafe.akka"     %% "akka-stream-kafka"         % Version.AlpakkaKafka exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.fasterxml.jackson.module", "jackson-module-scala")
   val AkkaStreamKafkaTestkit = "com.typesafe.akka"    %% "akka-stream-kafka-testkit" % Version.AlpakkaKafka exclude("com.typesafe.akka", "akka-stream-testkit")
+  val AkkaStreamTestkit      = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka         
+  
   val AkkaCluster           = "com.typesafe.akka"     %% "akka-cluster"              % Version.Akka
   val AkkaManagement        = "com.lightbend.akka.management" %% "akka-management"   % Version.AkkaMgmt
   val AkkaClusterBootstrap   = "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % Version.AkkaMgmt
@@ -60,7 +62,6 @@ object Library {
   // Test Dependencies
   val AkkaHttpTestkit        = "com.typesafe.akka"   %% "akka-http-testkit"          % Version.AkkaHttp     % Test
   val AkkaHttpSprayJsonTest  = AkkaHttpSprayJson                                                            % Test
-  val AkkaStreamTestkit      = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka         % Test 
   val Avro4sTest             = "com.sksamuel.avro4s" %% "avro4s-core"                % "3.0.0"              % Test
   val AkkaTestkit            = "com.typesafe.akka"   %% "akka-testkit"               % Version.Akka
   val ScalaTest              = ScalaTestUnscoped                                                            % Test

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -60,6 +60,7 @@ object Library {
   // Test Dependencies
   val AkkaHttpTestkit        = "com.typesafe.akka"   %% "akka-http-testkit"          % Version.AkkaHttp     % Test
   val AkkaHttpSprayJsonTest  = AkkaHttpSprayJson                                                            % Test
+  val AkkaStreamTestkit      = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka         % Test 
   val Avro4sTest             = "com.sksamuel.avro4s" %% "avro4s-core"                % "3.0.0"              % Test
   val AkkaTestkit            = "com.typesafe.akka"   %% "akka-testkit"               % Version.Akka
   val ScalaTest              = ScalaTestUnscoped                                                            % Test

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 // format: OFF
 object Version {
-  val Akka         = "2.5.29"
-  val AkkaHttp     = "10.1.9"
+  val Akka         = "2.6.5"
+  val AkkaHttp     = "10.1.11"
   val AkkaMgmt     = "1.0.3"
   val AlpakkaKafka = "2.0.2"
   val Scala        = "2.12.9"
@@ -33,34 +33,33 @@ object Library {
   val Config                = "com.typesafe"           % "config"                   % "1.3.4"
   val Logback               = "ch.qos.logback"         % "logback-classic"          % "1.2.3"
 
-  val SprayJson             = "io.spray"              %% "spray-json"               % "1.3.5"
-  val Bijection             = "com.twitter"           %% "bijection-avro"           % "0.9.6"
+  val SprayJson              = "io.spray"              %% "spray-json"               % "1.3.5"
+  val Bijection              = "com.twitter"           %% "bijection-avro"           % "0.9.6"
 
   val JacksonScalaModule    = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.0"
   val JacksonDatabind       = "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.9.9.1"
 
-  val Skuber                = "io.skuber"             %% "skuber"                   % "2.4.0" exclude("com.fasterxml.jackson.core","jackson-databind")
+  val Skuber                 = "io.skuber"             %% "skuber"                   % "2.4.0" exclude("com.fasterxml.jackson.core","jackson-databind")
 
-  val Spark                 = "org.apache.spark"      %% "spark-core"               % Version.Spark
-  val SparkMllib            = "org.apache.spark"      %% "spark-mllib"              % Version.Spark
-  val SparkSql              = "org.apache.spark"      %% "spark-sql"                % Version.Spark
-  val SparkSqlKafka         = "org.apache.spark"      %% "spark-sql-kafka-0-10"     % Version.Spark
-  val SparkStreaming        = "org.apache.spark"      %% "spark-streaming"          % Version.Spark
-  val ScalaTestUnscoped     = "org.scalatest"         %% "scalatest"                % "3.0.8"
+  val Spark                  = "org.apache.spark"      %% "spark-core"               % Version.Spark
+  val SparkMllib             = "org.apache.spark"      %% "spark-mllib"              % Version.Spark
+  val SparkSql               = "org.apache.spark"      %% "spark-sql"                % Version.Spark
+  val SparkSqlKafka          = "org.apache.spark"      %% "spark-sql-kafka-0-10"     % Version.Spark
+  val SparkStreaming         = "org.apache.spark"      %% "spark-streaming"          % Version.Spark
+  val ScalaTestUnscoped      = "org.scalatest"         %% "scalatest"                % "3.0.8"
 
-  val Flink                 = "org.apache.flink"      %% "flink-scala"              % Version.Flink
-  val FlinkStreaming        = "org.apache.flink"      %% "flink-streaming-scala"    % Version.Flink
-  val FlinkAvro             = "org.apache.flink"       % "flink-avro"               % Version.Flink
-  val FlinkKafka            = "org.apache.flink"      %% "flink-connector-kafka"    % Version.Flink
+  val Flink                  = "org.apache.flink"      %% "flink-scala"              % Version.Flink
+  val FlinkStreaming         = "org.apache.flink"      %% "flink-streaming-scala"    % Version.Flink
+  val FlinkAvro              = "org.apache.flink"       % "flink-avro"               % Version.Flink
+  val FlinkKafka             = "org.apache.flink"      %% "flink-connector-kafka"    % Version.Flink
 
-  val FastClasspathScanner  = "io.github.lukehutch"   %  "fast-classpath-scanner"   % "2.21"
-  val ScalaCheck            = "org.scalacheck"        %% "scalacheck"               % "1.14.0"
-  val Avro4sJson            = "com.sksamuel.avro4s"   %% "avro4s-json"              % "3.0.0"
+  val FastClasspathScanner   = "io.github.lukehutch"   %  "fast-classpath-scanner"   % "2.21"
+  val ScalaCheck             = "org.scalacheck"        %% "scalacheck"               % "1.14.0"
+  val Avro4sJson             = "com.sksamuel.avro4s"   %% "avro4s-json"              % "3.0.0"
 
   // Test Dependencies
   val AkkaHttpTestkit        = "com.typesafe.akka"   %% "akka-http-testkit"          % Version.AkkaHttp     % Test
   val AkkaHttpSprayJsonTest  = AkkaHttpSprayJson                                                            % Test
-  val AkkaStreamTestkit      = "com.typesafe.akka"   %% "akka-stream-testkit"        % Version.Akka         % Test 
   val Avro4sTest             = "com.sksamuel.avro4s" %% "avro4s-core"                % "3.0.0"              % Test
   val AkkaTestkit            = "com.typesafe.akka"   %% "akka-testkit"               % Version.Akka
   val ScalaTest              = ScalaTestUnscoped                                                            % Test

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 // format: OFF
 object Version {
   val Akka         = "2.6.5"
-  val AkkaHttp     = "10.1.11"
-  val AkkaMgmt     = "1.0.3"
+  val AkkaHttp     = "10.1.10"
+  val AkkaMgmt     = "1.0.6"
   val AlpakkaKafka = "2.0.2"
   val Scala        = "2.12.9"
   val Spark        = "2.4.5"
@@ -26,7 +26,7 @@ object Library {
   
   val AkkaCluster           = "com.typesafe.akka"     %% "akka-cluster"              % Version.Akka
   val AkkaManagement        = "com.lightbend.akka.management" %% "akka-management"   % Version.AkkaMgmt
-  val AkkaClusterBootstrap   = "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % Version.AkkaMgmt
+  val AkkaClusterBootstrap  = "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % Version.AkkaMgmt
   val AkkaDiscovery         = "com.typesafe.akka"     %% "akka-discovery"            % Version.Akka
   val AkkaDiscoveryK8       = "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % Version.AkkaMgmt
   val EmbeddedKafkaOrg      = "io.github.embeddedkafka"
@@ -38,7 +38,7 @@ object Library {
   val SprayJson              = "io.spray"              %% "spray-json"               % "1.3.5"
   val Bijection              = "com.twitter"           %% "bijection-avro"           % "0.9.6"
 
-  val JacksonScalaModule    = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.4"
+  val JacksonScalaModule     = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.4"
 
   val Skuber                 = "io.skuber"             %% "skuber"                   % "2.4.0" exclude("com.fasterxml.jackson.core","jackson-databind")
 

--- a/core/sbt-cloudflow/src/test/scala/cloudflow/sbt/StreamletScannerSpec.scala
+++ b/core/sbt-cloudflow/src/test/scala/cloudflow/sbt/StreamletScannerSpec.scala
@@ -26,7 +26,7 @@ final class StreamletScannerSpec extends WordSpec with TryValues with OptionValu
     val classLoader       = this.getClass.getClassLoader
     val results           = StreamletScanner.scan(classLoader)
     val (valid, invalid)  = results.partition { case (_, triedDiscoveredStreamlet) ⇒ triedDiscoveredStreamlet.isSuccess }
-    val validStreamlets   = valid.map { case (k, Success(discovered)) ⇒ (k, discovered) }
+    val validStreamlets   = valid.collect { case (k, Success(discovered)) ⇒ (k, discovered) }
     val invalidStreamlets = invalid.toMap
 
     // These are all valid streamlets defined in TestStreamlets.scala

--- a/examples/call-record-aggregator/akka-cdr-ingestor/src/test/scala/carly/ingestor/CallRecordMergeSpec.scala
+++ b/examples/call-record-aggregator/akka-cdr-ingestor/src/test/scala/carly/ingestor/CallRecordMergeSpec.scala
@@ -20,7 +20,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 import akka.actor._
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.testkit._
 import org.scalatest._
@@ -32,19 +31,17 @@ import carly.data._
 class CallRecordMergeSpec extends WordSpec with MustMatchers with ScalaFutures with BeforeAndAfterAll {
 
   private implicit val system = ActorSystem("CallRecordMergeSpec")
-  private implicit val mat = ActorMaterializer()
 
-  override def afterAll: Unit = {
+  override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)
-  }
 
   "A CallRecordMerge" should {
     "merge incoming data" in {
-      val testkit = AkkaStreamletTestKit(system, mat)
+      val testkit   = AkkaStreamletTestKit(system)
       val streamlet = new CallRecordMerge
 
       val instant = Instant.now.toEpochMilli / 1000
-      val past = Instant.now.minus(5000, ChronoUnit.DAYS).toEpochMilli / 1000
+      val past    = Instant.now.minus(5000, ChronoUnit.DAYS).toEpochMilli / 1000
 
       val cr1 = CallRecord("user-1", "user-2", "f", 10L, instant)
       val cr2 = CallRecord("user-1", "user-2", "f", 15L, instant)
@@ -54,27 +51,32 @@ class CallRecordMergeSpec extends WordSpec with MustMatchers with ScalaFutures w
       val source1 = Source(Vector(cr2))
       val source2 = Source(Vector(cr3))
 
-      val in0 = testkit.inletFromSource(streamlet.in0, source0)
-      val in1 = testkit.inletFromSource(streamlet.in1, source1)
-      val in2 = testkit.inletFromSource(streamlet.in2, source2)
-      val left = testkit.outletAsTap(streamlet.left)
+      val in0   = testkit.inletFromSource(streamlet.in0, source0)
+      val in1   = testkit.inletFromSource(streamlet.in1, source1)
+      val in2   = testkit.inletFromSource(streamlet.in2, source2)
+      val left  = testkit.outletAsTap(streamlet.left)
       val right = testkit.outletAsTap(streamlet.right)
 
-      testkit.run(streamlet, List(in0, in1, in2), List(left, right), () ⇒ {
-        right.probe.expectMsg(("user-1", cr1))
-        right.probe.expectMsg(("user-1", cr2))
-        right.probe.expectMsg(("user-1", cr3))
-      })
+      testkit.run(
+        streamlet,
+        List(in0, in1, in2),
+        List(left, right),
+        () ⇒ {
+          right.probe.expectMsg(("user-1", cr1))
+          right.probe.expectMsg(("user-1", cr2))
+          right.probe.expectMsg(("user-1", cr3))
+        }
+      )
 
       right.probe.expectMsg(Completed)
     }
 
     "split incoming data into valid call records and those outside the time range" in {
-      val testkit = AkkaStreamletTestKit(system, mat)
+      val testkit   = AkkaStreamletTestKit(system)
       val streamlet = new CallRecordMerge()
 
       val instant = Instant.now.toEpochMilli / 1000
-      val past = Instant.now.minus(5000, ChronoUnit.DAYS).toEpochMilli / 1000
+      val past    = Instant.now.minus(5000, ChronoUnit.DAYS).toEpochMilli / 1000
 
       val cr1 = CallRecord("user-1", "user-2", "f", 10L, instant)
       val cr2 = CallRecord("user-1", "user-2", "f", 15L, instant)
@@ -90,20 +92,24 @@ class CallRecordMergeSpec extends WordSpec with MustMatchers with ScalaFutures w
       val in1 = testkit.inletFromSource(streamlet.in1, source1)
       val in2 = testkit.inletFromSource(streamlet.in2, source2)
 
-      val left = testkit.outletAsTap(streamlet.left)
+      val left  = testkit.outletAsTap(streamlet.left)
       val right = testkit.outletAsTap(streamlet.right)
 
-      testkit.run(streamlet, List(in0, in1, in2), List(left, right), () ⇒ {
-        right.probe.expectMsg(("user-1", cr1))
-        right.probe.expectMsg(("user-1", cr2))
-        right.probe.expectMsg(("user-1", cr3))
-        left.probe.expectMsg((cr4.toString, InvalidRecord(cr4.toString, "Timestamp outside range!")))
-        left.probe.expectMsg((cr5.toString, InvalidRecord(cr5.toString, "Timestamp outside range!")))
-      })
+      testkit.run(
+        streamlet,
+        List(in0, in1, in2),
+        List(left, right),
+        () ⇒ {
+          right.probe.expectMsg(("user-1", cr1))
+          right.probe.expectMsg(("user-1", cr2))
+          right.probe.expectMsg(("user-1", cr3))
+          left.probe.expectMsg((cr4.toString, InvalidRecord(cr4.toString, "Timestamp outside range!")))
+          left.probe.expectMsg((cr5.toString, InvalidRecord(cr5.toString, "Timestamp outside range!")))
+        }
+      )
 
       left.probe.expectMsg(Completed)
       right.probe.expectMsg(Completed)
     }
   }
 }
-

--- a/examples/call-record-aggregator/build.sbt
+++ b/examples/call-record-aggregator/build.sbt
@@ -26,7 +26,6 @@ lazy val callRecordPipeline = appModule("call-record-pipeline")
   .settings(
     name := "call-record-aggregator"
   )
-  .dependsOn(akkaCdrIngestor, akkaJavaAggregationOutput, sparkAggregation)
 //end::docs-CloudflowApplicationPlugin-example[]
 
 lazy val datamodel = appModule("datamodel")

--- a/examples/call-record-aggregator/build.sbt
+++ b/examples/call-record-aggregator/build.sbt
@@ -37,7 +37,7 @@ lazy val akkaCdrIngestor= appModule("akka-cdr-ingestor")
     .settings(
       commonSettings,
       libraryDependencies ++= Seq(
-        "com.typesafe.akka"         %% "akka-http-spray-json"   % "10.1.10",
+        "com.typesafe.akka"         %% "akka-http-spray-json"   % "10.1.11",
         "ch.qos.logback"            %  "logback-classic"        % "1.2.3",
         "org.scalatest"             %% "scalatest"              % "3.0.8"    % "test"
       )
@@ -49,7 +49,7 @@ lazy val akkaJavaAggregationOutput= appModule("akka-java-aggregation-output")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
-      "com.typesafe.akka"      %% "akka-http-spray-json"   % "10.1.10",
+      "com.typesafe.akka"      %% "akka-http-spray-json"   % "10.1.11",
       "ch.qos.logback"         %  "logback-classic"        % "1.2.3",
       "org.scalatest"          %% "scalatest"              % "3.0.8"    % "test"
     )

--- a/examples/call-record-aggregator/project/cloudflow-plugins.sbt
+++ b/examples/call-record-aggregator/project/cloudflow-plugins.sbt
@@ -1,6 +1,5 @@
 // Resolver for the cloudflow-sbt plugin
 //
-resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")
 

--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallRecordGeneratorIngressSpec.scala
@@ -42,4 +42,3 @@ class CallRecordGeneratorIngressSpec extends SparkScalaTestSupport {
     }
   }
 }
-

--- a/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallStatsAggregatorSpec.scala
+++ b/examples/call-record-aggregator/spark-aggregation/src/test/scala/carly/aggregator/CallStatsAggregatorSpec.scala
@@ -26,9 +26,8 @@ import org.scalatest.OptionValues
 class CallStatsAggregatorSpec extends SparkScalaTestSupport with OptionValues {
 
   val streamlet = new CallStatsAggregator()
-  val testKit = SparkStreamletTestkit(session).withConfigParameterValues(
-    ConfigParameterValue(streamlet.GroupByWindow, "1 minute"),
-    ConfigParameterValue(streamlet.Watermark, "1 minute"))
+  val testKit = SparkStreamletTestkit(session).withConfigParameterValues(ConfigParameterValue(streamlet.GroupByWindow, "1 minute"),
+                                                                         ConfigParameterValue(streamlet.Watermark, "1 minute"))
 
   "CallStatsAggregator" should {
     "produce elements to its outlet" in {
@@ -65,4 +64,3 @@ class CallStatsAggregatorSpec extends SparkScalaTestSupport with OptionValues {
     }
   }
 }
-

--- a/examples/connected-car-cluster-sharding/build.sbt
+++ b/examples/connected-car-cluster-sharding/build.sbt
@@ -29,6 +29,7 @@ lazy val connectedCarExample = (project in file("./akka-connected-car"))
       "org.scalatest"  %% "scalatest"       % "3.0.7"    % "test"
       )
   )
+  .dependsOn(akkaConnectedCar)
 
 lazy val datamodel = (project in file("./datamodel"))
   .enablePlugins(CloudflowLibraryPlugin)

--- a/examples/connected-car-cluster-sharding/build.sbt
+++ b/examples/connected-car-cluster-sharding/build.sbt
@@ -1,7 +1,7 @@
 import sbt._
 import sbt.Keys._
 
-val AkkaVersion = "2.5.29"
+val AkkaVersion = "2.6.5"
 
 lazy val root =
   Project(id = "root", base = file("."))
@@ -26,16 +26,15 @@ lazy val connectedCarExample = (project in file("./akka-connected-car"))
     name := "connected-car-akka-cluster",
     libraryDependencies ++= Seq(
       "ch.qos.logback" %  "logback-classic" % "1.2.3",
-      "org.scalatest"          %% "scalatest"              % "3.0.7"    % "test"
+      "org.scalatest"  %% "scalatest"       % "3.0.7"    % "test"
       )
   )
-  .dependsOn(akkaConnectedCar)
 
 lazy val datamodel = (project in file("./datamodel"))
   .enablePlugins(CloudflowLibraryPlugin)
 
 lazy val akkaConnectedCar= (project in file("./akka-connected-car-streamlet"))
-  .enablePlugins(CloudflowAkkaStreamsLibraryPlugin)
+  .enablePlugins(CloudflowAkkaPlugin)
   .settings(
     commonSettings,
     name := "akka-connected-car-streamlet",

--- a/examples/connected-car-cluster-sharding/project/cloudflow-plugins.sbt
+++ b/examples/connected-car-cluster-sharding/project/cloudflow-plugins.sbt
@@ -1,5 +1,4 @@
 // Resolver for the cloudflow-sbt plugin
 //
-resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/connected-car-cluster-sharding/project/cloudflow-plugins.sbt
+++ b/examples/connected-car-cluster-sharding/project/cloudflow-plugins.sbt
@@ -3,5 +3,3 @@
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")
-
-

--- a/examples/snippets/modules/ROOT/examples/akkastreams-java/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-java/build.sbt
@@ -8,9 +8,9 @@ lazy val sensorData =  (project in file("."))
 //end::docs-projectSetup-example[]
       libraryDependencies ++= Seq(
         "com.lightbend.akka"     %% "akka-stream-alpakka-file"  % "1.1.2",
-        "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.10",
+        "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.11",
         "ch.qos.logback"         %  "logback-classic"           % "1.2.3",
-        "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.10" % "test",
+        "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.11" % "test",
         "org.scalatest"          %% "scalatest"                 % "3.0.8"  % "test"
 
 //tag::docs-projectName-example[]

--- a/examples/snippets/modules/ROOT/examples/akkastreams-java/src/main/java/cloudflow/akkastreamsdoc/FilterStreamlet.java
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-java/src/main/java/cloudflow/akkastreamsdoc/FilterStreamlet.java
@@ -112,7 +112,7 @@ public class FilterStreamlet extends AkkaStreamlet {
                                 acc.addAll(Collections.singletonList(entry.utf8String()));
                                 return acc;
                             },
-                            getMaterializer()
+                            system()
                         )
                 );
 

--- a/examples/snippets/modules/ROOT/examples/akkastreams-java/src/test/java/com/example/SampleTest.java
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-java/src/test/java/com/example/SampleTest.java
@@ -39,7 +39,7 @@ class TestProcessorTest {
   public void testFlowProcessor() {
 
     //tag::config-value[]
-    AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system, mat).withConfigParameterValues(ConfigParameterValue.create(RecordSumFlow.recordsInWindowParameter, "20"));
+    AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system).withConfigParameterValues(ConfigParameterValue.create(RecordSumFlow.recordsInWindowParameter, "20"));
     //end::config-value[]
   
   }

--- a/examples/snippets/modules/ROOT/examples/akkastreams-scala/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-scala/build.sbt
@@ -8,9 +8,9 @@ lazy val sensorData =  (project in file("."))
 //end::docs-projectSetup-example[]
       libraryDependencies ++= Seq(
         "com.lightbend.akka"     %% "akka-stream-alpakka-file"  % "1.1.2",
-        "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.10",
+        "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.11",
         "ch.qos.logback"         %  "logback-classic"           % "1.2.3",
-        "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.10" % "test",
+        "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.11" % "test",
         "org.scalatest"          %% "scalatest"                 % "3.0.8"  % "test"
 
 //tag::docs-projectName-example[]

--- a/examples/snippets/modules/ROOT/examples/akkastreams-scala/src/test/scala/com/example/SampleSpec.scala
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-scala/src/test/scala/com/example/SampleSpec.scala
@@ -21,7 +21,7 @@ class SampleSpec extends WordSpec with MustMatchers with BeforeAndAfterAll {
 
     //tag::config-value[]
     val testkit =
-      AkkaStreamletTestKit(system, mat).withConfigParameterValues(ConfigParameterValue(RecordSumFlow.recordsInWindowParameter, "20"))
+      AkkaStreamletTestKit(system).withConfigParameterValues(ConfigParameterValue(RecordSumFlow.recordsInWindowParameter, "20"))
     //end::config-value[]
 
     "Allow for creating a 'flow processor'" in {

--- a/examples/snippets/modules/ROOT/examples/build-akka-streamlets-java/step3/src/main/java/com/example/TestProcessor.java
+++ b/examples/snippets/modules/ROOT/examples/build-akka-streamlets-java/step3/src/main/java/com/example/TestProcessor.java
@@ -12,7 +12,7 @@ import cloudflow.streamlets.avro.*;
 //tag::processor[]
 class TestProcessor extends AkkaStreamlet {
   AvroInlet<Data> inlet = AvroInlet.<Data>create("in", Data.class);
-  AvroOutlet<Data> outlet = AvroOutlet.<Data>create("out", d -> d.getId().toString(), Data.class);
+  AvroOutlet<Data> outlet = AvroOutlet.<Data>create("out", d -> Integer.toString(d.getId()), Data.class);
 
   public StreamletShape shape() {
     return StreamletShape.createWithInlets(inlet).withOutlets(outlet);

--- a/examples/snippets/modules/ROOT/examples/build-akka-streamlets-java/step3/src/test/java/com/example/TestProcessorTest.java
+++ b/examples/snippets/modules/ROOT/examples/build-akka-streamlets-java/step3/src/test/java/com/example/TestProcessorTest.java
@@ -45,7 +45,7 @@ class TestProcessorTest {
     TestProcessor sfp = new TestProcessor();
 
     // 1. instantiate the testkit
-    AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system, mat);
+    AkkaStreamletTestKit testkit = AkkaStreamletTestKit.create(system);
 
     // 2. Setup inlet taps that tap the inlet ports of the streamlet
     QueueInletTap<Data> in = testkit.makeInletAsTap(sfp.inlet);

--- a/examples/snippets/modules/ROOT/examples/build-akka-streamlets-scala/step3/src/test/scala/com/example/TestProcessorSpec.scala
+++ b/examples/snippets/modules/ROOT/examples/build-akka-streamlets-scala/step3/src/test/scala/com/example/TestProcessorSpec.scala
@@ -31,7 +31,7 @@ class TestProcessorSpec extends WordSpec with MustMatchers with BeforeAndAfterAl
 
   "A TestProcessor" should {
 
-    val testkit = AkkaStreamletTestKit(system, mat)
+    val testkit = AkkaStreamletTestKit(system)
 
     "Allow for creating a 'flow processor'" in {
       val data = Vector(Data(1, "a"), Data(2, "b"), Data(3, "c"))

--- a/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/step3/src/main/java/com/example/FlinkProcessor.java
+++ b/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/step3/src/main/java/com/example/FlinkProcessor.java
@@ -18,7 +18,7 @@ public class FlinkProcessor extends FlinkStreamlet {
   //         the partitioner function explicitly or else RoundRobinPartitioner will
   //         be used : using `name` as the partitioner here
   AvroInlet<Data> in = AvroInlet.<Data>create("in", Data.class);
-  AvroOutlet<Data> out = AvroOutlet.<Data>create("out", (Data d) -> d.getId().toString(), Data.class);
+  AvroOutlet<Data> out = AvroOutlet.<Data>create("out", (Data d) -> Integer.toString(d.getId()), Data.class);
 
   // Step 2: Define the shape of the streamlet. In this example the streamlet
   //         has 1 inlet and 1 outlet

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/README.md
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/README.md
@@ -175,7 +175,7 @@ $ cat test-data/invalid-metric.json
 
 $ curl -i -X POST localhost:3000 -H "Content-Type: application/json" --data '@test-data/invalid-metric.json'
 HTTP/1.1 202 Accepted
-Server: akka-http/10.1.10
+Server: akka-http/10.1.11
 Date: Mon, 25 Nov 2019 10:29:37 GMT
 Content-Type: text/plain; charset=UTF-8
 Content-Length: 88
@@ -219,7 +219,7 @@ cat test-data/04-moderate-breeze.json
 
 $ curl -i -X POST localhost:3000 -H "Content-Type: application/json" --data '@test-data/04-moderate-breeze.json'
 HTTP/1.1 202 Accepted
-Server: akka-http/10.1.10
+Server: akka-http/10.1.11
 Date: Mon, 25 Nov 2019 11:23:14 GMT
 Content-Type: text/plain; charset=UTF-8
 Content-Length: 88

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/build.sbt
@@ -9,9 +9,9 @@ lazy val sensorData =  (project in file("."))
       scalafmtOnCompile := true,
       libraryDependencies ++= Seq(
         "com.lightbend.akka"     %% "akka-stream-alpakka-file"  % "1.1.2",
-        "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.10",
+        "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.11",
         "ch.qos.logback"         %  "logback-classic"           % "1.2.3",
-        "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.10" % "test",
+        "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.11" % "test",
         "org.scalatest"          %% "scalatest"                 % "3.0.8"  % "test"
 
 //tag::docs-projectName-example[]

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/project/cloudflow-plugins.sbt
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/project/cloudflow-plugins.sbt
@@ -2,5 +2,4 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-
 addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/snippets/modules/ROOT/examples/spark-scala/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/spark-scala/build.sbt
@@ -8,7 +8,7 @@ lazy val sensorData =  (project in file("."))
 //end::docs-projectSetup-example[]
       libraryDependencies ++= Seq(
         "com.lightbend.akka"     %% "akka-stream-alpakka-file"  % "1.1.2",
-        "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.10",
+        "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.11",
         "ch.qos.logback"         %  "logback-classic"           % "1.2.3",
         "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.10" % "test",
         "org.scalatest"          %% "scalatest"                 % "3.0.8"  % "test"

--- a/examples/snippets/modules/ROOT/examples/spark-scala/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/spark-scala/build.sbt
@@ -10,7 +10,7 @@ lazy val sensorData =  (project in file("."))
         "com.lightbend.akka"     %% "akka-stream-alpakka-file"  % "1.1.2",
         "com.typesafe.akka"      %% "akka-http-spray-json"      % "10.1.11",
         "ch.qos.logback"         %  "logback-classic"           % "1.2.3",
-        "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.10" % "test",
+        "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.11" % "test",
         "org.scalatest"          %% "scalatest"                 % "3.0.8"  % "test"
 
 //tag::docs-projectName-example[]

--- a/examples/spark-sensors/project/cloudflow-plugins.sbt
+++ b/examples/spark-sensors/project/cloudflow-plugins.sbt
@@ -2,6 +2,4 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-
 addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")
-

--- a/examples/taxi-ride/build.sbt
+++ b/examples/taxi-ride/build.sbt
@@ -26,7 +26,6 @@ lazy val taxiRidePipeline = appModule("taxi-ride-pipeline")
   .settings(
     name := "taxi-ride-fare"
   )
-  .dependsOn(ingestor, processor, ridelogger)
 
 lazy val datamodel = appModule("datamodel")
   .enablePlugins(CloudflowLibraryPlugin)

--- a/examples/taxi-ride/build.sbt
+++ b/examples/taxi-ride/build.sbt
@@ -39,7 +39,7 @@ lazy val ingestor = appModule("ingestor")
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
-      "com.typesafe.akka"         %% "akka-http-spray-json"   % "10.1.10",
+      "com.typesafe.akka"         %% "akka-http-spray-json"   % "10.1.11",
       "ch.qos.logback"            %  "logback-classic"        % "1.2.3",
       "org.scalatest"             %% "scalatest"              % "3.0.8"    % "test"
     )

--- a/examples/taxi-ride/project/cloudflow-plugins.sbt
+++ b/examples/taxi-ride/project/cloudflow-plugins.sbt
@@ -2,5 +2,4 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-
 addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/templates/single-backend-java/project/cloudflow-plugins.sbt
+++ b/examples/templates/single-backend-java/project/cloudflow-plugins.sbt
@@ -2,6 +2,5 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-
 addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")
 

--- a/examples/templates/single-backend-scala/project/cloudflow-plugins.sbt
+++ b/examples/templates/single-backend-scala/project/cloudflow-plugins.sbt
@@ -2,5 +2,4 @@
 //
 resolvers += "Akka Snapshots".at("https://repo.akka.io/snapshots/")
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-
 addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")

--- a/examples/tensorflow-akka/build.sbt
+++ b/examples/tensorflow-akka/build.sbt
@@ -9,7 +9,7 @@ lazy val tensorflowAkka =  (project in file("."))
       scalafmtOnCompile := true,
       libraryDependencies ++= Seq(
         "ch.qos.logback"         %  "logback-classic"           % "1.2.3",
-        "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.10" % "test",
+        "com.typesafe.akka"      %% "akka-http-testkit"         % "10.1.11" % "test",
         "org.tensorflow"         % "tensorflow"                 % "1.15.0",
         "org.tensorflow"         % "proto"                      % "1.15.0",
         "org.scalatest"          %% "scalatest"                 % "3.0.8"  % "test"

--- a/examples/tensorflow-akka/project/cloudflow-plugins.sbt
+++ b/examples/tensorflow-akka/project/cloudflow-plugins.sbt
@@ -2,6 +2,4 @@
 //
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
-
-
 addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "1.3.4-SNAPSHOT")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Upgrade to Akka 2.6.5.
runLocal for taxi-ride app does not work yet since Flink depends on Akka 2.5.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Support latest. This will also make it possible to add external sharding strategy.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, materializer is not necessary anymore, can use system in most places.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- [x] unit tests and runLocal.
- [x] Removed use of cloudflow-events in runner for test for now, which uses Akka (through use of Skuber).
- [x] Tested on GKE, taxi-ride and CRA app.