### PR TITLE
[WIP] Amend ScalaPB targets rather than replacing

### DIFF
--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CommonSettingsAndTasksPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CommonSettingsAndTasksPlugin.scala
@@ -74,10 +74,11 @@ object CommonSettingsAndTasksPlugin extends AutoPlugin {
             SchemaFormat.Avro  -> "src/main/avro",
             SchemaFormat.Proto -> "src/main/protobuf"
           ),
-      PB.targets in Compile := {
+      PB.targets in Compile ++= {
         val schemaLang = schemaCodeGenerator.value
         schemaLang match {
-          case SchemaCodeGenerator.Java ⇒ Seq(PB.gens.java -> (sourceManaged in Compile).value)
+          case SchemaCodeGenerator.Java =>
+            Seq[protocbridge.Target](PB.gens.java -> (sourceManaged in Compile).value)
           case SchemaCodeGenerator.Scala =>
             Seq(scalaPbTarget((crossTarget in Compile).value / "scalapb"))
         }


### PR DESCRIPTION
# What changes were proposed in this pull request?

Rather than replacing the `PB.targets`, amend them.

### Why are the changes needed?

To allow invoking the Akka gRPC code generators in a project also using Akka gRPC.

### Does this PR introduce any user-facing change?

Previously the Cloudflow plugin would wipe out the `PB.generators`, possibly removing useful generators.

The new behaviour, appending, is not foolproof either: now we run the risk of running the same generators (e.g. the standard ScalaPB ones) multiple times. We need to think about how to deduplicate here.

### How was this patch tested?

Manually in https://github.com/raboof/cloudflow-grpc-experiment
