### PR TITLE
fix publication of multi-version setups

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
     - name: Build documentation  
       run: |
         cd docs


### PR DESCRIPTION
This 1-liner fixes the publication of multiple versions using Antora. 
It turns out that the checkout action only checks out a single commit

>Improved performance
Fetches only a single commit by default

And Antora silently fails to build the configured versions because the branches are not there.

@rstento FYI -- this was quite tricky.