### PR TITLE
Check what Cloudflow dependencies are installed

### DIFF
--- a/kubectl-cloudflow/cmd/deploy_command.go
+++ b/kubectl-cloudflow/cmd/deploy_command.go
@@ -377,7 +377,7 @@ func validateDeployCmdArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// The function validates that the operators for Spark and Flink is installed if the application uses any of those streamlet types
+// The function validates that the operators for Spark and Flink are installed if the application uses any of those streamlet types
 func validateStreamletRunnersDependencies(applicatonSpec cfapp.CloudflowApplicationSpec) {
 
 	const requiredSparkVersion = "v1beta2"

--- a/kubectl-cloudflow/cmd/deploy_command.go
+++ b/kubectl-cloudflow/cmd/deploy_command.go
@@ -127,7 +127,7 @@ func (opts *deployOptions) deployImpl(cmd *cobra.Command, args []string) {
 		printutil.LogAndExit("%s", err.Error())
 	}
 
-	validateStreamletRunnersDependencies(applicationSpec)
+	validateStreamletRunnersInstalled(applicationSpec)
 
 	namespace := applicationSpec.AppID
 

--- a/kubectl-cloudflow/cmd/deploy_command.go
+++ b/kubectl-cloudflow/cmd/deploy_command.go
@@ -127,7 +127,7 @@ func (opts *deployOptions) deployImpl(cmd *cobra.Command, args []string) {
 		printutil.LogAndExit("%s", err.Error())
 	}
 
-	validateStreamletRunnersInstalled(applicationSpec)
+	validateStreamletRunnersDependencies(applicationSpec)
 
 	namespace := applicationSpec.AppID
 
@@ -381,7 +381,7 @@ func validateDeployCmdArgs(cmd *cobra.Command, args []string) error {
 func validateStreamletRunnersDependencies(applicationSpec cfapp.CloudflowApplicationSpec) {
 
 	runnerType := func(runnerTypeName string) bool {
-		for _, v := range applicatonSpec.Streamlets {
+		for _, v := range applicationSpec.Streamlets {
 			if v.Descriptor.Runtime == runnerTypeName {
 				return true
 			}

--- a/kubectl-cloudflow/cmd/deploy_command.go
+++ b/kubectl-cloudflow/cmd/deploy_command.go
@@ -378,7 +378,7 @@ func validateDeployCmdArgs(cmd *cobra.Command, args []string) error {
 }
 
 // The function validates that the operators for Spark and Flink are installed if the application uses any of those streamlet types
-func validateStreamletRunnersDependencies(applicatonSpec cfapp.CloudflowApplicationSpec) {
+func validateStreamletRunnersDependencies(applicationSpec cfapp.CloudflowApplicationSpec) {
 
 	const requiredSparkVersion = "v1beta2"
 	const requiredFlinkVersion = "v1beta1"

--- a/kubectl-cloudflow/cmd/deploy_command.go
+++ b/kubectl-cloudflow/cmd/deploy_command.go
@@ -393,10 +393,9 @@ func validateStreamletRunnersDependencies(applicatonSpec cfapp.CloudflowApplicat
 	}
 
 	validateRunnerType := func(crdName string, prettyName string, expectedVersion string) error {
-		cmd := exec.Command("kubectl", "get", "crds", crdName, "-o jsonpath='{.spec.version}'")
-		version, err := cmd.Output()
+		version, err := exec.Command("kubectl", "get", "crds", crdName, "-o", "jsonpath={.spec.version}").Output()
 		if err != nil {
-			return fmt.Errorf("cannot detect that %s is installed, please install %s before continuing", prettyName, prettyName)
+			return fmt.Errorf("cannot detect that %s is installed, please install %s before continuing (%v)", prettyName, prettyName, err.Error())
 		}
 		if string(version) != expectedVersion {
 			return fmt.Errorf("%s is installed but the wrong version, required %s, installed %s", prettyName, requiredSparkVersion, string(version))

--- a/kubectl-cloudflow/cmd/deploy_command.go
+++ b/kubectl-cloudflow/cmd/deploy_command.go
@@ -380,9 +380,6 @@ func validateDeployCmdArgs(cmd *cobra.Command, args []string) error {
 // The function validates that the operators for Spark and Flink are installed if the application uses any of those streamlet types
 func validateStreamletRunnersDependencies(applicationSpec cfapp.CloudflowApplicationSpec) {
 
-	const requiredSparkVersion = "v1beta2"
-	const requiredFlinkVersion = "v1beta1"
-
 	runnerType := func(runnerTypeName string) bool {
 		for _, v := range applicatonSpec.Streamlets {
 			if v.Descriptor.Runtime == runnerTypeName {
@@ -398,19 +395,19 @@ func validateStreamletRunnersDependencies(applicationSpec cfapp.CloudflowApplica
 			return fmt.Errorf("cannot detect that %s is installed, please install %s before continuing (%v)", prettyName, prettyName, err.Error())
 		}
 		if string(version) != expectedVersion {
-			return fmt.Errorf("%s is installed but the wrong version, required %s, installed %s", prettyName, requiredSparkVersion, string(version))
+			return fmt.Errorf("%s is installed but the wrong version, required %s, installed %s", prettyName, expectedVersion, string(version))
 		}
 		return nil
 	}
 
 	if runnerType("spark") {
-		if err := validateRunnerType("sparkapplications.sparkoperator.k8s.io", "Spark", requiredSparkVersion); err != nil {
+		if err := validateRunnerType("sparkapplications.sparkoperator.k8s.io", "Spark", version.RequiredSparkVersion); err != nil {
 			printutil.LogErrorAndExit(err)
 		}
 	}
 
 	if runnerType("flink") {
-		if err := validateRunnerType("flinkapplications.flink.k8s.io", "Flink", requiredFlinkVersion); err != nil {
+		if err := validateRunnerType("flinkapplications.flink.k8s.io", "Flink", version.RequiredFlinkVersion); err != nil {
 			printutil.LogErrorAndExit(err)
 		}
 	}

--- a/kubectl-cloudflow/version/version.go
+++ b/kubectl-cloudflow/version/version.go
@@ -36,6 +36,13 @@ const ProtocolVersionConfigMapName = "cloudflow-protocol-version"
 // CloudflowDeploymentName is the name of the Cloudflow operator deployment
 const CloudflowDeploymentName = "cloudflow-operator"
 
+// RequiredSparkVersion is the Spark version required by Cloudflow
+const RequiredSparkVersion = "v1beta2"
+
+// RequiredFlinkVersion is the Flink version required by Cloudflow
+const RequiredFlinkVersion = "v1beta1"
+
+
 // FailOnProtocolVersionMismatch fails and exits if the protocol version of kubectl-cloudflow does not match with the cloudflow operator protocol version.
 func FailOnProtocolVersionMismatch() {
 	cm, err := getProtocolVersionConfigMap()

--- a/kubectl-cloudflow/version/version.go
+++ b/kubectl-cloudflow/version/version.go
@@ -42,7 +42,6 @@ const RequiredSparkVersion = "v1beta2"
 // RequiredFlinkVersion is the Flink version required by Cloudflow
 const RequiredFlinkVersion = "v1beta1"
 
-
 // FailOnProtocolVersionMismatch fails and exits if the protocol version of kubectl-cloudflow does not match with the cloudflow operator protocol version.
 func FailOnProtocolVersionMismatch() {
 	cm, err := getProtocolVersionConfigMap()


### PR DESCRIPTION
In a future PR we will provide a streamlined installation process for Cloudflow, where Cloudflow is installed and any dependency is installed separately. 

We will no longer install Strimzi, Spark, or Flink automatically, but instead, provide documentation on how to do it using `Helm`. 

The upside of this is that besides a streamlined installation process, users who not use Spark, will never have to have the Spark operator installed. It will also significantly reduce the complexity of upgrading Cloudflow.

This change, however, requires more validation when an application is deployed, for example, this PR adds those checks.

When deploying a CLoudflow application, the application descriptor will be inspected for runner types, and those will be used to validate the existence of these runners in the cluster before proceeding with the deployment.