### PR TITLE
Fixed API versions

### DIFF
--- a/docs/docs-source/docs/modules/get-started/pages/versions.adoc
+++ b/docs/docs-source/docs/modules/get-started/pages/versions.adoc
@@ -6,7 +6,7 @@ Cloudflow makes use of a number of open source projects. This page summarizes th
 
 **Akka**
 
-* https://github.com/akka/akka[Akka]: `2.5.29`
+* https://github.com/akka/akka[Akka]: `2.6.5`
 
 **Apache Spark**
 

--- a/installer/release/cloudflow-installer.yaml
+++ b/installer/release/cloudflow-installer.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: cloudflow-installer
   name: cloudflow-installer
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null

--- a/installer/test/installer-deployment.yaml
+++ b/installer/test/installer-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: cloudflow-installer
   name: cloudflow-installer
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null

--- a/installer/test/nfs.yaml
+++ b/installer/test/nfs.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: default
   name: nfs-controller
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nfs-controller

--- a/kubectl-cloudflow/README.md
+++ b/kubectl-cloudflow/README.md
@@ -43,7 +43,7 @@ and follow the install instructions: https://golang.org/doc/install
 
 OSX:
 
-`brew install golang` (latest known/tested version: 1.12)
+`brew install golang` (latest known/tested version: 1.14)
 
 ### Set up your workspace and `$GOPATH`
 

--- a/kubectl-cloudflow/go.mod
+++ b/kubectl-cloudflow/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightbend/cloudflow/kubectl-cloudflow
 
-go 1.12
+go 1.14
 
 require (
 	cloud.google.com/go v0.37.2 // indirect


### PR DESCRIPTION
### What changes were proposed in this pull request?
Updated deprecated API version for cluster role bindings.
Updated Akka version in doc.
Updated Go version

### Why are the changes needed?
rbac.authorization.k8s.io/v1 has been available since k8s 1.8. v1beta1 is long deprecated and should be avoided.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
GKE