### PR TITLE
Upgrade test impl to 2.0.0 rc4

### DIFF
--- a/integration-tests/itest/cli/cli.go
+++ b/integration-tests/itest/cli/cli.go
@@ -45,54 +45,56 @@ type StreamletPod struct {
 
 var pollSleepInterval, _ = time.ParseDuration("5s")
 
+func logIfOutputFailure(command string, output []byte, err error) {
+	if err != nil {
+		fmt.Printf("[%s] error. Output: [%s] Error code: [%s]", command, output, err.Error())
+	}
+}
+
 // Deploy initiates the deployment of an application to the k8s cluster
 func Deploy(app App, user string, pwd string) (deployRes string, deployErr error) {
 	cmd := exec.Command("kubectl", "cloudflow", "deploy", app.CRFile, "--username", user, "--password", pwd)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		fmt.Printf("deploy error out [%s] code %s", out, err.Error())
-	}
+	logIfOutputFailure("deploy", out, err)
 	return string(out), err
 }
 
 // Undeploy initiates an application undeployment on the active cluster
 func Undeploy(app App) error {
 	cmd := exec.Command("kubectl", "cloudflow", "undeploy", app.Name)
-	_, err := cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
+	logIfOutputFailure("undeploy", out, err)
 	return err
 }
 
 // Scale changes the scale factor of a streamlet in an app
 func Scale(app App, streamlet string, scale int) error {
 	cmd := exec.Command("kubectl", "cloudflow", "scale", app.Name, streamlet, strconv.Itoa(scale))
-	_, err := cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
+	logIfOutputFailure("scale", out, err)
 	return err
 }
 
 // Configure applies a configuration file to a given application
 func Configure(app App, filePath string) error {
-	// kubectl cloudflow configure swiss-knife --conf message.conf
 	cmd := exec.Command("kubectl", "cloudflow", "configure", app.Name, "--conf", filePath)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		fmt.Printf("Configure failed. Reason: %s", out)
-		return err
-	}
-	return nil
+	logIfOutputFailure("configure", out, err)
+	return err
 }
 
 // ListApps returns the list of of deployed applications on the currently active cluster
 func ListApps() (entries []AppEntry, err error) {
 	cmd := exec.Command("kubectl", "cloudflow", "list")
-	out, er := cmd.CombinedOutput()
-	if er != nil {
-		err = er
-		return
+	out, err := cmd.CombinedOutput()
+	var res []AppEntry
+	logIfOutputFailure("list", out, err)
+	if err != nil {
+		return res, err
 	}
 	str := string(out)
 	splits := strings.Split(str, "\n")
 	whitespaces := regexp.MustCompile(`\s+`)
-	var res []AppEntry
 	for i, line := range splits {
 		switch i {
 		case 0: // skip the first line
@@ -101,7 +103,6 @@ func ListApps() (entries []AppEntry, err error) {
 			parts := whitespaces.Split(line, -1)
 			if len(parts) == 7 {
 				appEntry := AppEntry{parts[0], parts[1], parts[2], parts[3] + parts[4] + parts[5] + parts[6]}
-				fmt.Printf("App listed %s", appEntry)
 				res = append(res, appEntry)
 			}
 		}
@@ -127,12 +128,12 @@ func ListAppNames() (appNames []string, err error) {
 func Status(app App) (status AppStatus, err error) {
 	cmd := exec.Command("kubectl", "cloudflow", "status", app.Name)
 	out, err := cmd.CombinedOutput()
+	logIfOutputFailure("status", out, err)
 	mkErr := func(err error) (AppStatus, error) {
 		return AppStatus{}, err
 	}
 	if err != nil {
-		fmt.Printf("Error executing status command: %s", out)
-		return
+		return mkErr(err)
 	}
 	str := string(out)
 	splits := strings.Split(str, "\n")
@@ -150,7 +151,7 @@ func Status(app App) (status AppStatus, err error) {
 				return mkErr(err)
 			}
 			if value[0] != names[i] {
-				err = fmt.Errorf("unexpected header name. Got [%s] but expected [%s]", value[0], names[i])
+				err = fmt.Errorf("Unexpected header name. Got [%s] but expected [%s]", value[0], names[i])
 				return mkErr(err)
 			}
 			*fields[i] = value[1]
@@ -162,27 +163,44 @@ func Status(app App) (status AppStatus, err error) {
 			if len(strings.TrimSpace(line)) == 0 {
 				continue
 			}
-			parts, err := parseLineInN(line, 5)
+			parts, err := parseLineInN(line, 4)
 			if err != nil {
 				return mkErr(err)
 			}
 			var streamletPod StreamletPod
 			streamletPod.Streamlet = parts[0]
-			streamletPod.Pod = parts[1]
-			streamletPod.ActualReady, streamletPod.ExpectedReady, err = parseReady(parts[2])
-			if err != nil {
-				return mkErr(err)
+
+			var parseErr error
+			if len(parts) == 4 { // POD = empty
+				streamletPod.Pod = ""
+				streamletPod, parseErr = parseStreamletPod(streamletPod, parts[1:4])
+			} else {
+				streamletPod.Pod = parts[1]
+				streamletPod, parseErr = parseStreamletPod(streamletPod, parts[2:5])
 			}
-			streamletPod.Status = parts[3]
-			streamletPod.Restarts, err = strconv.Atoi(parts[4])
-			if err != nil {
-				return mkErr(err)
+
+			if parseErr != nil {
+				return mkErr(parseErr)
 			}
 			streamletPods = append(streamletPods, streamletPod)
 		}
 	}
 	status.StreamletPods = streamletPods
 	return status, nil
+}
+
+func parseStreamletPod(streamletPod StreamletPod, elems []string) (StreamletPod, error) {
+	var err error
+	streamletPod.ActualReady, streamletPod.ExpectedReady, err = parseReady(elems[0])
+	if err != nil {
+		return streamletPod, err
+	}
+	streamletPod.Status = elems[1]
+	streamletPod.Restarts, err = strconv.Atoi(elems[2])
+	if err != nil {
+		return streamletPod, err
+	}
+	return streamletPod, nil
 }
 
 func parseReady(str string) (actual int, expected int, err error) {

--- a/integration-tests/itest/deploy_test.go
+++ b/integration-tests/itest/deploy_test.go
@@ -29,6 +29,8 @@ const (
 	UpdateAkkaRuntimeResourcesFile = "./resources/update_akka_runtime.conf"
 )
 
+var deploySleepTime, _ = time.ParseDuration("5s")
+
 var swissKnifeApp = cli.App{
 	CRFile: "./resources/swiss-knife.json",
 	Name:   "swiss-knife",
@@ -58,6 +60,7 @@ var _ = Describe("Application deployment", func() {
 			output, err := cli.Deploy(swissKnifeApp, "", "")
 			Expect(err).NotTo(HaveOccurred())
 			expected := "Deployment of application `" + swissKnifeApp.Name + "` has started."
+			time.Sleep(deploySleepTime) // this wait is to let the application go into deployment
 			Expect(output).To(ContainSubstring(expected))
 		})
 
@@ -167,8 +170,7 @@ var _ = Describe("Application deployment", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Wait for the deployment of the new configuration")
-			sleepTime, _ := time.ParseDuration("5s")
-			time.Sleep(sleepTime) // this wait is to let the application go into deployment
+			time.Sleep(deploySleepTime) // this wait is to let the application go into deployment
 			cli.PollUntilAppStatusIs(swissKnifeApp, "Running")
 
 			By("Get new resource configuration")
@@ -204,8 +206,7 @@ var _ = Describe("Application deployment", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Wait for the deployment of the new configuration")
-			sleepTime, _ := time.ParseDuration("5s")
-			time.Sleep(sleepTime) // this wait is to let the application go into deployment
+			time.Sleep(deploySleepTime) // this wait is to let the application go into deployment
 			cli.PollUntilAppStatusIs(swissKnifeApp, "Running")
 
 			By("Get new resource configuration")

--- a/integration-tests/itest/resources/swiss-knife.json
+++ b/integration-tests/itest/resources/swiss-knife.json
@@ -17,12 +17,12 @@
       "prometheus": "/prometheus/jmx_prometheus_javaagent.jar"
     },
     "app_id": "swiss-knife",
-    "app_version": "396-065ce27",
+    "app_version": "425-de453c8",
     "deployments": [
       {
         "class_name": "swissknife.akka.AkkaLogger",
         "config": {},
-        "image": "docker.io/lightbend/akka:396-065ce27",
+        "image": "docker.io/lightbend/akka:425-de453c8",
         "name": "swiss-knife.akka-egress",
         "port_mappings": {
           "in": {
@@ -37,7 +37,7 @@
       {
         "class_name": "swissknife.spark.SparkCounter",
         "config": {},
-        "image": "docker.io/lightbend/spark:396-065ce27",
+        "image": "docker.io/lightbend/spark:425-de453c8",
         "name": "swiss-knife.spark-process",
         "port_mappings": {
           "in": {
@@ -56,7 +56,7 @@
       {
         "class_name": "swissknife.akka.AkkaLogger",
         "config": {},
-        "image": "docker.io/lightbend/akka:396-065ce27",
+        "image": "docker.io/lightbend/akka:425-de453c8",
         "name": "swiss-knife.flink-egress",
         "port_mappings": {
           "in": {
@@ -71,7 +71,7 @@
       {
         "class_name": "swissknife.spark.SparkDataGenerator",
         "config": {},
-        "image": "docker.io/lightbend/spark:396-065ce27",
+        "image": "docker.io/lightbend/spark:425-de453c8",
         "name": "swiss-knife.ingress",
         "port_mappings": {
           "out": {
@@ -86,7 +86,7 @@
       {
         "class_name": "swissknife.flink.FlinkCounter",
         "config": {},
-        "image": "docker.io/lightbend/flink:396-065ce27",
+        "image": "docker.io/lightbend/flink:425-de453c8",
         "name": "swiss-knife.flink-process",
         "port_mappings": {
           "in": {
@@ -105,7 +105,7 @@
       {
         "class_name": "swissknife.akka.AkkaLogger",
         "config": {},
-        "image": "docker.io/lightbend/akka:396-065ce27",
+        "image": "docker.io/lightbend/akka:425-de453c8",
         "name": "swiss-knife.spark-egress",
         "port_mappings": {
           "in": {
@@ -120,7 +120,7 @@
       {
         "class_name": "swissknife.akka.AkkaTransformation",
         "config": {},
-        "image": "docker.io/lightbend/akka:396-065ce27",
+        "image": "docker.io/lightbend/akka:425-de453c8",
         "name": "swiss-knife.akka-process",
         "port_mappings": {
           "in": {
@@ -139,7 +139,7 @@
       {
         "class_name": "swissknife.akka.AkkaLogger",
         "config": {},
-        "image": "docker.io/lightbend/akka:396-065ce27",
+        "image": "docker.io/lightbend/akka:425-de453c8",
         "name": "swiss-knife.raw-egress",
         "port_mappings": {
           "in": {
@@ -154,7 +154,7 @@
       {
         "class_name": "swissknife.spark.SparkOutput",
         "config": {},
-        "image": "docker.io/lightbend/spark:396-065ce27",
+        "image": "docker.io/lightbend/spark:425-de453c8",
         "name": "swiss-knife.spark-output",
         "port_mappings": {
           "in": {
@@ -167,7 +167,7 @@
         "streamlet_name": "spark-output"
       }
     ],
-    "library_version": "1.3.4-SNAPSHOT",
+    "library_version": "2.0.0-RC4",
     "streamlets": [
       {
         "descriptor": {

--- a/integration-tests/swiss-knife/project/cloudflow-plugins.sbt
+++ b/integration-tests/swiss-knife/project/cloudflow-plugins.sbt
@@ -3,5 +3,5 @@
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 resolvers += Resolver.url("cloudflow", url("https://lightbend.bintray.com/cloudflow"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "2.0.0-SNAPSHOT")
+addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % "2.0.0-RC4")
 


### PR DESCRIPTION
This PR upgrades swiss-knife and the test impl to support cloudflow 2.0.0-RC4.
In particular:
- added a delay after deploy to ensure that the deploy status is known
- refactored the `Status` parsing to support the absence of pods
- added command output when a CLI command fails to improve debugging.