### PR TITLE
Changed base images for Akka and Flink to Alpine

### DIFF
--- a/external/multi-base-images/akka/Dockerfile
+++ b/external/multi-base-images/akka/Dockerfile
@@ -17,17 +17,19 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk8
+FROM adoptopenjdk/openjdk8:alpine
 
 USER root
 
-RUN mkdir -p /home/cloudflow && \
+RUN apk add bash curl && \
+    mkdir -p /home/cloudflow && \
     mkdir -p /opt && \
-    groupadd -r cloudflow -g 185 && \
-    useradd -u 185 -r -g root -G cloudflow -m -d /home/cloudflow -s /sbin/nologin -c CloudflowUser cloudflow && \
+    addgroup -g 185 -S cloudflow && \
+    adduser -u 185 -S -h /home/cloudflow -s /sbin/nologin cloudflow cloudflow && \
+    adduser cloudflow root && \
     mkdir -p /prometheus && \
-    curl  https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar -o /prometheus/jmx_prometheus_javaagent.jar 
+    curl https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar -o /prometheus/jmx_prometheus_javaagent.jar
 
 COPY akka-entrypoint.sh /opt/
 USER 185
-ENTRYPOINT ["/opt/akka-entrypoint.sh"]
+ENTRYPOINT ["bash", "/opt/akka-entrypoint.sh"]

--- a/external/multi-base-images/flink/Dockerfile
+++ b/external/multi-base-images/flink/Dockerfile
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM adoptopenjdk/openjdk8
+FROM adoptopenjdk/openjdk8:alpine
 
 # Prepare environment
 ENV FLINK_VERSION=1.10.0 \
@@ -29,19 +29,20 @@ USER root
 ENV FLINK_TGZ=flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION}.tgz
 ENV FLINK_TGZ_URL=https://archive.apache.org/dist/flink/flink-${FLINK_VERSION}/${FLINK_TGZ}
 
-RUN mkdir ${FLINK_HOME}; \
-    groupadd --system --gid=9999 flink && \
-    useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink; \
-    groupadd -r cloudflow -g 185 && \
-    useradd -u 185 -r -g root -G cloudflow -m -d /home/cloudflow \
-    -s /sbin/nologin -c CloudflowUser cloudflow
+RUN apk add curl bash
+
+RUN mkdir ${FLINK_HOME} && \
+    addgroup -S -g 9999 flink &&\
+    adduser -S -h $FLINK_HOME -u 9999 flink flink && \
+    addgroup -S -g 185 cloudflow && \
+    adduser -u 185 -S -h /home/cloudflow -s /sbin/nologin cloudflow root && \
+    adduser cloudflow cloudflow
 
 # Note that gettext is for the envsubst command in the Flink entrypoint script.
 RUN set -ex; \
   curl -O "$FLINK_TGZ_URL"; \
   tar -xvzf $FLINK_TGZ; \
-  apt-get update; \
-  apt-get -y install libsnappy1v5 gettext-base; \
+  apk add gettext-dev; \
   rm -rf /var/lib/apt/lists/*; \
   rm $FLINK_TGZ; \
   mv flink-${FLINK_VERSION}/* $FLINK_HOME; \
@@ -51,7 +52,7 @@ RUN set -ex; \
   mkdir $FLINK_HOME/flink-web-upload; \
   mv $FLINK_HOME/opt/flink-queryable-state-runtime_$SCALA_VERSION-$FLINK_VERSION.jar $FLINK_HOME/lib; \
   mkdir -p /prometheus && \
-  curl  https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar -o /prometheus/jmx_prometheus_javaagent.jar && \
+  curl https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar -o /prometheus/jmx_prometheus_javaagent.jar && \
   chmod -R 777 $FLINK_HOME
 
 ADD config.sh $FLINK_HOME/bin/
@@ -61,4 +62,4 @@ COPY flink-entrypoint.sh /opt/
 
 ENV FLINK_HOME=/opt/flink
 USER 185
-ENTRYPOINT ["/opt/flink-entrypoint.sh"]
+ENTRYPOINT ["bash", "/opt/flink-entrypoint.sh"]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Updated base images for Akka and Flink.

Note that this PR does not include the update for the Spark Dockerfile because it's more involved. We need to re-inspect Lightbend fork of Spark and make sure some custom fixes are in there (e.g. Spark executor inherits the service account from the driver). And then rebuild the Spark distribution (tgz file). Updating Spark base image should come after all these.

### Why are the changes needed?
Alpine images are lighter-weight and have no known critical security vulnerabilities.

### Does this PR introduce any user-facing change?
No. 

### How was this patch tested?
Tested with Taxi Ride app that uses both Akka and Flink runtimes. Built the app using the new base images. The app worked fine.