### PR TITLE
The Berkeley site no longer hosts Flink 1.10.0. Changed to Apache.

### DIFF
--- a/external/multi-base-images/flink/Dockerfile
+++ b/external/multi-base-images/flink/Dockerfile
@@ -27,8 +27,7 @@ ENV FLINK_HOME=/opt/flink
 USER root
 
 ENV FLINK_TGZ=flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION}.tgz
-ENV FLINK_URL_FILE_PATH=flink/flink-${FLINK_VERSION}/${FLINK_TGZ}
-ENV FLINK_TGZ_URL=https://mirrors.ocf.berkeley.edu/apache/$FLINK_URL_FILE_PATH
+ENV FLINK_TGZ_URL=https://archive.apache.org/dist/flink/flink-${FLINK_VERSION}/${FLINK_TGZ}
 
 RUN mkdir ${FLINK_HOME}; \
     groupadd --system --gid=9999 flink && \


### PR DESCRIPTION
Apache site has both old and current releases. So we don't have to change it again when we upgrade.