### PR TITLE
Reduce resources requested

### DIFF
--- a/installer/yaml/Makefile
+++ b/installer/yaml/Makefile
@@ -207,10 +207,10 @@ ${cloudflow_operator_managed_strimzi_work_dir}/base.yaml: helm-fetch-cloudflow-o
 			--set kafka.strimzi.topicOperatorNamespace="${strimziTopicOperatorNamespacePH}" \
 			--set operator.image.name="${cloudflow_operator_image_name}:${cloudflowOperatorImageTagPH}"\
 			--set operator.image.tag="${cloudflowOperatorImageTagPH}" \
-			--set operator.resources.requests.memory="256M" \
-			--set operator.resources.requests.cpu="1" \
+			--set operator.resources.requests.memory="512M" \
+			--set operator.resources.requests.cpu="100m" \
 			--set operator.resources.limits.memory="1024M" \
-			--set operator.resources.limits.cpu="2" \
+			--set operator.resources.limits.cpu="1" \
 			--set operator.persistentStorageClass="${cloudflowRWMStorageClassPH}",\
 			${cloudflow_operator_chart_name} | cat > "../../${cloudflow_operator_managed_strimzi_work_dir}/base.yaml")
 

--- a/installer/yaml/resources/cloudflow-operator-managed-strimzi/strimzi-kafka-cluster.yaml
+++ b/installer/yaml/resources/cloudflow-operator-managed-strimzi/strimzi-kafka-cluster.yaml
@@ -10,11 +10,19 @@ metadata:
     cloudflow.lightbend.com/build-number: __cloudflowOperator.imageTag__
 spec:
   kafka:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2G
     storage:
       type: persistent-claim
       class: __kafkaClusterCr.kafkaPersistentStorageClass__
 
   zookeeper:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2G
     storage:
       type: persistent-claim
       class: __kafkaClusterCr.zookeeperPersistentStorageClass__

--- a/installer/yaml/resources/flink-operator/flink-deployment.yaml
+++ b/installer/yaml/resources/flink-operator/flink-deployment.yaml
@@ -1,0 +1,17 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: cloudflow-flink-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: flinkoperator-gojson
+          image: lyft/flinkk8soperator:v0.4.0
+          resources:
+            limits:
+              cpu:     "2"
+              memory:  1G
+            requests:
+              cpu:     500m
+              memory:  1G

--- a/installer/yaml/resources/spark-operator/spark-operator-deployment.yaml
+++ b/installer/yaml/resources/spark-operator/spark-operator-deployment.yaml
@@ -33,3 +33,10 @@ spec:
             - -webhook-port=8080
             - -webhook-svc-name=cloudflow-webhook
             - -webhook-config-name=cloudflow-sparkoperator-webhook-config
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1024M
+            requests:
+              cpu: 100m
+              memory: 512M


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/lightbend/cloudflow-internal-ops/issues/48
Reduce resource requested for multiple components installed by the Cloudflow operator.

### Why are the changes needed?
Prior to this change, Cloudflow requires a big cluster to even install. This change requires the minimum required cluster size.


### Does this PR introduce any user-facing change?
Yes. Cluster won't be scaled upon Cloudflow installation.

### How was this patch tested?
Installing Cloudflow on a minimal cluster and checking that the installation has succeeded and the cluster has NOT scaled.