### PR TITLE
deprecate buildAndPublish

### DIFF
--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/BuildAppPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/BuildAppPlugin.scala
@@ -55,7 +55,7 @@ object BuildAppPlugin extends AutoPlugin {
           .taskDyn {
             val filter = ScopeFilter(inProjects(allProjectsWithCloudflowBasePlugin.value: _*))
             Def.task {
-              val allValues = buildAndPublish.all(filter).value
+              val allValues = buildAndPublishImage.all(filter).value
               allValues
             }
           })

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
@@ -88,7 +88,7 @@ object CloudflowBasePlugin extends AutoPlugin {
     buildAndPublish := Def.task {
           val log = streams.value.log
           log.err("""`buildAndPublish` is deprecated since Cloudflow v2.0. Use `buildApp` instead.
-                     | See https://cloudflow.io/docs/current/app-development-process.html#_publishing_the_application_artifacts for more info.
+                     | See https://cloudflow.io/docs/current/project-info/migration-1_3-2_0.html#_build_process for more info.
                   """.stripMargin)
         }.value,
     buildAndPublishImage := Def.task {

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
@@ -86,6 +86,12 @@ object CloudflowBasePlugin extends AutoPlugin {
           )
           .value,
     buildAndPublish := Def.task {
+          val log = streams.value.log
+          log.err("""`buildAndPublish` is deprecated since Cloudflow v2.0. Use `buildApp` instead.
+                     | See https://cloudflow.io/docs/current/app-development-process.html#_publishing_the_application_artifacts for more info.
+                  """.stripMargin)
+        }.value,
+    buildAndPublishImage := Def.task {
           val _ = (checkUncommittedChanges.value, verifyDockerRegistry.value)
           Def.task {
             val streamletDescriptors = streamletDescriptorsInProject.value

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowKeys.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowKeys.scala
@@ -57,10 +57,11 @@ trait CloudflowTaskKeys {
   val extraDockerInstructions   = taskKey[Seq[sbtdocker.Instruction]]("A list of instructions to add to the dockerfile.")
   val verifyBlueprint           = taskKey[Unit]("Verify Blueprint.")
   val build                     = taskKey[Unit]("Build the image.")
-  val buildAndPublish           = taskKey[(ImageNameAndId, Map[String, StreamletDescriptor])]("Build and publish the image.")
+  val buildAndPublish           = taskKey[Unit]("[Deprecated! Use buildApp] Build and publish the image.")
   val runLocal                  = taskKey[Unit]("Run the Cloudflow application in a local Sandbox.")
   val buildApp                  = taskKey[Unit]("Build the Cloudflow Application CR.")
 
+  private[sbt] val buildAndPublishImage  = taskKey[(ImageNameAndId, Map[String, StreamletDescriptor])]("Build and publish a project image.")
   private[sbt] val allBuildAndPublish    = taskKey[Map[ImageNameAndId, Map[String, StreamletDescriptor]]]("Build and push all the images.")
   private[sbt] val cloudflowWorkDir      = taskKey[File]("The directory under /target used for internal bookkeeping.")
   private[sbt] val cloudflowStageAppJars = taskKey[Unit]("Stages the jars for the application.")


### PR DESCRIPTION
Deprecates `buildAndPublish` in favor of `buildApp`
Adds an error message to  `buildAndPublish` 
and moves the internal implementation to a private key.