### PR TITLE
Changing Cloudflow operator to use alpine base image

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,8 +1,7 @@
 import sbt._
 import sbt.Keys._
-
 import Library._
-
+import sbtdocker.Instructions
 import sbtrelease.ReleaseStateTransformations._
 
 lazy val root =
@@ -431,9 +430,12 @@ lazy val operator =
         val targetDir    = "/app"
 
         new Dockerfile {
-          from("adoptopenjdk/openjdk8:latest")
+          from("adoptopenjdk/openjdk8:alpine")
+
           entryPoint(s"$targetDir/bin/${executableScriptName.value}")
           copy(appDir, targetDir, chown = "daemon:daemon")
+          addInstruction(
+            Instructions.Run("apk add bash; \\"))
         }
       },
       Test / fork := true,

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -431,7 +431,6 @@ lazy val operator =
 
         new Dockerfile {
           from("adoptopenjdk/openjdk8:alpine")
-
           entryPoint(s"$targetDir/bin/${executableScriptName.value}")
           copy(appDir, targetDir, chown = "daemon:daemon")
           addInstruction(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
changing base image from ubuntu to alpine


### Why are the changes needed?
To avoid High Risk vulnerabilities found through Jfrog/Xray:

dpkg-source in dpkg 1.3.0 through 1.18.23 is able to use a non-GNU patch program and does not offer a protection mechanism for blank-indented diff hunks, which allows remote attackers to conduct directory traversal attacks via a crafted Debian source package, as demonstrated by use of dpkg-source on NetBSD.

In util-linux before 2.32-rc1, bash-completion/umount allows local users to gain privileges by embedding shell commands in a mountpoint name, which is mishandled during a umount command (within Bash) by a different user, as demonstrated by logging in as root and entering umount followed by a tab character for autocompletion.

Some HTTP/2 implementations are vulnerable to resource loops, potentially leading to a denial of service. The attacker creates multiple request streams and continually shuffles the priority of the streams in a way that causes substantial churn to the priority tree. This can consume excess CPU.
...

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Deploying in GKE the operator and deploying example app [call-record-aggregator](https://github.com/lightbend/cloudflow/tree/master/examples/call-record-aggregator)
