### PR TITLE
Made installer image configurable in bootstrap script

### DIFF
--- a/installer/release/bootstrap-install-script.sh.template
+++ b/installer/release/bootstrap-install-script.sh.template
@@ -16,6 +16,13 @@ print_error_message() {
   echo "$(tput setaf 1)$errorMessage$(tput sgr0)"
 }
 
+CLOUDFLOW_INSTALLER_IMAGE=$1
+if [ -z "$CLOUDFLOW_INSTALLER_IMAGE" ]; then
+    CLOUDFLOW_INSTALLER_IMAGE=lightbend/cloudflow-installer
+fi
+echo "Cloudflow installer image to be used: $CLOUDFLOW_INSTALLER_IMAGE"
+echo
+
 ##### 1) Download yaml for the installer and Cloudflow CR
 # Embedded Yaml, inserted by the Makefile
 
@@ -223,7 +230,8 @@ else
 fi
 
 echo "$CLOUDFLOW_INSTALLER_YAML" | \
-  sed -e "s/CLOUDFLOW_INSTALLER_IMAGE_TAG_PH/$CLOUDFLOW_INSTALLER_IMAGE_TAG/" | \
+  sed -e "s~CLOUDFLOW_INSTALLER_IMAGE_TAG_PH~$CLOUDFLOW_INSTALLER_IMAGE_TAG~" \
+      -e "s~CLOUDFLOW_INSTALLER_IMAGE_PH~$CLOUDFLOW_INSTALLER_IMAGE~" | \
   kubectl apply -f -
 
 ##### 5) Wait for installer deployment rollout

--- a/installer/release/cloudflow-installer.yaml
+++ b/installer/release/cloudflow-installer.yaml
@@ -42,7 +42,7 @@ spec:
       serviceAccountName: cloudflow-installer
       containers:
         - name: cloudflow-installer
-          image: lightbend/cloudflow-installer:CLOUDFLOW_INSTALLER_IMAGE_TAG_PH
+          image: CLOUDFLOW_INSTALLER_IMAGE_PH:CLOUDFLOW_INSTALLER_IMAGE_TAG_PH
           imagePullPolicy: Always
           ports:
             - containerPort: 5001

--- a/installer/release/definitions.mk
+++ b/installer/release/definitions.mk
@@ -1,5 +1,5 @@
-version := 2.0.0-SNAPSHOT
-cloudflow_installer_image_tag := 2.0.0-SNAPSHOT
-cloudflow_operator_image_tag := 2.0.0-SNAPSHOT
+version := 2.0.0
+cloudflow_installer_image_tag := 2.0.0
+cloudflow_operator_image_tag := 2.0.0
 
 cloudflow_spark_operator_image := 1.3.3-OpenJDK-2.4.5-1.1.0-cloudflow-2.12


### PR DESCRIPTION
### What changes were proposed in this pull request?
#505 Previously, the installer image is hard coded as `lightbend/cloudflow-installer`. The user can now pass a custom image (including the docker repository and the image name) to the bootstrap script. Something like: `./bootstrap-install-script-2.0.0.sh lightbend-docker-commercial-registry.bintray.io/lightbend/cloudflow-installer`. If not specified, the default image `lightbend/cloudflow-installer` will be used.

### Why are the changes needed?
A user request

### Does this PR introduce any user-facing change?
Yes. Bootstrap script now has an optional argument.

### How was this patch tested?
By running the script without the argument and with argument and making sure the installer image has been changed properly.