### PR TITLE
Tiny improvement to docs for external Kafka topic configuration

### DIFF
--- a/docs/shared-content-source/docs/modules/develop/pages/blueprints.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/blueprints.adoc
@@ -148,7 +148,10 @@ In the following snippet, we declare a three topics that connect to an external 
 
 [source, HOCON]
 ----
-cloudflow {
+blueprint {
+
+  // streamlets omitted for brevity
+
   topics {
     rides = ${shared-config} {      //<1>
       topic.name = "incoming-rides" //<2>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the section of the docs titled [Advanced Topic Configuration](https://cloudflow.io/docs/current/develop/blueprints.html#_advanced_topic_configuration) the configuration is changed so it shows inside a `blueprint` block instead of a `cloudflow` block. 

section here provides config in the `cloudflow` block - this should be in the `blueprint` block within the blueprint file. This PR changes that to (hopefully) make it less confusing.


### Why are the changes needed?
When I tried to follow the docs the `cloudflow` block suggested to me that I should be configuring things inside the `application.conf` file rather than the `blueprint` file. This, to me at least, makes that more clear.


### Does this PR introduce any user-facing change?
Yes, a small change to the documentation.


### How was this patch tested?
I created a version of the `sensor-data-scala` example [here](https://github.com/thinkmorestupidless/cloudflow-external-kafka-topic-example) that uses the config inside the `blueprint` and it works!
