### PR TITLE
Replaced Ubuntu with Alpine in webhook patch job

### DIFF
--- a/installer/release/definitions.mk
+++ b/installer/release/definitions.mk
@@ -12,4 +12,4 @@ kafka_image_name := strimzi/kafka
 kafka_image_tag := 0.16.2-kafka-2.4.0
 strimzi_operator_image_name := strimzi/operator
 strimzi_operator_image_tag := 0.16.2
-webhook_patch_job_image := ubuntu:latest
+webhook_patch_job_image := alpine:3.9

--- a/installer/src/test/scala/com/lightbend/cloudflow/installer/TestInstance.scala
+++ b/installer/src/test/scala/com/lightbend/cloudflow/installer/TestInstance.scala
@@ -8,7 +8,7 @@ object TestInstance {
   def get(): CustomResource[Spec, Status] = {
     val kafkaClusterCr    = KafkaClusterCR("strimzi", "0.16.2", "gp2", "gp2", "strimzi/kafka", "0.16.2-kafka-2.4.0", "strimzi/operator", "0.16.2")
     val flinkOperator     = FlinkOperator("0.8.2", "flink-service-account", "lyft/flinkk8soperator", "v0.4.0")
-    val sparkOperator     = SparkOperator("0.6.7", "lightbend/sparkoperator", "1.3.3-OpenJDK-2.4.5-1.1.0-cloudflow-2.12", "ubuntu:latest")
+    val sparkOperator     = SparkOperator("0.6.7", "lightbend/sparkoperator", "1.3.3-OpenJDK-2.4.5-1.1.0-cloudflow-2.12", "alpine:3.9")
     val cloudflowOperator = CloudflowOperator("lightbend/cloudflow-operator", "2.0.0", "glusterfs-storage")
     val spec = Spec(
       kafkaClusterCr,

--- a/installer/yaml/definitions.mk
+++ b/installer/yaml/definitions.mk
@@ -18,4 +18,4 @@ kafka_image_name                     := strimzi/kafka
 kafka_image_tag                      := 0.16.2-kafka-2.4.0
 strimzi_operator_image_name          := strimzi/operator
 strimzi_operator_image_tag           := 0.16.2
-webhook_patch_job_image              := ubuntu:latest
+webhook_patch_job_image              := alpine:3.9

--- a/installer/yaml/resources/patch-owner-reference-of-spark-mutatingwebhookconfig/patch_mutatingwebhookconfig.yaml
+++ b/installer/yaml/resources/patch-owner-reference-of-spark-mutatingwebhookconfig/patch_mutatingwebhookconfig.yaml
@@ -13,11 +13,11 @@ spec:
         - name: main
           image: __webhookPatchJob.image__
           command:
-            - bash
+            - /bin/ash
             - "-c"
             - |
-              apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
-              wget -q -O /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl && chmod 755 /bin/kubectl
+              apk update && apk add wget
+              wget -q -O /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.12/bin/linux/amd64/kubectl && chmod 755 /bin/kubectl
               NAME="cloudflow-sparkoperator"
               API_VERSION=$(kubectl get deployment -n __namespace__ $NAME -o jsonpath='{.apiVersion}')
               UUID=$(kubectl get deployment -n __namespace__ $NAME -o jsonpath='{.metadata.uid}')


### PR DESCRIPTION
### What changes were proposed in this pull request?
Addressed #570 

### Why are the changes needed?
To use a lighter-weight and more secure base image.

### Does this PR introduce any user-facing change?
No. The job patches the webhook config object. This change is transparent to the user.

### How was this patch tested?
By running the installer and checking that the patch job succeeded and the MutatingWebhookConfiguration resource has been properly patched.