### PR TITLE
Updated Spark base image to use Alpine; Fixed Spark build script

### DIFF
--- a/external/multi-base-images/spark/Dockerfile
+++ b/external/multi-base-images/spark/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk8
+FROM adoptopenjdk/openjdk8:alpine
 
 ARG spark_uid=185
 
@@ -41,9 +41,8 @@ ADD spark-entrypoint.sh /opt/spark-entrypoint.sh
 # docker build -t spark:latest -f kubernetes/dockerfiles/spark/Dockerfile .
 ENV TINI_VERSION v0.18.0
 RUN set -ex && \
-    apt-get update && \
     ln -s /lib /lib64 && \
-    apt install -y bash libc6 libpam-modules krb5-user libnss3 && \
+    apk add bash libc6 libpam-modules krb5-user libnss3 && \
     mkdir -p /opt/spark/work-dir && \
     touch /opt/spark/RELEASE && \
     rm /bin/sh && \
@@ -53,11 +52,11 @@ RUN set -ex && \
     rm -rf /var/cache/apt/* && \
     curl -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /sbin/tini && \
     chmod +x /sbin/tini && \
-    groupadd -r cloudflow -g 185 && \
-    useradd -u 185 -r -g root -G cloudflow -m -d /home/cloudflow \
-    -s /sbin/nologin -c CloudflowUser cloudflow && \
+    addgroup -S -g 185 cloudflow && \
+    adduser -u 185 -S -h /home/cloudflow -s /sbin/nologin cloudflow root && \
+    adduser cloudflow cloudflow && \
     mkdir -p /prometheus && \
-    curl  https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar -o /prometheus/jmx_prometheus_javaagent.jar && \
+    curl https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar -o /prometheus/jmx_prometheus_javaagent.jar && \
     chmod ug+rwX /home/cloudflow && \
     mkdir -p /opt/spark/conf && \
     mv /opt/log4j.properties /opt/spark/conf/log4j.properties && \
@@ -72,14 +71,13 @@ RUN set -ex && \
     chown cloudflow:root /opt && \
     chmod 775 /opt
 
-
 ENV SPARK_HOME=/opt/spark \
     SPARK_VERSION=2.4.5
 
 WORKDIR /opt/spark/work-dir
 RUN chmod g+w /opt/spark/work-dir
 
-ENTRYPOINT [ "/opt/spark-entrypoint.sh" ]
+ENTRYPOINT ["bash", "/opt/spark-entrypoint.sh"]
 
 # Specify the User that the actual main process will run as
 USER ${spark_uid}

--- a/external/multi-base-images/spark/Dockerfile
+++ b/external/multi-base-images/spark/Dockerfile
@@ -42,12 +42,9 @@ ADD spark-entrypoint.sh /opt/spark-entrypoint.sh
 ENV TINI_VERSION v0.18.0
 RUN set -ex && \
     ln -s /lib /lib64 && \
-    apk add bash libc6 libpam-modules krb5-user libnss3 && \
+    apk add bash curl && \
     mkdir -p /opt/spark/work-dir && \
     touch /opt/spark/RELEASE && \
-    rm /bin/sh && \
-    ln -sv /bin/bash /bin/sh && \
-    echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
     chgrp root /etc/passwd && chmod ug+rw /etc/passwd && \
     rm -rf /var/cache/apt/* && \
     curl -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /sbin/tini && \

--- a/external/multi-base-images/spark/buildLightbendSpark.sh
+++ b/external/multi-base-images/spark/buildLightbendSpark.sh
@@ -19,17 +19,11 @@
 #
 SCRIPT=`basename ${BASH_SOURCE[0]}`
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
-TAG=v2.4.5
-ORIGIN_TAG=custom-2.4.5
+VERSION=2.4.5
 DOCKER_USERNAME=lightbend
-CLOUDFLOW_VERSION=1.3.1-SNAPSHOT
+CLOUDFLOW_VERSION=2.1.0-SNAPSHOT
 SPARK_IMAGE_TAG=${CLOUDFLOW_VERSION}-cloudflow-spark-2.4.5-scala-2.12
 SPARK_OPERATOR_TAG=${CLOUDFLOW_VERSION}-cloudflow-spark-2.4.5-1.1.0-scala-2.12
-
-hub version > /dev/null 2>&1 || {
-  echo "The hub command is not installed. Please install (https://github.com/github/hub) and retry."
-  exit 1
-}
 
 set -ex
 if [ "$(uname)" == "Darwin" ]; then
@@ -37,30 +31,24 @@ if [ "$(uname)" == "Darwin" ]; then
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
   export JAVA_HOME="$(dirname $(dirname $(readlink -f $(which javac))))"
 else
-  echo "Please setup JAVA_HOME."
+  echo "Please set up JAVA_HOME."
   exit 1
 fi
 
 rm -rf $DIR/spark
 git clone https://github.com/lightbend/spark.git
 cd $DIR/spark
-git remote add upstream https://github.com/apache/spark.git
-git fetch --tags --all
-git checkout tags/$ORIGIN_TAG -b cloudflow-$ORIGIN_TAG
-rm -rf resource-managers/kubernetes/lightbend-build
+git checkout lightbend-$VERSION
 $DIR/spark/dev/change-scala-version.sh 2.12
-$DIR/spark/dev/make-distribution.sh --name cloudflow-2.12 --r --tgz -Psparkr -Pscala-2.12 -Phadoop-2.7 -Pkubernetes -Phive
-# remove upstream because hub will use it as the default push repo
-git remote remove upstream
-hub release create -a $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12.tgz -m "Cloudflow Spark $TAG distribution for K8s" -m "Cloudflow Spark $TAG release." cloudflow-$ORIGIN_TAG
+$DIR/spark/dev/make-distribution.sh --name cloudflow-2.12 --tgz -Pscala-2.12 -Phadoop-2.7 -Pkubernetes -Phive
 
 # build the Spark image
-tar -zxvf spark-${TAG:1}-bin-cloudflow-2.12.tgz
-cd $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12
-cp $DIR/metrics.properties $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12
-cp $DIR/prometheus.yaml $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12
-cp $DIR/log4j.properties $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12
-cp $DIR/spark-entrypoint.sh $DIR/spark/spark-${TAG:1}-bin-cloudflow-2.12
+tar -zxvf spark-$VERSION-bin-cloudflow-2.12.tgz
+cd $DIR/spark/spark-$VERSION-bin-cloudflow-2.12
+cp $DIR/metrics.properties $DIR/spark/spark-$VERSION-bin-cloudflow-2.12
+cp $DIR/prometheus.yaml $DIR/spark/spark-$VERSION-bin-cloudflow-2.12
+cp $DIR/log4j.properties $DIR/spark/spark-$VERSION-bin-cloudflow-2.12
+cp $DIR/spark-entrypoint.sh $DIR/spark/spark-$VERSION-bin-cloudflow-2.12
 docker build -f $DIR/Dockerfile -t $DOCKER_USERNAME/spark:$SPARK_IMAGE_TAG .
 
 # build the Spark operator image
@@ -69,7 +57,6 @@ rm -rf $DIR/spark-on-k8s-operator
 git clone https://github.com/GoogleCloudPlatform/spark-on-k8s-operator.git
 cd $DIR/spark-on-k8s-operator
 git checkout f78361119976beb7a147df9cd64e1fdd317b9311 -b spark-operator-1.1.0
-# adoptjdk image comes with all packages installed and also is based on ubuntu
 sed -i -e '/RUN apk add --no-cache openssl curl tini/d' Dockerfile
 docker build --no-cache --build-arg SPARK_IMAGE=$DOCKER_USERNAME/spark:$SPARK_IMAGE_TAG -t $DOCKER_USERNAME/sparkoperator:$SPARK_OPERATOR_TAG -f Dockerfile .
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Addressed:
https://github.com/lightbend/cloudflow-internal-ops/issues/63
#468 

The Spark build script no longer builds with R profile. It doesn't create a Github release either. We'll move away from maintaining a Lightbend fork eventually.

### Why are the changes needed?
Alpine is a lighter-weight image that has no known security vulnerabilities. The build script was also broken.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
I ported Stavros' changes at [SPARK-24748](https://github.com/apache/spark/pull/24748) to a separate branch named "lightbend-2.4.5". See diffs [here](https://github.com/apache/spark/compare/v2.4.5...lightbend:lightbend-2.4.5?expand=1). 

Then I tested with call-record-aggregator app because it uses Spark runtime. By setting in its `build.sbt`:
```
cloudflowSparkBaseImage := Some("lightbend/spark:2.1.0-SNAPSHOT-cloudflow-spark-2.4.5-scala-2.12")
```
which is an image built using the script contained in this PR, along with the Spark fork mentioned above, the executor pods start up successfully.

With the old Spark image `lightbend/spark:2.0.5-cloudflow-spark-2.4.5-scala-2.12`, the executor pods couldn't pull the image from GCR because they didn't have the same service account as the driver pods:
```
$ k -n call-record-aggregator get po
NAME                                                         READY   STATUS         RESTARTS   AGE
call-record-aggregator-cdr-aggregator-1594750835890-exec-1   0/1     ErrImagePull   0          111s
call-record-aggregator-cdr-aggregator-driver                 1/1     Running        0          2m23s
call-record-aggregator-cdr-generator1-1594750836384-exec-1   0/1     ErrImagePull   0          111s
call-record-aggregator-cdr-generator1-driver                 1/1     Running        0          2m23s
call-record-aggregator-cdr-generator2-1594750835093-exec-1   0/1     ErrImagePull   0          113s
call-record-aggregator-cdr-generator2-driver                 1/1     Running        0          2m25s
call-record-aggregator-cdr-ingress-c45b677c9-jjkfx           1/1     Running        0          2m40s
call-record-aggregator-console-egress-5f5cb59c44-hf7rt       1/1     Running        0          2m39s
call-record-aggregator-error-egress-649897b6f8-8689t         1/1     Running        0          2m40s
call-record-aggregator-split-68d98cd56f-r9ksw                1/1     Running        0          2m40s
```
Now with the new image, the executor pods can run:
```
$ k -n call-record-aggregator get po
NAME                                                         READY   STATUS    RESTARTS   AGE
call-record-aggregator-cdr-aggregator-1594750370482-exec-1   1/1     Running   0          2m25s
call-record-aggregator-cdr-aggregator-driver                 1/1     Running   0          2m57s
call-record-aggregator-cdr-generator1-1594750370691-exec-1   1/1     Running   0          2m23s
call-record-aggregator-cdr-generator1-driver                 1/1     Running   0          2m57s
call-record-aggregator-cdr-generator2-1594750369600-exec-1   1/1     Running   0          2m25s
call-record-aggregator-cdr-generator2-driver                 1/1     Running   0          2m58s
call-record-aggregator-cdr-ingress-66cb57877d-hmw46          1/1     Running   0          3m13s
call-record-aggregator-console-egress-7854dbf96f-4bd2d       1/1     Running   0          3m13s
call-record-aggregator-error-egress-6849c69b79-dxblv         1/1     Running   0          3m13s
call-record-aggregator-split-6555449494-v7kx6                1/1     Running   0          3m13s
```
And I've verified that they have the right service account.
