### PR TITLE
Made usage of strimzi entity operator optional.

### DIFF
--- a/core/cloudflow-operator/src/main/resources/application.conf
+++ b/core/cloudflow-operator/src/main/resources/application.conf
@@ -23,9 +23,6 @@ cloudflow {
       bootstrap-servers = "localhost:9092"
       bootstrap-servers = ${?KAFKA_BOOTSTRAP_SERVERS}
 
-      zookeeper-connect = "localhost:2081"
-      zookeeper-connect = ${?KAFKA_ZOOKEEPER_CONNECT}
-
       strimzi-cluster-name = ${?KAFKA_STRIMZI_CLUSTER_NAME}
       strimzi-topic-operator-namespace = ${?KAFKA_STRIMZI_TOPIC_OPERATOR_NAMESPACE}
 

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/DeploymentContext.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/DeploymentContext.scala
@@ -45,9 +45,11 @@ case class KafkaContext(
     bootstrapServers: String,
     partitionsPerTopic: Int,
     replicationFactor: Int,
-    strimziTopicOperatorNamespace: Option[String] = None,
-    strimziClusterName: Option[String] = None
-)
+    strimziTopicOperatorNamespace: Option[String],
+    strimziClusterName: Option[String]
+) {
+  def useStrimzi = strimziTopicOperatorNamespace.nonEmpty && strimziClusterName.nonEmpty
+}
 
 final case class Host(name: String, port: Option[Int]) {
   override def toString = s"""$name:${port.getOrElse(80)}"""

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/DeploymentContext.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/DeploymentContext.scala
@@ -42,11 +42,11 @@ case class DeploymentContext(kafkaContext: KafkaContext,
 }
 
 case class KafkaContext(
-    strimziTopicOperatorNamespace: String,
-    strimziClusterName: String,
     bootstrapServers: String,
     partitionsPerTopic: Int,
-    replicationFactor: Int
+    replicationFactor: Int,
+    strimziTopicOperatorNamespace: Option[String] = None,
+    strimziClusterName: Option[String] = None
 )
 
 final case class Host(name: String, port: Option[Int]) {

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Settings.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Settings.scala
@@ -167,11 +167,11 @@ final case class Settings(config: Config) extends Extension {
   val podNamespace   = getNonEmptyString(config, s"$root.pod-namespace")
 
   val kafka = KafkaSettings(
-    getNonEmptyString(config, s"$root.kafka.strimzi-topic-operator-namespace"),
-    getNonEmptyString(config, s"$root.kafka.strimzi-cluster-name"),
     getNonEmptyString(config, s"$root.kafka.bootstrap-servers"),
     partitionsPerTopic,
-    replicationFactor
+    replicationFactor,
+    config.as[Option[String]](s"$root.kafka.strimzi-topic-operator-namespace"),
+    config.as[Option[String]](s"$root.kafka.strimzi-cluster-name")
   )
 
   val akkaRunnerSettings        = getAkkaRunnerSettings(config, s"$root.deployment.akka-runner", runner.AkkaRunner.runtime)
@@ -187,11 +187,11 @@ final case class Settings(config: Config) extends Extension {
   val deploymentContext = {
     DeploymentContext(
       KafkaContext(
-        kafka.strimziTopicOperatorNamespace,
-        kafka.strimziClusterName,
         kafka.bootstrapServers,
         kafka.partitionsPerTopic,
-        kafka.replicationFactor
+        kafka.replicationFactor,
+        kafka.strimziTopicOperatorNamespace,
+        kafka.strimziClusterName
       ),
       akkaRunnerSettings,
       sparkRunnerSettings,
@@ -204,11 +204,11 @@ final case class Settings(config: Config) extends Extension {
 }
 
 final case class KafkaSettings(
-    strimziTopicOperatorNamespace: String,
-    strimziClusterName: String,
     bootstrapServers: String,
     partitionsPerTopic: Int,
-    replicationFactor: Int
+    replicationFactor: Int,
+    strimziTopicOperatorNamespace: Option[String] = None,
+    strimziClusterName: Option[String] = None
 )
 
 final case class Resources(request: String, limit: String)

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/Actions.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/Actions.scala
@@ -93,7 +93,7 @@ object Actions {
       currentApp: Option[CloudflowApplication.CR],
       deleteOutdatedTopics: Boolean = false
   )(implicit ctx: DeploymentContext): Seq[Action[ObjectResource]] =
-    if (ctx.kafkaContext.strimziTopicOperatorNamespace.nonEmpty && ctx.kafkaContext.strimziClusterName.nonEmpty) {
+    if (ctx.kafkaContext.useStrimzi) {
       StrimziTopicActions(
         newApp = newApp,
         currentApp = currentApp,

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/Actions.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/Actions.scala
@@ -93,7 +93,20 @@ object Actions {
       currentApp: Option[CloudflowApplication.CR],
       deleteOutdatedTopics: Boolean = false
   )(implicit ctx: DeploymentContext): Seq[Action[ObjectResource]] =
-    TopicActions(newApp, currentApp, deleteOutdatedTopics)
+    if (ctx.kafkaContext.strimziTopicOperatorNamespace.nonEmpty && ctx.kafkaContext.strimziClusterName.nonEmpty) {
+      StrimziTopicActions(
+        newApp = newApp,
+        currentApp = currentApp,
+        strimziTopicOperatorNamespace = ctx.kafkaContext.strimziTopicOperatorNamespace.get,
+        strimziClusterName = ctx.kafkaContext.strimziClusterName.get,
+        partitionsPerTopic = ctx.kafkaContext.partitionsPerTopic,
+        replicationFactor = ctx.kafkaContext.replicationFactor,
+        deleteOutdatedTopics = deleteOutdatedTopics
+      )
+    } else {
+      // TODO add Kafka AdminClient support
+      Seq.empty[Action[ObjectResource]]
+    }
 
   private def deployRunners(
       newApp: CloudflowApplication.CR,

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/TestDeploymentContext.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/TestDeploymentContext.scala
@@ -22,8 +22,8 @@ trait TestDeploymentContext {
   implicit val ctx: DeploymentContext =
     DeploymentContext(
       kafkaContext = KafkaContext(
-        strimziClusterName = "kafka",
-        strimziTopicOperatorNamespace = "strimzi",
+        strimziClusterName = Some("kafka"),
+        strimziTopicOperatorNamespace = Some("strimzi"),
         bootstrapServers = "localhost:9092",
         partitionsPerTopic = 3,
         replicationFactor = 1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
The strimzi settings in the cloudflow-operator are now optional. If these are not provided, the cloudflow operator will not create Strimzi KafkaTopic CRs, which are used by the strimzi topic operator.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Users have asked if it is possible to install and run Cloudflow without strimzi kafka cluster and topic operator.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
all green, tested on gke.

What still has to happen (in a separate PR) is that the helm chart for installing cloudflow should make it possible to configure the default kafka broker that the cloudflow operator will use for managed topics.