### PR TITLE
Adding cache-dir option to all antora docker runs.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -48,6 +48,7 @@ html-author-mode: clean
 		-v ${ROOT_DIR}:/antora \
 		--rm \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
+		--cache-dir=./.cache/antora \
 		--stacktrace \
 		docs/docs-source/author-mode-site.yml
 	@echo "Done"
@@ -58,6 +59,7 @@ check-links:
 		--rm \
 		--entrypoint /bin/sh \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
+		--cache-dir=./.cache/antora \
 		-c 'find /antora/docs-source -name '*.adoc' -print0 | xargs -0 -n1 asciidoc-link-check -p -c docs-source/asciidoc-link-check-config.json'
 
 list-todos: html
@@ -66,6 +68,7 @@ list-todos: html
 		--rm \
 		--entrypoint /bin/sh \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
+		--cache-dir=./.cache/antora \
 		-c 'find /antora/docs-source/build/site/cloudflow/${version} -name "*.html" -print0 | xargs -0 grep -iE "TODO|FIXME|REVIEWERS|adoc"'
 
 # Generate the ScalaDoc and the JavaDoc, and put it in ${output}/scaladoc and ${output}/javadoc


### PR DESCRIPTION
It did not work for me locally without this setting, got error:
```Error: EACCES: permission denied, mkdir '/.cache'```