### PR TITLE
Add 2.0 docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,6 +16,11 @@ javascaladoc_dir := ${staging_dir}/docs/current/api
 
 all: build
 
+local-preview: html-author-mode
+	@echo "Access the documentation on http://localhost:8000"
+	(cd target/staging/; python3 -m http.server)
+
+
 show:
 	echo work dir: ${work_dir}
 	echo ROOT_DIR: ${ROOT_DIR}

--- a/docs/docs-source/docs/modules/ROOT/partials/include.adoc
+++ b/docs/docs-source/docs/modules/ROOT/partials/include.adoc
@@ -1,7 +1,7 @@
 :page-partial:
 // global attributes
-:cloudflow-version: 2.0.0-SNAPSHOT
-:cloudflow-examples-version: 2.0.0-SNAPSHOT
+:cloudflow-version: 2.1.0-SNAPSHOT
+:cloudflow-examples-version: 2.1.0-SNAPSHOT
 
 :installer-image-tag:          INSTALLER_IMAGE_TAG
 :kubernetes-platform-name:     Kubernetes

--- a/docs/docs-source/site.yml
+++ b/docs/docs-source/site.yml
@@ -9,7 +9,7 @@ content:
       - docs/docs-source/docs
       - docs/shared-content-source/docs
       - examples/snippets
-    branches: [master, v1.3.3-docs]  # versioned content - add branches here 
+    branches: [master, v1.3.3-docs, v2.0.0-docs]  # versioned content - add branches here 
   - url: git@github.com:lightbend/cloudflow.git
     start-path: docs/homepage-source/docs
     branches: [master] # should always remain as master

--- a/docs/shared-content-source/docs/antora.yml
+++ b/docs/shared-content-source/docs/antora.yml
@@ -1,6 +1,6 @@
 name: shared-content
 title: ""
-version: 2.0.0-SNAPSHOT
+version: 2.1.0-SNAPSHOT
 prerelease: Beta
 
 

--- a/docs/shared-content-source/docs/modules/ROOT/partials/include.adoc
+++ b/docs/shared-content-source/docs/modules/ROOT/partials/include.adoc
@@ -1,6 +1,6 @@
 // global attributes
 :page-partial:
 
-:cloudflow-version: 2.0.0-SNAPSHOT
-:cloudflow-examples-version: 2.0.0-SNAPSHOT
+:cloudflow-version: 2.1.0-SNAPSHOT
+:cloudflow-examples-version: 2.1.0-SNAPSHOT
 :cli-plugin: kubectl

--- a/docs/shared-content-source/docs/modules/develop/pages/streamlet-volume-mounts.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/streamlet-volume-mounts.adoc
@@ -1,3 +1,7 @@
+:page-partial:
+
+include::ROOT:partial$include.adoc[]
+
 Sometimes a streamlet needs to read and/or write files from/to some shared file system. Since streamlets run as processes on Kubernetes, they do not automatically have such a file system available. Cloudflow makes it possible for a streamlet to declare the need for a shared file system (e.g. a "volume" in Kubernetes terms) that should be mounted at a specific path. At deployment time the user can then indicate where that file system is actually located using a Kubernetes Persistent Volume Claim (PVC). Cloudflow will then make sure that the PVC will be mounted at the specified path at runtime and the streamlet can then treat it like a local file system.
 
 The following example streamlet shows how to declare and use a volume mount:

--- a/docs/shared-content-source/docs/modules/develop/pages/use-akka-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-akka-streamlets.adoc
@@ -1,5 +1,7 @@
 :page-partial:
 
+include::ROOT:partial$include.adoc[]
+
 An Akka-based streamlet has the following responsibilities:
 
 * Capturing your stream processing logic.

--- a/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -1,5 +1,7 @@
 :page-partial:
 
+include::ROOT:partial$include.adoc[]
+
 A Flink streamlet has the following responsibilities:
 
 * It needs to capture your stream processing logic.

--- a/examples/snippets/antora.yml
+++ b/examples/snippets/antora.yml
@@ -1,4 +1,4 @@
 name: "docsnippets"
-version: 2.0.0-SNAPSHOT
+version: 2.1.0-SNAPSHOT
 title: ""
 prerelease: Beta


### PR DESCRIPTION
This PR Adds the 2.0-docs branch to the supported branches of Antora.
Under the covers, I also created a [2.0.0-docs](https://github.com/lightbend/cloudflow/tree/v2.0.0-docs) branch and demoted the [1.3.3 branch](https://github.com/lightbend/cloudflow/commit/135ed115c019c831cfc476221cafd9e4a9077742) from `current` to `1.3.3`. 

This should create the required versions on the website once this gets merged. :crossed_fingers:  

cc: @rstento for you to see the version upgrade process. It's maybe useful for you, or you might have suggestions to improve it.