### PR TITLE
was an old name referring to the project

### DIFF
--- a/examples/call-record-aggregator/send_data.sh
+++ b/examples/call-record-aggregator/send_data.sh
@@ -10,7 +10,7 @@ fi
 
 echo "Using $RESOURCE"
 
-ROUTE_HOST=$(kubectl cloudflow status call-record-pipeline | grep /cdr-ingress | awk '{print $2}')
+ROUTE_HOST=$(kubectl cloudflow status call-record-aggregator | grep cdr-ingress | awk '{print $2}')
 
 for str in $( cat $RESOURCE ); do
   echo Sending $str


### PR DESCRIPTION
### What changes were proposed in this pull request?
change the name of the project we are trying to fetch on the script


### Why are the changes needed?
the name was incorrect. it has 'pipeline' instead of 'aggregator'


### Does this PR introduce any user-facing change?
no


### How was this patch tested?
running the command from the script and checking there was a response. 
`kubectl cloudflow status call-record-aggregator | grep cdr-ingress | awk '{print $2}'` gave the response 

`call-record-aggregator-cdr-ingress-6784bd7d44-lclsz`

from 
```
→ kubectl cloudflow status call-record-aggregator                                                                                                            [ab5224c]
Name:             call-record-aggregator
Namespace:        call-record-aggregator
Version:          612-ab5224c
Created:          2020-08-05 09:13:15 +0200 CEST
Status:           Running

STREAMLET         POD                                                        READY             STATUS            RESTARTS
cdr-aggregator    call-record-aggregator-cdr-aggregator-driver               1/1               Running           0
cdr-aggregator    call-record-aggregator-cdr-aggregator-1596611611087-exec-1 1/1               Running           0
cdr-generator1    call-record-aggregator-cdr-generator1-driver               1/1               Running           0
cdr-generator1    call-record-aggregator-cdr-generator1-1596611612202-exec-1 1/1               Running           0
cdr-generator2    call-record-aggregator-cdr-generator2-1596611610491-exec-1 1/1               Running           0
cdr-generator2    call-record-aggregator-cdr-generator2-driver               1/1               Running           0
cdr-ingress       call-record-aggregator-cdr-ingress-6784bd7d44-lclsz        1/1               Running           0
console-egress    call-record-aggregator-console-egress-84cb6f88bf-82mgx     1/1               Running           0
error-egress      call-record-aggregator-error-egress-f48c95cc9-5wfgx        1/1               Running           0
split             call-record-aggregator-split-66449ddb84-dc9nv              1/1               Running           0

```