### PR TITLE
Explicitly set service account on Spark executor CR.

### DIFF
--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/SparkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/SparkRunner.scala
@@ -383,6 +383,7 @@ object SparkResource {
       coreLimit: Option[String] = None,
       env: Option[List[EnvVar]] = None,
       javaOptions: Option[String] = None,
+      serviceAccount: Option[String] = Some(SparkServiceAccount),
       labels: Map[String, String] = Map(),
       configMaps: Seq[NamePath] = Seq(),
       secrets: Seq[NamePathSecretType] = Seq(),


### PR DESCRIPTION
Fixes #511 

- The executor cannot pull from private docker registry since it is not running with the cloudflow service account which has the image pull secrets.
