### PR TITLE
adds coverage for runtime/kubernetes configuration

### DIFF
--- a/integration-tests/itest/deploy_test.go
+++ b/integration-tests/itest/deploy_test.go
@@ -167,8 +167,8 @@ var _ = Describe("Application deployment", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Wait for the deployment of the new configuration")
-			oneSecond, _ := time.ParseDuration("5s")
-			time.Sleep(oneSecond) // this wait is to let the application go into deployment
+			sleepTime, _ := time.ParseDuration("5s")
+			time.Sleep(sleepTime) // this wait is to let the application go into deployment
 			cli.PollUntilAppStatusIs(swissKnifeApp, "Running")
 
 			By("Get new resource configuration")
@@ -185,7 +185,7 @@ var _ = Describe("Application deployment", func() {
 			close(done)
 		}, LongTimeout)
 
-		FIt("Should reconfigure the Akka runtime of the complete application", func(done Done) {
+		It("Should reconfigure the Akka runtime of the complete application", func(done Done) {
 			By("Register the current CPU and memory for all Akka streamlets")
 			appStatus, err := cli.Status(swissKnifeApp)
 			Expect(err).NotTo(HaveOccurred())
@@ -204,8 +204,8 @@ var _ = Describe("Application deployment", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Wait for the deployment of the new configuration")
-			oneSecond, _ := time.ParseDuration("5s")
-			time.Sleep(oneSecond) // this wait is to let the application go into deployment
+			sleepTime, _ := time.ParseDuration("5s")
+			time.Sleep(sleepTime) // this wait is to let the application go into deployment
 			cli.PollUntilAppStatusIs(swissKnifeApp, "Running")
 
 			By("Get new resource configuration")

--- a/integration-tests/itest/deploy_test.go
+++ b/integration-tests/itest/deploy_test.go
@@ -26,6 +26,7 @@ const (
 	UpdateConfigParamsFile         = "./resources/update_config_params.conf"
 	UpdateConfigPayload            = "payload: updated_config"
 	UpdateAkkaProcessResourcesFile = "./resources/update_akka_process_resources.conf"
+	UpdateAkkaRuntimeResourcesFile = "./resources/update_akka_runtime.conf"
 )
 
 var swissKnifeApp = cli.App{
@@ -181,6 +182,48 @@ var _ = Describe("Application deployment", func() {
 			// TODO: Read the config file and compare with the values there to avoid out-of-sync situations
 			Expect(podUpdatedRes.Cpu).To(Equal("550m"))
 			Expect(podUpdatedRes.Mem).To(Equal("612M"))
+			close(done)
+		}, LongTimeout)
+
+		FIt("Should reconfigure the Akka runtime of the complete application", func(done Done) {
+			By("Register the current CPU and memory for all Akka streamlets")
+			appStatus, err := cli.Status(swissKnifeApp)
+			Expect(err).NotTo(HaveOccurred())
+			streamlets := [5]string{"akka-process", "akka-egress", "spark-egress", "raw-egress", "flink-egress"}
+			streamletResourceConfigMap := make(map[string]kubectl.PodResources)
+			for _, streamlet := range streamlets {
+				pod := cli.GetFirstStreamletPod(&appStatus, streamlet)
+				Expect(pod).NotTo(Equal(nil))
+				podRes, err := kubectl.GetPodResources(swissKnifeApp.Name, pod.Pod)
+				Expect(err).NotTo(HaveOccurred())
+				streamletResourceConfigMap[streamlet] = podRes
+			}
+
+			By("Reconfigure the Akka Kubernetes Runtime")
+			err = cli.Configure(swissKnifeApp, UpdateAkkaRuntimeResourcesFile)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Wait for the deployment of the new configuration")
+			oneSecond, _ := time.ParseDuration("5s")
+			time.Sleep(oneSecond) // this wait is to let the application go into deployment
+			cli.PollUntilAppStatusIs(swissKnifeApp, "Running")
+
+			By("Get new resource configuration")
+			updatedAppStatus, err := cli.Status(swissKnifeApp)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, streamlet := range streamlets {
+				pod := cli.GetFirstStreamletPod(&updatedAppStatus, streamlet)
+				Expect(pod).NotTo(Equal(nil))
+				updatedPodRes, err := kubectl.GetPodResources(swissKnifeApp.Name, pod.Pod)
+				Expect(err).NotTo(HaveOccurred())
+				oldRes := streamletResourceConfigMap[streamlet]
+				Expect(updatedPodRes.Cpu).NotTo(Equal(oldRes.Cpu))
+				Expect(updatedPodRes.Mem).NotTo(Equal(oldRes.Mem))
+				// TODO: Read the config file for these values
+				Expect(updatedPodRes.Cpu).To(Equal("665m"))
+				Expect(updatedPodRes.Mem).To(Equal("655M"))
+			}
 			close(done)
 		}, LongTimeout)
 	})

--- a/integration-tests/itest/kubectl/kubectl.go
+++ b/integration-tests/itest/kubectl/kubectl.go
@@ -72,7 +72,7 @@ func GetPodResources(namespace string, pod string) (podResources PodResources, e
 		return
 	}
 	res := string(out)
-	regex := regexp.MustCompile(`cpu:(?P<cpu>\d+\w+) memory:(?P<memory>\d+\w+)`)
+	regex := regexp.MustCompile(`cpu:(?P<cpu>\d+\w*) memory:(?P<memory>\d+\w+)`)
 	match := regex.FindStringSubmatch(res)
 	names := regex.SubexpNames()
 	for i, matchInstance := range match {

--- a/integration-tests/itest/resources/update_akka_runtime.conf
+++ b/integration-tests/itest/resources/update_akka_runtime.conf
@@ -1,0 +1,4 @@
+cloudflow.runtimes.akka.kubernetes.pods.pod.containers.container.resources.requests {
+    memory = "655M"
+    cpu = "665m"
+}


### PR DESCRIPTION
Adds coverage for testing the behavior of configuring runtime Kubernetes options by testing that an update of a runtime value gets propagated to all streamlets of that runtime.