### PR TITLE
ProvidedAction now retries up to a minute to get the resource.

### DIFF
--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/Action.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/Action.scala
@@ -333,6 +333,7 @@ final class ProvidedAction[T <: ObjectResource, R <: ObjectResource](
           }
           .getOrElse {
             if (waiting <= timeout) {
+              sys.log.info(s"resource $resourceName not found in namespace $namespace, scheduling retry to get resource.")
               after(delayWhenNotFound, sys.scheduler)(executeUntil(client, timeout, delayWhenNotFound, waiting + 1.second))
             } else {
               // last attempt expects to be there or fail with error that the resource is not there.

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/Action.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/Action.scala
@@ -329,7 +329,9 @@ final class ProvidedAction[T <: ObjectResource, R <: ObjectResource](
           getAction(existing).execute(client)
         }
     getAndProvide.recoverWith {
-      case _ if retries > 0 => after(delay, sys.scheduler)(executeWithRetry(client, delay, retries - 1))
+      case _ if retries > 0 =>
+        sys.log.info(s"Scheduling retry to get resource $namespace/$resourceName")
+        after(delay, sys.scheduler)(executeWithRetry(client, delay, retries - 1))
     }
   }
 }

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/Action.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/Action.scala
@@ -15,8 +15,10 @@
  */
 
 package cloudflow.operator.action
-
 import scala.concurrent._
+import scala.concurrent.duration._
+import akka.actor.ActorSystem
+import akka.pattern._
 
 import play.api.libs.json._
 import skuber._
@@ -47,7 +49,7 @@ sealed trait Action[+T <: ObjectResource] {
    * Executes the action using a KubernetesClient.
    * Returns the created or modified resource, or None if the resource is deleted.
    */
-  def execute(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[Action[T]]
+  def execute(client: KubernetesClient)(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action[T]]
 
   /**
    * It is expected that f will always first get the resource in question to break out of the conflict, to avoid a fast recover loop.
@@ -152,12 +154,12 @@ class CreateOrUpdateAction[T <: ObjectResource](
   /**
    * Creates the resources if it does not exist. If it does exist it updates the resource as required.
    */
-  def execute(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[Action[T]] =
+  def execute(client: KubernetesClient)(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action[T]] =
     for {
       result <- executeCreate(client)
     } yield new CreateOrUpdateAction(result, format, resourceDefinition, editor)
 
-  private def executeCreate(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[T] =
+  private def executeCreate(client: KubernetesClient)(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[T] =
     for {
       existing ← client.getOption[T](resource.name)
       res ← existing
@@ -195,12 +197,14 @@ class CreateOrPatchAction[T <: ObjectResource, O <: Patch](
   /**
    * Updates the resource, without changing the `resourceVersion`.
    */
-  def execute(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[Action[T]] =
+  def execute(client: KubernetesClient)(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action[T]] =
     for {
       result <- executeCreateOrPatch(client)
     } yield new CreateOrPatchAction(result, patch, format, patchWriter, resourceDefinition)
 
-  private def executeCreateOrPatch(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[T] =
+  private def executeCreateOrPatch(
+      client: KubernetesClient
+  )(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[T] =
     for {
       existing ← client.getOption[T](resource.name)
       res ← existing
@@ -222,7 +226,7 @@ class PatchAction[T <: ObjectResource, O <: Patch](
   /**
    * Updates the target resource using a patch
    */
-  def execute(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[Action[T]] =
+  def execute(client: KubernetesClient)(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action[T]] =
     client
       .patch(resource.name, patch, Some(resource.ns))
       .map(r ⇒ new PatchAction(r, patch, format, patchWriter, resourceDefinition))
@@ -245,12 +249,12 @@ class UpdateStatusAction[T <: ObjectResource](
   /**
    * Updates the resource status subresource, without changing the `resourceVersion`.
    */
-  def execute(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[Action[T]] =
+  def execute(client: KubernetesClient)(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action[T]] =
     for {
       result <- executeUpdateStatus(client)
     } yield new UpdateStatusAction(result, format, resourceDefinition, statusEv, editor)
 
-  def executeUpdateStatus(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[T] =
+  def executeUpdateStatus(client: KubernetesClient)(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[T] =
     for {
       existing ← client.getOption[T](resource.name)
       resourceVersionUpdated = existing
@@ -285,7 +289,7 @@ final case class DeleteAction[T <: ObjectResource](
   /**
    * Deletes the resource.
    */
-  def execute(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[Action[T]] = {
+  def execute(client: KubernetesClient)(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action[T]] = {
     val options = DeleteOptions(propagationPolicy = Some(DeletePropagation.Foreground))
     client.deleteWithOptions(name, options)(resourceDefinition, lc).map(_ ⇒ this)
   }
@@ -305,9 +309,38 @@ final class ProvidedAction[T <: ObjectResource, R <: ObjectResource](
   def executed =
     s"Provided $namespace/$resourceName to next action"
 
-  def execute(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[Action[R]] =
-    for {
-      existing ← client.usingNamespace(namespace).get[T](resourceName)
-      res      <- getAction(existing).execute(client)
-    } yield res
+  def execute(client: KubernetesClient)(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action[R]] =
+    executeUntil(
+      client,
+      timeout = 1.minute,
+      delayWhenNotFound = 1.second,
+      waiting = 0.second
+    )
+
+  private def executeUntil(
+      client: KubernetesClient,
+      timeout: FiniteDuration,
+      delayWhenNotFound: FiniteDuration,
+      waiting: FiniteDuration
+  )(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action[R]] =
+    client
+      .usingNamespace(namespace)
+      .getOption[T](resourceName)
+      .flatMap { result =>
+        result
+          .map { existing =>
+            getAction(existing).execute(client)
+          }
+          .getOrElse {
+            if (waiting <= timeout) {
+              after(delayWhenNotFound, sys.scheduler)(executeUntil(client, timeout, delayWhenNotFound, waiting + 1.second))
+            } else {
+              // last attempt expects to be there or fail with error that the resource is not there.
+              client
+                .usingNamespace(namespace)
+                .get[T](resourceName)
+                .flatMap(existing => getAction(existing).execute(client))
+            }
+          }
+      }
 }

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/AppActions.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/AppActions.scala
@@ -19,7 +19,7 @@ package action
 
 import scala.collection.immutable._
 import scala.concurrent._
-
+import akka.actor.ActorSystem
 import play.api.libs.json._
 import skuber.api.client._
 import skuber.json.format._
@@ -254,8 +254,9 @@ object AppActions {
       format: Format[PersistentVolumeClaim],
       resourceDefinition: ResourceDefinition[PersistentVolumeClaim]
   ) extends CreateOrUpdateAction[PersistentVolumeClaim](resource, format, resourceDefinition, persistentVolumeClaimEditor) {
-    override def execute(client: KubernetesClient)(implicit ec: ExecutionContext,
-                                                   lc: LoggingContext): Future[Action[PersistentVolumeClaim]] =
+    override def execute(
+        client: KubernetesClient
+    )(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action[PersistentVolumeClaim]] =
       for {
         pvcResult ← client.getOption[PersistentVolumeClaim](resource.name)(format, resourceDefinition, lc)
         res ← pvcResult

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/EndpointActions.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/EndpointActions.scala
@@ -19,7 +19,7 @@ package action
 
 import scala.concurrent._
 import scala.collection.immutable._
-
+import akka.actor.ActorSystem
 import play.api.libs.json._
 
 import skuber._
@@ -110,7 +110,9 @@ object EndpointActions {
       format: Format[Service],
       resourceDefinition: ResourceDefinition[Service]
   ) extends CreateOrUpdateAction[Service](resource, format, resourceDefinition, serviceEditor) {
-    override def execute(client: KubernetesClient)(implicit ec: ExecutionContext, lc: LoggingContext): Future[Action[Service]] =
+    override def execute(
+        client: KubernetesClient
+    )(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action[Service]] =
       for {
         serviceResult ← client.getOption[Service](resource.name)(format, resourceDefinition, lc)
         res ← serviceResult


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Fix for ProvidedAction, retries up to a minute to get and then provide the action.
Tested on GKE by deleting secrets while the app is deployed the first time:
```
2020-05-29 11:51:56,200 INFO  [Materializer] - [action] Element: Executed update action for CloudflowApplication/swiss-knife/swiss-knife
2020-05-29 11:51:56,971 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:51:58,000 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:51:58,437 INFO  [ActorSystemImpl] - [app: swiss-knife status of streamlet akka-process changed: (Pod swiss-knife-akka-process-69b5c487c9-vrzkq MODIFIED)
2020-05-29 11:51:58,475 INFO  [Materializer] - [action] Element: Executed update action for CloudflowApplication/swiss-knife/swiss-knife
2020-05-29 11:51:59,031 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:00,063 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:01,095 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:02,133 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:03,160 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:04,193 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:05,220 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:06,251 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:07,281 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:08,314 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:09,275 INFO  [ActorSystemImpl] - [app: swiss-knife status of streamlet akka-process changed: (Pod swiss-knife-akka-process-69b5c487c9-vrzkq MODIFIED)
2020-05-29 11:52:09,314 INFO  [Materializer] - [action] Element: Executed update action for CloudflowApplication/swiss-knife/swiss-knife
2020-05-29 11:52:09,343 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:10,380 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:11,413 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:12,441 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:13,472 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:14,500 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:15,561 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:16,601 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:17,632 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:18,660 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:19,697 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:20,734 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:21,762 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:22,793 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:23,819 INFO  [ActorSystemImpl] - Scheduling retry to get resource swiss-knife/spark-process
2020-05-29 11:52:24,644 INFO  [ActorSystemImpl] - [app: swiss-knife application configuration changed (Secret config-swiss-knife ADDED)]
```
```
Every 3.0s: ./kubectl-cloudflow status swiss-knife                                                                                                                                                ray-tracer-3.local: Fri May 29 14:03:25 2020

Name:             swiss-knife
Namespace:        swiss-knife
Version:          390-7f37bba5-dirty
Created:          2020-05-29 13:51:55 +0200 CEST
Status:           Running

STREAMLET         POD                                                    READY             STATUS            RESTARTS
spark-process     swiss-knife-spark-process-driver                       1/1               Running           0
spark-process     swiss-knife-spark-process-1590753147606-exec-2         1/1               Running           0
spark-process     swiss-knife-spark-process-1590753147606-exec-1         1/1               Running           0
ingress           swiss-knife-ingress-driver                             1/1               Running           0
ingress           swiss-knife-ingress-1590753147898-exec-1               1/1               Running           0
ingress           swiss-knife-ingress-1590753147898-exec-2               1/1               Running           0
flink-process     swiss-knife-flink-process-1e17a273-tm-5b59b86f5b-2m56t 1/1               Running           0
flink-process     swiss-knife-flink-process-1e17a273-tm-5b59b86f5b-8knmt 1/1               Running           0
flink-process     swiss-knife-flink-process-1e17a273-jm-66889dbf88-nf94d 1/1               Running           0
akka-process      swiss-knife-akka-process-69b5c487c9-vrzkq              1/1               Running           0
spark-output      swiss-knife-spark-output-driver                        1/1               Running           0
spark-output      swiss-knife-spark-output-1590753147981-exec-2          1/1               Running           0
spark-output      swiss-knife-spark-output-1590753147981-exec-1          1/1               Running           0
egress            swiss-knife-egress-68d97797ff-5fbml                    1/1               Running           0
```