### PR TITLE
Topics conf

### DIFF
--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -154,18 +154,18 @@ class AkkaStreamletConsumerGroupSpec extends EmbeddedKafkaSpec(kafkaPort, zkPort
 
     def run(testData: List[Data], outlet: String): StreamletExecution = {
       val gen     = new Generator(testData)
-      val context = new AkkaStreamletContextImpl(definition(StreamletRef, outlet), system)
+      val context = new AkkaStreamletContextImpl(definition(outlet), system)
       gen.setContext(context)
       gen.run(context)
     }
 
-    def definition(streamletRef: String, outlet: String) = StreamletDefinition(
+    def definition(outlet: String) = StreamletDefinition(
       appId = appId,
       appVersion = appVersion,
       streamletRef = StreamletRef,
       streamletClass = StreamletClass,
       portMappings = List(
-        PortMapping("out", Topic(appId, streamletRef, outlet))
+        PortMapping("out", Topic(outlet))
       ),
       volumeMounts = List.empty[VolumeMount],
       config = config
@@ -197,7 +197,7 @@ class AkkaStreamletConsumerGroupSpec extends EmbeddedKafkaSpec(kafkaPort, zkPort
       streamletRef = streamletRef,
       streamletClass = "TestReceiver",
       portMappings = List(
-        PortMapping("in", Topic(appId, Generator.StreamletRef, genOutlet))
+        PortMapping("in", Topic(genOutlet))
       ),
       volumeMounts = List.empty[VolumeMount],
       config = config

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamlet.scala
@@ -93,11 +93,6 @@ abstract class AkkaStreamlet extends Streamlet[AkkaStreamletContext] {
       val blockingIODispatcherConfig = context.system.settings.config.getConfig("akka.actor.default-blocking-io-dispatcher")
       val dispatcherConfig           = context.system.settings.config.getConfig("akka.actor.default-dispatcher")
       val deploymentConfig           = context.system.settings.config.getConfig("akka.actor.deployment")
-      val streamletConfig = Try {
-        context.system.settings.config.getConfig("cloudflow.runner.streamlets")
-      }.getOrElse(ConfigFactory.empty())
-
-      context.system.log.info(startRunnerMessage(blockingIODispatcherConfig, dispatcherConfig, deploymentConfig, streamletConfig))
 
       val logic = createLogic()
 

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -65,7 +65,7 @@ final class AkkaStreamletContextImpl(
   // internal implementation that uses the CommittableOffset implementation to provide access to the underlying offsets
   private[akkastream] def sourceWithContext[T](inlet: CodecInlet[T]): SourceWithContext[T, CommittableOffset, _] = {
     val topic = findTopicForPort(inlet)
-    val gId   = topic.groupId(streamletRef, inlet)
+    val gId   = topic.groupId(streamletDefinition.appId, streamletRef, inlet)
 
     val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new ByteArrayDeserializer)
       .withBootstrapServers(topic.bootstrapServers.getOrElse(internalKafkaBootstrapServers))
@@ -140,7 +140,7 @@ final class AkkaStreamletContextImpl(
   def plainSource[T](inlet: CodecInlet[T], resetPosition: ResetPosition = Latest): Source[T, NotUsed] = {
     // TODO clean this up, lot of copying code, refactor.
     val topic = findTopicForPort(inlet)
-    val gId   = topic.groupId(streamletRef, inlet)
+    val gId   = topic.groupId(streamletDefinition.appId, streamletRef, inlet)
     val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new ByteArrayDeserializer)
       .withBootstrapServers(topic.bootstrapServers.getOrElse(internalKafkaBootstrapServers))
       .withGroupId(gId)

--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/Blueprint.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/Blueprint.scala
@@ -76,22 +76,15 @@ object Blueprint {
 
         val topics = if (config.hasPath(TopicsSectionKey)) {
           getKeys(config, TopicsSectionKey).map { key ⇒
-            val topicKey            = s"$TopicsSectionKey.${key}.$TopicKey"
-            val bootstrapServersKey = s"$TopicsSectionKey.${key}.$BootstrapServersKey"
-            val createKey           = s"$TopicsSectionKey.${key}.$ManagedKey"
-            val producersKey        = s"$TopicsSectionKey.${key}.$ProducersKey"
-            val consumersKey        = s"$TopicsSectionKey.${key}.$ConsumersKey"
-            val configKey           = s"$TopicsSectionKey.${key}"
+            val topicKey     = s"$TopicsSectionKey.${key}.$TopicKey"
+            val producersKey = s"$TopicsSectionKey.${key}.$ProducersKey"
+            val consumersKey = s"$TopicsSectionKey.${key}.$ConsumersKey"
+            val configKey    = s"$TopicsSectionKey.${key}"
 
-            val topic                    = getStringOrNone(config, topicKey).getOrElse(key)
-            val bootstrapServersOverride = getStringOrNone(config, bootstrapServersKey)
-            val create                   = getBooleanOrNone(config, createKey).getOrElse(true)
-            val producers                = getStringListOrEmpty(config, producersKey)
-            val consumers                = getStringListOrEmpty(config, consumersKey)
+            val topicId   = key
+            val producers = getStringListOrEmpty(config, producersKey)
+            val consumers = getStringListOrEmpty(config, consumersKey)
             val kafkaConfig = getConfigOrEmpty(config, configKey)
-              .withoutPath(TopicKey)
-              .withoutPath(ManagedKey)
-              .withoutPath(BootstrapServersKey)
               .withoutPath(ProducersKey)
               .withoutPath(ConsumersKey)
             // validate at least that producer and consumer sections are objects.
@@ -104,7 +97,7 @@ object Blueprint {
               if (topicConfig.hasPath(PartitionsKey)) topicConfig.getInt(PartitionsKey)
               if (topicConfig.hasPath(ReplicasKey)) topicConfig.getInt(ReplicasKey)
             }
-            Topic(topic, producers, consumers, kafkaConfig, bootstrapServersOverride, create)
+            Topic(topicId, producers, consumers, kafkaConfig)
           }.toVector
         } else Vector.empty[Topic]
 
@@ -133,8 +126,6 @@ object Blueprint {
 
   private def getStringOrNone(config: Config, key: String): Option[String] =
     if (config.hasPath(key)) Some(config.getString(key)) else None
-  private def getBooleanOrNone(config: Config, key: String): Option[Boolean] =
-    if (config.hasPath(key)) Some(config.getBoolean(key)) else None
   private def getConfigOrEmpty(config: Config, key: String): Config =
     if (config.hasPath(key)) config.getConfig(key) else ConfigFactory.empty()
   private def getStringListOrEmpty(config: Config, key: String): Vector[String] =

--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/Topic.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/Topic.scala
@@ -15,7 +15,7 @@
  */
 
 package cloudflow.blueprint
-
+import scala.util.Try
 import com.typesafe.config._
 object Topic {
   val LegalTopicChars   = "[a-zA-Z0-9\\._\\-]"
@@ -28,16 +28,14 @@ object Topic {
  */
 // TODO check that topic-name is valid topic-name.
 final case class Topic(
-    name: String,
+    id: String,
     producers: Vector[String] = Vector.empty[String],
     consumers: Vector[String] = Vector.empty[String],
     kafkaConfig: Config = ConfigFactory.empty(),
-    // override for bootstrapServers
-    bootstrapServers: Option[String] = None,
-    create: Boolean = true,
     problems: Vector[BlueprintProblem] = Vector.empty[BlueprintProblem],
     verified: Option[VerifiedTopic] = None
 ) {
+  def name = Try(kafkaConfig.getString("topic.name")).getOrElse(id)
   import Topic._
   def verify(verifiedStreamlets: Vector[VerifiedStreamlet]): Topic = {
 
@@ -85,7 +83,7 @@ final case class Topic(
       problems = invalidTopicError ++ patternErrors ++ portPathErrors ++ producerErrors ++ consumerErrors ++ schemaErrors,
       verified =
         if (verifiedPorts.nonEmpty)
-          Some(VerifiedTopic(name, verifiedPorts.distinct.sortBy(_.portPath.toString), bootstrapServers, create, kafkaConfig))
+          Some(VerifiedTopic(id, verifiedPorts.distinct.sortBy(_.portPath.toString), kafkaConfig))
         else None
     )
   }

--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/VerifiedBlueprint.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/VerifiedBlueprint.scala
@@ -60,10 +60,8 @@ final case class VerifiedStreamlet(
 }
 
 final case class VerifiedTopic(
-    name: String,
+    id: String,
     connections: Vector[VerifiedPort],
-    bootstrapServers: Option[String],
-    create: Boolean,
     kafkaConfig: Config
 )
 final case class VerifiedStreamletConnection(verifiedOutlet: VerifiedOutlet, verifiedInlet: VerifiedInlet, label: Option[String] = None)

--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/deployment/ApplicationDescriptor.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/deployment/ApplicationDescriptor.scala
@@ -16,6 +16,7 @@
 
 package cloudflow.blueprint.deployment
 
+import scala.util.Try
 import com.typesafe.config._
 import cloudflow.blueprint._
 
@@ -97,12 +98,8 @@ object ApplicationDescriptor {
     blueprint.topics.flatMap { topic =>
       topic.connections.filter(_.streamlet.name == streamlet.name).map { verifiedPort =>
         verifiedPort.portName -> Topic(
-          appId,
-          streamlet.name,
-          topic.name,
-          topic.kafkaConfig,
-          topic.bootstrapServers,
-          topic.create
+          topic.id,
+          topic.kafkaConfig
         )
       }
     }.toMap
@@ -182,13 +179,12 @@ object StreamletDeployment {
 }
 
 final case class Topic(
-    appId: String,
-    streamlet: String,
-    name: String,
-    config: Config = ConfigFactory.empty(),
-    bootstrapServers: Option[String] = None,
-    managed: Boolean = true
-)
+    id: String,
+    config: Config = ConfigFactory.empty()
+) {
+  def name: String     = Try(config.getString("topic.name")).getOrElse(id)
+  def managed: Boolean = Try(config.getBoolean("managed")).getOrElse(true)
+}
 
 final case class Endpoint(
     appId: String,

--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/deployment/ApplicationDescriptorJsonFormat.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/deployment/ApplicationDescriptorJsonFormat.scala
@@ -35,7 +35,7 @@ trait ConfigJsonFormat extends DefaultJsonProtocol {
 trait ApplicationDescriptorJsonFormat extends StreamletDescriptorFormat with ConfigJsonFormat {
   implicit val streamletFormat = jsonFormat(StreamletInstance.apply, "name", "descriptor")
 
-  implicit val topicFormat    = jsonFormat(Topic.apply, "app_id", "streamlet", "name", "config", "bootstrap_servers", "managed")
+  implicit val topicFormat    = jsonFormat(Topic.apply, "id", "config")
   implicit val endpointFormat = jsonFormat(Endpoint.apply, "app_id", "streamlet", "container_port")
 
   implicit val streamletDeploymentFormat = jsonFormat(

--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/BlueprintBuilder.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/BlueprintBuilder.scala
@@ -188,7 +188,7 @@ object BlueprintBuilder extends StreamletDescriptorBuilder {
       val producers = verifiedOutlets.map(_.portPath.toString) ++ unverifiedPorts
 
       val foundTopic = topics
-        .find(_.name == topic.name)
+        .find(_.id == topic.id)
         .map(t =>
           t.copy(
             producers = (t.producers ++ producers).distinct,
@@ -197,7 +197,7 @@ object BlueprintBuilder extends StreamletDescriptorBuilder {
         )
         .getOrElse(topic.copy(producers = producers, consumers = consumers))
       val verifiedTopic = foundTopic.verify(streamlets.flatMap(_.verified))
-      val otherTopics   = topics.filterNot(_.name == foundTopic.name)
+      val otherTopics   = topics.filterNot(_.id == foundTopic.id)
       copy(topics = otherTopics :+ verifiedTopic).verify
     }
 
@@ -216,13 +216,13 @@ object BlueprintBuilder extends StreamletDescriptorBuilder {
       } yield {
         val unmodified = verifiedTopics
           .filterNot(_.connections.exists(_.portPath == verifiedPort.portPath))
-          .flatMap(verifiedTopic => topics.find(_.name == verifiedTopic.name))
+          .flatMap(verifiedTopic => topics.find(_.id == verifiedTopic.id))
 
         val modified = verifiedTopics
           .filter(_.connections.exists(_.portPath == verifiedPort.portPath))
           .flatMap { verifiedTopic =>
             topics
-              .find(_.name == verifiedTopic.name)
+              .find(_.id == verifiedTopic.id)
               .map { topic =>
                 topic.copy(
                   producers = topic.producers.filterNot(path => VerifiedPortPath(path).exists(_ == verifiedPortPath)),

--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/ApplicationDescriptorSpec.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/ApplicationDescriptorSpec.scala
@@ -127,7 +127,7 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
       ingressDeployment.endpoint mustBe Some(Endpoint(appId, ingressRef.name, ingressContainerPort))
       ingressDeployment.config.getInt("cloudflow.internal.server.container-port") mustBe ingressContainerPort
       ingressDeployment.portMappings.size mustBe 1
-      ingressDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("out" -> "foos")
+      ingressDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("out" -> "foos")
       ingressDeployment.replicas mustBe None
 
       processorDeployment.name mustBe s"${appId}.${processorRef.name}"
@@ -137,8 +137,8 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
       processorDeployment.endpoint mustBe None
       processorDeployment.config mustBe ConfigFactory.empty()
       processorDeployment.portMappings.size mustBe 2
-      processorDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("in"  -> "foos")
-      processorDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("out" -> "bars")
+      processorDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("in"  -> "foos")
+      processorDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("out" -> "bars")
       processorDeployment.replicas mustBe None
 
       egressDeployment.name mustBe s"${appId}.${egressRef.name}"
@@ -148,7 +148,7 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
       egressDeployment.endpoint mustBe Some(Endpoint(appId, egressRef.name, egressContainerPort))
       egressDeployment.config.getInt("cloudflow.internal.server.container-port") mustBe egressContainerPort
       egressDeployment.portMappings.size mustBe 1
-      egressDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("in" -> "bars")
+      egressDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("in" -> "bars")
       egressDeployment.replicas mustBe None
     }
 
@@ -193,18 +193,18 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
       val processor2Deployment = descriptor.deployments.find(_.streamletName == processor2Ref.name).value
 
       ingressDeployment.portMappings.size mustBe 1
-      ingressDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("out" -> "foos")
+      ingressDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("out" -> "foos")
 
       processorDeployment.portMappings.size mustBe 2
-      processorDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("in"  -> "foos")
-      processorDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("out" -> "bars1")
+      processorDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("in"  -> "foos")
+      processorDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("out" -> "bars1")
 
       egressDeployment.portMappings.size mustBe 1
-      egressDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("in" -> "bars1")
+      egressDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("in" -> "bars1")
 
       processor2Deployment.portMappings.size mustBe 2
-      processor2Deployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("in"  -> "bars1")
-      processor2Deployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("out" -> "foos2")
+      processor2Deployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("in"  -> "bars1")
+      processor2Deployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("out" -> "foos2")
     }
 
     "be built correctly from a verified blueprint (with dual-inlet merging)" in {
@@ -243,15 +243,15 @@ class ApplicationDescriptorSpec extends WordSpec with MustMatchers with EitherVa
       val mergeDeployment    = descriptor.deployments.find(_.streamletName == mergeRef.name).value
 
       ingress1Deployment.portMappings.size mustBe 1
-      ingress1Deployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("out" -> "foos1")
+      ingress1Deployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("out" -> "foos1")
 
       ingress2Deployment.portMappings.size mustBe 1
-      ingress2Deployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("out" -> "foos2")
+      ingress2Deployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("out" -> "foos2")
 
       mergeDeployment.portMappings.size mustBe 3
-      mergeDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("in-0" -> "foos1")
-      mergeDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("in-1" -> "foos2")
-      mergeDeployment.portMappings.map { case (port, sp) => port -> sp.name } must contain("out"  -> "merged-bars")
+      mergeDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("in-0" -> "foos1")
+      mergeDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("in-1" -> "foos2")
+      mergeDeployment.portMappings.map { case (port, sp) => port -> sp.id } must contain("out"  -> "merged-bars")
     }
   }
 

--- a/core/cloudflow-events/src/test/resources/config-map-sample.json
+++ b/core/cloudflow-events/src/test/resources/config-map-sample.json
@@ -1,58 +1,52 @@
 {
   "cloudflow": {
-    "common" : {"attribute" : "value"},
+    "common": {
+      "attribute": "value"
+    },
     "kafka": {
       "bootstrap-servers": "cloudflow-kafka.lightbend:9092"
     },
     "runner": {
-        "streamlets": [{
-          "class_name": "cloudflow.examples.sensordata.SensorDataIngress$",
-          "streamlet_ref": "sensor-data",
-          "context": {
-            "app_id": "appId",
-            "app_version": "unknown",
-            "config": {
-              "cloudflow": {
-                "internal": {
-                  "server": {
-                    "container-port": 2049
-                  }
+      "streamlet": {
+        "class_name": "cloudflow.examples.sensordata.SensorDataIngress$",
+        "context": {
+          "app_id": "appId",
+          "app_version": "unknown",
+          "config": {
+            "cloudflow": {
+              "internal": {
+                "server": {
+                  "container-port": 2049
                 }
               }
-            },
-            "connected_ports": [
-              {
-                "port": "accepted",
-                "topic":
-                  {
-                    "app_id": "appId",
-                    "streamlet_ref": "sensor-data",
-                    "name": "appId.sensor-data.accepted",
-                    "config": {},
-                    "managed" : true
-                  }
+            }
+          },
+          "port_mappings": {
+            "accepted": {
+              "app_id": "appId",
+              "config": {
+                "managed": true
               },
-              {
-                "port": "rejected",
-                "topic":
-                  {
-                    "app_id": "appId",
-                    "streamlet_ref": "sensor-data",
-                    "name": "appId.sensor-data.rejected",
-                    "config": {},
-                    "managed" : true
-                  }
-              }
-            ],
-            "volume_mounts" : [
-              {
-                "name" : "mounted-vol",
-                "path": "/mnt/streamlet",
-                "access_mode": "ReadWriteMany"
-              }
-            ]
-          }
-        }]
+              "id": "accepted"
+            },
+            "rejected": {
+              "app_id": "appId",
+              "config": {
+                "managed": true
+              },
+              "id": "rejected"
+            }
+          },
+          "volume_mounts": [
+            {
+              "access_mode": "ReadWriteMany",
+              "name": "mounted-vol",
+              "path": "/mnt/streamlet"
+            }
+          ]
+        },
+        "streamlet_ref": "sensor-data"
       }
     }
   }
+}

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContextImpl.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContextImpl.scala
@@ -46,7 +46,7 @@ class FlinkStreamletContextImpl(
   override def readStream[In: TypeInformation](inlet: CodecInlet[In]): DataStream[In] = {
     val topic            = findTopicForPort(inlet)
     val srcTopic         = topic.name
-    val groupId          = topic.groupId(streamletRef, inlet)
+    val groupId          = topic.groupId(streamletDefinition.appId, streamletRef, inlet)
     val bootstrapServers = topic.bootstrapServers.getOrElse(internalKafkaBootstrapServers)
     val propsMap = Map("bootstrap.servers" -> bootstrapServers, "group.id" -> groupId, "auto.offset.reset" -> "earliest") ++
           topic.kafkaConsumerProperties

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Operator.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Operator.scala
@@ -93,8 +93,8 @@ object Operator {
       ),
       resourceVersion = None
     )
-    // watch only Input secrets, transform the streamlet change events (the input secrets)
-    // into Output secret (create-or-) update actions.
+    // watch only Input secrets, transform the application input secret
+    // into Output secret create actions.
     runStream(
       watch[Secret](client, watchOptions)
         .via(ConfigInputChangeEvent.fromWatchEvent())

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/TopicActions.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/TopicActions.scala
@@ -38,7 +38,7 @@ object TopicActions {
       deleteOutdatedTopics: Boolean
   )(implicit ctx: DeploymentContext): Seq[Action[ObjectResource]] = {
     def distinctTopics(app: CloudflowApplication.Spec): Set[TopicInfo] =
-      app.deployments.flatMap(_.portMappings.values.map(sp => TopicInfo(sp.name, sp.managed))).toSet
+      app.deployments.flatMap(_.portMappings.values.map(topic => TopicInfo(topic.name, topic.managed))).toSet
 
     val labels = CloudflowLabels(newApp)
 

--- a/core/cloudflow-spark/src/test/scala/cloudflow/spark/StreamletLoaderSpec.scala
+++ b/core/cloudflow-spark/src/test/scala/cloudflow/spark/StreamletLoaderSpec.scala
@@ -43,28 +43,20 @@ class StreamletLoaderSpec extends WordSpec with StreamletLoader with MustMatcher
         "config" : {
           "fake-config-value" : "bla"
         }
-        "connected_ports": [
-          {
-            "port": "in",
-            "topic":
-              {
-                "app_id": "appId",
-                "streamlet_ref": "to-metrics",
-                "name": "appId.to-metrics.in",
-                "config": {}
-              }
+        "port_mappings": {
+          "in ": {
+            "app_id": "appId",
+            "streamlet_ref": "to-metrics",
+            "id": "metrics-in",
+            "config": {}
           },
-          {
-            "port": "out",
-            "topic":
-              {
-                "app_id": "appId",
-                "streamlet_ref": "to-metrics",
-                "name": "appId.to-metrics.out",
-                "config": {}
-              }
+          "out": {
+            "app_id": "appId",
+            "streamlet_ref": "to-metrics",
+            "id": "metrics-out",
+            "config": {}
           }
-        ],
+        },
         "volume_mounts": [
           {
             "name":"test-mount",

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletDefinition.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletDefinition.scala
@@ -46,23 +46,16 @@ case class StreamletDefinition(appId: String,
 }
 
 object Topic {
-  //TODO  used for testing, remove
-  def apply(appId: String, streamletRef: String, outlet: String): Topic =
-    Topic(appId, streamletRef, s"$appId.$streamletRef.$outlet", ConfigFactory.empty(), None)
+  def apply(name: String): Topic = Topic(name, ConfigFactory.parseString("managed=true"))
 }
 
-/**
- * The path to a savepoint.
- */
 final case class Topic(
-    appId: String,
-    streamletRef: String,
-    name: String,
-    config: Config,
-    bootstrapServers: Option[String]
+    id: String,
+    config: Config
 ) {
-
-  def groupId[T](readingStreamletRef: String, inlet: CodecInlet[T]) = {
+  def name             = Try(config.getString("topic.name")).toOption.getOrElse(id)
+  def bootstrapServers = Try(config.getString("bootstrap.servers")).toOption
+  def groupId[T](appId: String, readingStreamletRef: String, inlet: CodecInlet[T]) = {
     val base = s"$appId.$readingStreamletRef.${inlet.name}"
     if (inlet.hasUniqueGroupId) s"${base}.${randomUUID.toString}"
     else base
@@ -116,15 +109,15 @@ object StreamletDefinition {
       appVersion = streamletContextData.appVersion,
       streamletRef = streamletRef,
       streamletClass = config.as[String]("class_name"),
-      streamletContextData.portMappings,
+      streamletContextData.portMappings.map { case (port, topic) => PortMapping(port, topic) }.toList,
       streamletContextData.volumeMounts.getOrElse(List()),
       streamletContextData.config
     )
   }
 
-  val StreamletRootPath = "cloudflow.runner.streamlets"
+  val StreamletRootPath = "cloudflow.runner.streamlet"
   def read(config: Config, rootPath: String = StreamletRootPath): Try[StreamletDefinition] = Try {
-    config.as[Vector[StreamletDefinition]](rootPath).head
+    config.as[StreamletDefinition](rootPath)
   }
 
   // checkpoint folder set up
@@ -139,7 +132,7 @@ object StreamletDefinition {
 case class StreamletContextData(
     appId: String,
     appVersion: String,
-    portMappings: List[PortMapping],
+    portMappings: Map[String, Topic],
     volumeMounts: Option[List[VolumeMount]] = None,
     config: Config
 )
@@ -153,7 +146,7 @@ object StreamletContextDataJsonSupport extends DefaultJsonProtocol {
     def write(config: Config): JsValue = config.root().render(ConfigRenderOptions.concise()).parseJson
     def read(json: JsValue): Config    = ConfigFactory.parseString(json.toString)
   }
-  implicit val topicFormat = jsonFormat(Topic.apply, "app_id", "streamlet_ref", "name", "config", "bootstrap_servers")
+  implicit val topicFormat = jsonFormat(Topic.apply, "id", "config")
   protected implicit val accessModeFormat = new JsonFormat[AccessMode] {
     val jsReadWriteMany = JsString("ReadWriteMany")
     val jsReadOnlyMany  = JsString("ReadOnlyMany")
@@ -171,7 +164,7 @@ object StreamletContextDataJsonSupport extends DefaultJsonProtocol {
   protected implicit val volumeMountFormat  = jsonFormat(VolumeMount.apply _, "name", "path", "access_mode")
   protected implicit val portMappingsFormat = jsonFormat(PortMapping, "port", "topic")
   protected implicit val contextDataFormat =
-    jsonFormat(StreamletContextData, "app_id", "app_version", "connected_ports", "volume_mounts", "config")
+    jsonFormat(StreamletContextData, "app_id", "app_version", "port_mappings", "volume_mounts", "config")
 
   /**
    * Converts a json String, that is expected to contain one streamlet

--- a/core/cloudflow-streamlets/src/test/resources/config-map-sample.json
+++ b/core/cloudflow-streamlets/src/test/resources/config-map-sample.json
@@ -1,58 +1,52 @@
 {
   "cloudflow": {
-    "common" : {"attribute" : "value"},
+    "common": {
+      "attribute": "value"
+    },
     "kafka": {
       "bootstrap-servers": "cloudflow-kafka.lightbend:9092"
     },
     "runner": {
-        "streamlets": [{
-          "class_name": "cloudflow.examples.sensordata.SensorDataIngress$",
-          "streamlet_ref": "sensor-data",
-          "context": {
-            "app_id": "appId",
-            "app_version": "unknown",
-            "config": {
-              "cloudflow": {
-                "internal": {
-                  "server": {
-                    "container-port": 2049
-                  }
+      "streamlet": {
+        "class_name": "cloudflow.examples.sensordata.SensorDataIngress$",
+        "context": {
+          "app_id": "appId",
+          "app_version": "unknown",
+          "config": {
+            "cloudflow": {
+              "internal": {
+                "server": {
+                  "container-port": 2049
                 }
               }
-            },
-            "connected_ports": [
-              {
-                "port": "accepted",
-                "topic":
-                  {
-                    "app_id": "appId",
-                    "streamlet_ref": "sensor-data",
-                    "name": "appId.sensor-data.accepted",
-                    "config" : {},
-                    "managed" : true
-                  }
+            }
+          },
+          "port_mappings": {
+            "accepted": {
+              "app_id": "appId",
+              "config": {
+                "managed": true
               },
-              {
-                "port": "rejected",
-                "topic":
-                  {
-                    "app_id": "appId",
-                    "streamlet_ref": "sensor-data",
-                    "name": "appId.sensor-data.rejected",
-                    "config" : {},
-                    "managed" : true
-                  }
-              }
-            ],
-            "volume_mounts" : [
-              {
-                "name" : "mounted-vol",
-                "path": "/mnt/streamlet",
-                "access_mode": "ReadWriteMany"
-              }
-            ]
-          }
-        }]
+              "id": "accepted"
+            },
+            "rejected": {
+              "app_id": "appId",
+              "config": {
+                "managed": true
+              },
+              "id": "rejected"
+            }
+          },
+          "volume_mounts": [
+            {
+              "access_mode": "ReadWriteMany",
+              "name": "mounted-vol",
+              "path": "/mnt/streamlet"
+            }
+          ]
+        },
+        "streamlet_ref": "sensor-data"
       }
     }
   }
+}

--- a/core/cloudflow-streamlets/src/test/scala/cloudflow/streamlets/StreamletDefinitionSpec.scala
+++ b/core/cloudflow-streamlets/src/test/scala/cloudflow/streamlets/StreamletDefinitionSpec.scala
@@ -34,10 +34,10 @@ class StreamletDefinitionSpec extends WordSpec with MustMatchers with TryValues 
     "a loaded instance must have port configuration" in {
       val ports = streamletConfig.portMappings
       val expectedPorts = Map(
-        "accepted" -> Topic("appId", "sensor-data", "accepted"),
-        "rejected" -> Topic("appId", "sensor-data", "rejected")
+        "accepted" -> Topic("accepted"),
+        "rejected" -> Topic("rejected")
       )
-      ports.foreach(connectedPort ⇒ expectedPorts(connectedPort.port) must be(connectedPort.topic))
+      ports.foreach(portMapping ⇒ expectedPorts(portMapping.port) must be(portMapping.topic))
     }
 
     "a loaded instance must have its own configuration" in {

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
@@ -244,9 +244,11 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
           val formattedTopic = topicFormat(topic.name)
           val io             = inletOutlets(port)
           if (io == "inlet") {
-            s"$formattedTopic" -> s"${topic.streamlet}"
+            // TODO verify this
+            s"$formattedTopic" -> s"${deployment.streamletName}"
           } else {
-            s"${topic.streamlet}" -> s"$formattedTopic"
+            // TODO verify this
+            s"${deployment.streamletName}" -> s"$formattedTopic"
           }
       }
       topicsOtherStreamlet

--- a/kubectl-cloudflow/cfapp/cloudflowapplication.go
+++ b/kubectl-cloudflow/cfapp/cloudflowapplication.go
@@ -15,12 +15,9 @@ import (
 
 // PortMapping maps outlets
 type PortMapping struct {
-	AppID            string          `json:"app_id"`
-	Name             string          `json:"name"`
-	Streamlet        string          `json:"streamlet"`
-	Config           json.RawMessage `json:"config"`
-	BootstrapServers string          `json:"bootstrap_servers,omitempty"`
-	Managed          bool            `json:"managed"`
+	AppID  string          `json:"app_id"`
+	ID     string          `json:"id"`
+	Config json.RawMessage `json:"config"`
 }
 
 // Endpoint contains deployment endpoint information

--- a/kubectl-cloudflow/config/config_test.go
+++ b/kubectl-cloudflow/config/config_test.go
@@ -287,6 +287,15 @@ func Test_validateConfig(t *testing.T) {
 				Name: "my-streamlet",
 			},
 		},
+		Deployments: []cfapp.Deployment{
+			{
+				PortMappings: map[string]cfapp.PortMapping{
+					"port": {
+						ID: "my-topic",
+					},
+				},
+			},
+		},
 	}
 
 	noStreamletsOrRuntimes := newConfig("a.b.c { }")
@@ -358,6 +367,24 @@ func Test_validateConfig(t *testing.T) {
 		 }
 	`)
 	assert.NotEmpty(t, validateConfig(unknownConfigParameterInStreamletConfigSection, spec))
+
+	validTopic := newConfig(`
+     cloudflow.topics {
+			 my-topic {
+         topic.name = "my-topic-name"
+			 }
+		 }
+	`)
+	assert.Empty(t, validateConfig(validTopic, spec))
+	unknownTopic := newConfig(`
+     cloudflow.topics {
+			 topic {
+         topic.name = "my-topic-name"
+			 }
+		 }
+	`)
+	assert.NotEmpty(t, validateConfig(unknownTopic, spec))
+
 }
 
 func Test_ValidationOfDuration(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Adding support for topics configuration. configuration can contain a `cloudflow.topics` section to provide settings for topics, for example:
```
cloudflow {
  topics {
    rides {
      bootstrap.servers = ${broker}
      topic.name = "incoming-rides"
    }
    fares {
      bootstrap.servers = ${broker}
      topic.name = "incoming-fares"
    }
    taxifares {
      bootstrap.servers = ${broker}
      topic.name = "taxi-fares"
    }
  }
}
broker = "my-kafka-cloud.service:31310"
```
A more extensive example:
```
cloudflow {
  topics {
    rides = ${shared-config} {
      topic.name = "incoming-rides"
    }
    fares = ${shared-config} {
      topic.name = "incoming-fares"
    }
    taxifares = ${shared-config} {
      topic.name = "taxi-fares"
    }
  }
}

shared-config {
  bootstrap.servers = "my-kafka-cloud.service:31310"
  managed = no
  
  producer-config = ${kafka-connection-config} {
    # more config can be added here from Kafka ProducerConfig
  }
  consumer-config = ${kafka-connection-config} {
    # more config can be added here from Kafka ConsumerConfig
  }
}

kafka-connection-config {
  security.protocol = "SSL"
  ssl.endpoint.identification.algorithm = ""
  # files need to be bundled in your image using extraDockerInstructions in you sbt file
  ssl.truststore.location = "/opt/certs/client.truststore.jks"
  ssl.truststore.password = "secret"
  ssl.keystore.type = "PKCS12"
  # files need to be bundled in your image using extraDockerInstructions in you sbt file
  ssl.keystore.location = "/opt/certs/client.keystore.p12"
  ssl.keystore.password = "secret"
  ssl.key.password = "secret"
}
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Configure topics details using --conf and command line args.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, after this the user will be able to configure topics when deploying apps.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
GKE, against a kafka cloud service.