### PR TITLE
Added missing check for port (inlet or outlet) bound to many topics.

### DIFF
--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/Blueprint.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/Blueprint.scala
@@ -157,7 +157,7 @@ final case class Blueprint(
     val volumeMountProblems     = verifyVolumeMounts(streamletDescriptors)
 
     val unconnectedPortProblems = verifyPortsConnected(verifiedStreamlets, verifiedTopics)
-    val portsBoundToManyTopics  = verifyPortsBoundToManyTopics(verifiedStreamlets, verifiedTopics)
+    val portsBoundToManyTopics  = verifyPortsBoundToManyTopics(verifiedTopics)
     val globalProblems = Vector(
         emptyStreamletsProblem,
         emptyStreamletDescriptorsProblem,
@@ -216,7 +216,6 @@ final case class Blueprint(
     problems
   }
   private def verifyPortsBoundToManyTopics(
-      verifiedStreamlets: Vector[VerifiedStreamlet],
       verifiedTopics: Vector[VerifiedTopic]
   ): Vector[PortBoundToManyTopics] =
     verifiedTopics

--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/Blueprint.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/Blueprint.scala
@@ -219,14 +219,13 @@ final case class Blueprint(
       verifiedStreamlets: Vector[VerifiedStreamlet],
       verifiedTopics: Vector[VerifiedTopic]
   ): Vector[PortBoundToManyTopics] =
-    // portPath to topic
     verifiedTopics
-      .flatMap(vt => vt.connections.map(_ -> vt.id))
-      .groupBy { case (vpp, _) => vpp }
+      .flatMap(verifiedTopic => verifiedTopic.connections.map(_ -> verifiedTopic.id))
+      .groupBy { case (verifiedPort, _) => verifiedPort }
       .flatMap {
-        case (vpp, groupedTopicIds) =>
+        case (verifiedPort, groupedTopicIds) =>
           val topicIds = groupedTopicIds.map { case (_, topic) => topic }.toIndexedSeq
-          if (topicIds.size > 1) Some(PortBoundToManyTopics(vpp.portPath.toString, topicIds))
+          if (topicIds.size > 1) Some(PortBoundToManyTopics(verifiedPort.portPath.toString, topicIds))
           else None
       }
       .toVector

--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/Blueprint.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/Blueprint.scala
@@ -224,7 +224,7 @@ final case class Blueprint(
       .groupBy { case (verifiedPort, _) => verifiedPort }
       .flatMap {
         case (verifiedPort, groupedTopicIds) =>
-          val topicIds = groupedTopicIds.map { case (_, topic) => topic }.toIndexedSeq
+          val topicIds = groupedTopicIds.map { case (_, topic) => topic }
           if (topicIds.size > 1) Some(PortBoundToManyTopics(verifiedPort.portPath.toString, topicIds))
           else None
       }

--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/BlueprintProblem.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/BlueprintProblem.scala
@@ -74,8 +74,8 @@ object BlueprintProblem {
         s"Volume mount `$name` in streamlet `$className` is invalid. Names must consist of lower case alphanumeric characters and may contain '-' except for at the start or end."
       case NonAbsoluteVolumeMountPath(className, name, path) ⇒
         s"`$className` contains a volume mount `$name` with a non-absolute path (`$path`)."
-      case PortAlreadyBoundToTopic(path, topic) ⇒
-        s"'$path' is already bound to topic '$topic'."
+      case PortBoundToManyTopics(path, topics) ⇒
+        s"'$path' is bound to more than one topic: ${topics.mkString(",")}."
       case PortPathNotFound(path, suggestions) ⇒
         val end = if (suggestions.nonEmpty) s""", please try ${suggestions.map(_.toString).mkString(" or ")}.""" else "."
         s"'$path' does not point to a known streamlet inlet or outlet$end"
@@ -115,7 +115,7 @@ final case class InvalidProducerPortPath(topic: String, path: String) extends Bl
 final case class InvalidConsumerPortPath(topic: String, path: String) extends BlueprintProblem with PortPathError
 final case class PortPathNotFound(path: String, suggestions: immutable.IndexedSeq[VerifiedPortPath] = immutable.IndexedSeq.empty)
     extends PortPathError
-final case class PortAlreadyBoundToTopic(path: String, topic: String) extends PortPathError
+final case class PortBoundToManyTopics(path: String, topics: immutable.IndexedSeq[String]) extends PortPathError
 
 final case class InvalidStreamletClassName(streamletRef: String, streamletClassName: String) extends BlueprintProblem
 final case class InvalidStreamletName(streamletRef: String)                                  extends BlueprintProblem

--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/BlueprintSpec.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/BlueprintSpec.scala
@@ -252,9 +252,9 @@ class BlueprintSpec extends WordSpec with MustMatchers with EitherValues with Op
       blueprint.problems.collect { case unconnected: UnconnectedInlets ⇒ unconnected }.size mustBe 0
       val paths = Vector(VerifiedPortPath(ingressRef.name, "out"), VerifiedPortPath(egress2Ref.name, "in"))
         .sortBy(_.toString)
-      blueprint.problems.filterNot {
-        case PortBoundToManyTopics(_, _) => true
-        case _                           => false
+      blueprint.problems.filter {
+        case PortBoundToManyTopics(_, _) => false
+        case _                           => true
       } mustBe Vector(
         IncompatibleSchema(
           paths(0),

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/CloudflowApplicationSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/CloudflowApplicationSpec.scala
@@ -237,7 +237,7 @@ class CloudflowApplicationSpec
       .use(egress1Ref)
       .use(egress2Ref)
       .connect(Topic("foos1"), ingressRef.out, egress1Ref.in)
-      .connect(Topic("foos2"), ingressRef.out, egress2Ref.in)
+      .connect(Topic("foos2"), egress2Ref.in)
       .verified
       .right
       .value
@@ -261,7 +261,7 @@ class CloudflowApplicationSpec
       .use(sparkEgressRef)
       .use(flinkEgressRef)
       .connect(Topic("foos1"), ingressRef.out, sparkEgressRef.in)
-      .connect(Topic("foos2"), ingressRef.out, flinkEgressRef.in)
+      .connect(Topic("foos2"), flinkEgressRef.in)
       .verified
       .right
       .value


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Fixes #549  Missing check for connecting an inlet or outlet to more than one topic.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The API implementation does not auto merge sources to the inlet, or broadcast to sinks from an outlet. So it is important this check is in place.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.