### PR TITLE
Adding GRPC support for protobuf generation

### DIFF
--- a/core/project/plugins.sbt
+++ b/core/project/plugins.sbt
@@ -18,5 +18,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.2"
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.34")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.7"

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CommonSettingsAndTasksPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CommonSettingsAndTasksPlugin.scala
@@ -64,8 +64,16 @@ object CommonSettingsAndTasksPlugin extends AutoPlugin {
           }.value,
       publishArtifact in (Compile, packageDoc) := false,
       publishArtifact in (Compile, packageSrc) := false,
-      libraryDependencies += "com.twitter"     %% "bijection-avro" % "0.9.7",
-      libraryDependencies += "org.apache.avro" % "avro"            % "1.8.2",
+      // Add Avro libraries
+      libraryDependencies ++= Seq(
+            "com.twitter"     %% "bijection-avro" % "0.9.7",
+            "org.apache.avro" % "avro"            % "1.8.2"
+          ),
+      // Add protoc libraries
+      libraryDependencies ++= Seq(
+            "io.grpc"              % "grpc-netty"            % scalapb.compiler.Version.grpcJavaVersion,
+            "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
+          ),
       // TODO move all of this to schema plugins, possibly specific for runtime (when specific versions of libraries are needed, like Spark and Avro 1.8.2)
       // Also needs some cleanup.
       schemaCodeGenerator := SchemaCodeGenerator.Scala,
@@ -133,7 +141,7 @@ object CommonSettingsAndTasksPlugin extends AutoPlugin {
     protocbridge.Target(
       ScalaGenerator,
       targetPath,
-      Seq("flat_package")
+      Seq("grpc")
     )
   }
 }

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CommonSettingsAndTasksPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CommonSettingsAndTasksPlugin.scala
@@ -71,7 +71,7 @@ object CommonSettingsAndTasksPlugin extends AutoPlugin {
           ),
       // Add protoc libraries
       libraryDependencies ++= Seq(
-            "io.grpc"              % "grpc-netty"            % scalapb.compiler.Version.grpcJavaVersion,
+            "io.grpc"              % "grpc-netty-shaded"     % scalapb.compiler.Version.grpcJavaVersion,
             "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
           ),
       // TODO move all of this to schema plugins, possibly specific for runtime (when specific versions of libraries are needed, like Spark and Avro 1.8.2)


### PR DESCRIPTION
Current SBT plugin does not provide GRPC stub generation, which is required for some applications. To enable this generation, its necessary to add "grpc" to protocbridge.Target and a couple of libraries. I also removed "flat_package" to get a more user friendly code generation.