### PR TITLE
Update skuber to use the same Akka version as the rest

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -408,16 +408,16 @@ lazy val operator =
     .settings(
       scalafmtOnCompile := true,
       libraryDependencies ++= Vector(
-            AkkaSlf4jOperator,
-            AkkaStreamOperator,
+            AkkaSlf4j,
+            AkkaStream,
             Ficus,
             Logback,
             Skuber,
             ScalaTest,
-            "org.apache.kafka"        % "kafka-clients" % Version.KafkaClients,
-            AkkaStreamTestkitOperator % "test",
-            ScalaCheck                % "test",
-            Avro4sJson                % "test"
+            "org.apache.kafka" % "kafka-clients" % Version.KafkaClients,
+            AkkaStreamTestkit  % "test",
+            ScalaCheck         % "test",
+            Avro4sJson         % "test"
           )
     )
     .settings(
@@ -428,10 +428,6 @@ lazy val operator =
       mainClass in Compile := Some("cloudflow.operator.Main"),
       publishArtifact in (Compile, packageDoc) := false,
       publishArtifact in (Compile, packageSrc) := false,
-      // skuber version 2.4.0 depends on akka-http 10.1.9 : hence overriding
-      // with akka-http 10.1.12 to use akka 2.6
-      // remove this override once skuber is updated
-      dependencyOverrides += AkkaHttpOperator,
       buildOptions in docker := BuildOptions(
             cache = true,
             removeIntermediateContainers = BuildOptions.Remove.OnSuccess,

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -13,11 +13,6 @@ object Version {
   val Flink         = "1.10.0"
   val KafkaClients  = "2.5.0"
   val EmbeddedKafka = "2.5.0" 
-
-  // We've postponed updating Akka and Akka HTTP for the operator
-  // because of https://github.com/lightbend/cloudflow/issues/610
-  val AkkaOperator     = "2.5.29"
-  val AkkaHttpOperator = "10.1.12"
 }
 
 object Library {
@@ -37,11 +32,6 @@ object Library {
   val AkkaStreamKafkaTestkit = ("com.typesafe.akka" %% "akka-stream-kafka-testkit" % Version.AlpakkaKafka) .exclude("com.typesafe.akka", "akka-stream-testkit")
   val AkkaStreamTestkit      = "com.typesafe.akka"  %% "akka-stream-testkit"       % Version.Akka
   
-  val AkkaSlf4jOperator         = "com.typesafe.akka" %% "akka-slf4j"                % Version.AkkaOperator
-  val AkkaStreamOperator        = "com.typesafe.akka" %% "akka-stream"               % Version.AkkaOperator
-  val AkkaStreamTestkitOperator = "com.typesafe.akka" %% "akka-stream-testkit"       % Version.AkkaOperator
-  val AkkaHttpOperator          = "com.typesafe.akka" %% "akka-http"                 % Version.AkkaHttpOperator
-
   val AkkaCluster           = "com.typesafe.akka"     %% "akka-cluster"              % Version.Akka
   val AkkaManagement        = "com.lightbend.akka.management" %% "akka-management"   % Version.AkkaMgmt
   val AkkaClusterBootstrap  = "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % Version.AkkaMgmt
@@ -63,7 +53,7 @@ object Library {
 
   val JacksonScalaModule    = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.4"
 
-  val Skuber                = "io.skuber"                  %% "skuber"               % "2.4.1-cve-fix-a8d7617c"
+  val Skuber                = "io.skuber"                  %% "skuber"               % "2.6.0"
   
   val Spark                 = "org.apache.spark"           %% "spark-core"           % Version.Spark
   val SparkJacksonDatabind  = "com.fasterxml.jackson.core"  % "jackson-databind"     % "2.6.7.3"


### PR DESCRIPTION
This is possible since the rest is now ahead of Skuber,
and Akka is binary compatible.


### What changes were proposed in this pull request?

Use the same Akka version for the operator and the rest of the components

### Why are the changes needed?

The version of Akka used with the operator is too low to support Akka HTTP
10.2.0, and instead of bumping the Akka version in the operator 'just enough'
it seems neater to just pull it all the way up to be consistent with the
other components.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

`sbt test`