### PR TITLE
Update core to Akka HTTP 10.2.0

### DIFF
--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/HttpServerLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/HttpServerLogic.scala
@@ -137,22 +137,21 @@ abstract class HttpServerLogic(
    */
   def route(): Route
 
-  protected def flow = Route.handlerFlow(route())
-
   def run() =
     startServer(
       context,
-      flow,
+      route(),
       containerPort
     )
 
   protected def startServer(
       context: AkkaStreamletContext,
-      handler: Flow[HttpRequest, HttpResponse, _],
+      route: Route,
       port: Int
   ): Unit =
     Http()
-      .bindAndHandle(handler, "0.0.0.0", port)
+      .newServerAt("0.0.0.0", port)
+      .bind(route)
       .map { binding ⇒
         context.signalReady()
         system.log.info(s"Bound to ${binding.localAddress.getHostName}:${binding.localAddress.getPort}")

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/HealthChecks.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/HealthChecks.scala
@@ -19,20 +19,18 @@ package cloudflow.operator
 import scala.concurrent._
 import scala.util._
 import akka.actor._
-import akka.stream._
 import akka.http.scaladsl._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 
 object HealthChecks {
-  def serve(settings: Settings)(implicit system: ActorSystem, ec: ExecutionContext) = {
-    implicit val materializer = ActorMaterializer()
+  def serve(settings: Settings)(implicit system: ActorSystem, ec: ExecutionContext) =
     Http()
-      .bindAndHandle(
-        route,
+      .newServerAt(
         settings.api.bindInterface,
         settings.api.bindPort
       )
+      .bind(route)
       .onComplete {
         case Success(serverBinding) ⇒
           system.log.info(s"Bound to ${serverBinding.localAddress}.")
@@ -43,7 +41,6 @@ object HealthChecks {
             sys.exit(-1)
           }
       }
-  }
   def route =
     // format: OFF
     path("robots.txt") {

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Version {
 
   val Akka          = "2.6.6"
-  val AkkaHttp      = "10.1.12"
+  val AkkaHttp      = "10.2.0"
   val AkkaMgmt      = "1.0.8"
   val AlpakkaKafka  = "2.0.3"
   val Scala         = "2.12.11"

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -11,8 +11,6 @@ object Version {
   val Spark         = "2.4.5"
   val Flink         = "1.10.0"
   val EmbeddedKafka = "2.5.0" 
-  // skuber depends on 2.5.29
-  val AkkaOperator  = "2.5.29"
 
 }
 
@@ -29,9 +27,9 @@ object Library {
   val AkkaStreamKafkaTestkit = ("com.typesafe.akka" %% "akka-stream-kafka-testkit" % Version.AlpakkaKafka) .exclude("com.typesafe.akka", "akka-stream-testkit")
   val AkkaStreamTestkit      = "com.typesafe.akka"  %% "akka-stream-testkit"       % Version.Akka
   
-  val AkkaSlf4jOperator         = "com.typesafe.akka" %% "akka-slf4j"                % Version.AkkaOperator
-  val AkkaStreamOperator        = "com.typesafe.akka" %% "akka-stream"               % Version.AkkaOperator
-  val AkkaStreamTestkitOperator = "com.typesafe.akka" %% "akka-stream-testkit"       % Version.AkkaOperator
+  val AkkaSlf4jOperator         = "com.typesafe.akka" %% "akka-slf4j"                % Version.Akka
+  val AkkaStreamOperator        = "com.typesafe.akka" %% "akka-stream"               % Version.Akka
+  val AkkaStreamTestkitOperator = "com.typesafe.akka" %% "akka-stream-testkit"       % Version.Akka
 
   val AkkaCluster           = "com.typesafe.akka"     %% "akka-cluster"              % Version.Akka
   val AkkaManagement        = "com.lightbend.akka.management" %% "akka-management"   % Version.AkkaMgmt


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update core to Akka HTTP 10.2.0 and use the new 'newServerAt' API.

### Why are the changes needed?

In particular this means you can now configure HTTP/2 on the
`HttpServerLogic`, which is useful for gRPC.

### Does this PR introduce any user-facing change?

This removes the `Flow` from the protected methods in `HttpServerLogic`,
instead relying only on `Route` (which matches better with HTTP/2).

### How was this patch tested?

`sbt test`