### PR TITLE
Adding java opts to config

### DIFF
--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
@@ -82,10 +82,10 @@ object FlinkRunner extends Runner[CR] {
     )
 
     val flinkConfig: Map[String, String] = Map(
-        "state.backend"                  -> "filesystem",
-        "state.backend.fs.checkpointdir" -> s"file://${PVCMountPath}/checkpoints/${deployment.streamletName}",
-        "state.checkpoints.dir"          -> s"file://${PVCMountPath}/externalized-checkpoints/${deployment.streamletName}",
-        "state.savepoints.dir"           -> s"file://${PVCMountPath}/savepoints/${deployment.streamletName}"
+        "state.backend"                    -> "filesystem",
+        "state.backend.fs.checkpointdir"   -> s"file://${PVCMountPath}/checkpoints/${deployment.streamletName}",
+        "state.checkpoints.dir"            -> s"file://${PVCMountPath}/externalized-checkpoints/${deployment.streamletName}",
+        "state.savepoints.dir"             -> s"file://${PVCMountPath}/savepoints/${deployment.streamletName}"
       ) ++ javaOptions.map("env.java.opts" -> _) ++ getFlinkConfig(configSecret)
 
     val _spec = Spec(

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
@@ -26,7 +26,6 @@ import skuber.json.format._
 import skuber.Resource._
 import cloudflow.blueprint.deployment._
 import FlinkResource._
-import cloudflow.operator.runner.SparkRunner.{DriverPod, getJavaOptions}
 import skuber.ResourceSpecification.Subresources
 
 /**
@@ -72,16 +71,16 @@ object FlinkRunner extends Runner[CR] {
     val jobManagerConfig = JobManagerConfig(
       Some(jobManagerSettings.replicas),
       getJobManagerResourceRequirements(podsConfig, JobManagerPod),
-      Some(EnvConfig(getEnvironmentVariables(podsConfig, JobManagerPod))
-    ))
+      Some(EnvConfig(getEnvironmentVariables(podsConfig, JobManagerPod)))
+    )
 
     val scale = deployment.replicas
 
     val taskManagerConfig = TaskManagerConfig(
       Some(taskManagerSettings.taskSlots),
       getTaskManagerResourceRequirements(podsConfig, TaskManagerPod),
-      Some(EnvConfig(getEnvironmentVariables(podsConfig, TaskManagerPod)
-      )))
+      Some(EnvConfig(getEnvironmentVariables(podsConfig, TaskManagerPod)))
+      )
 
     val flinkConfig: Map[String, String] = Map(
         "state.backend"                  -> "filesystem",

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
@@ -317,7 +317,6 @@ object FlinkResource {
       taskSlots: Option[Int],
       resources: Option[Requirements] = None,
       envConfig: Option[EnvConfig]
-
   )
 
   /*

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
@@ -67,7 +67,6 @@ object FlinkRunner extends Runner[CR] {
 
     import ctx.flinkRunnerSettings._
 
-
     val jobManagerConfig = JobManagerConfig(
       Some(jobManagerSettings.replicas),
       getJobManagerResourceRequirements(podsConfig, JobManagerPod),
@@ -80,7 +79,7 @@ object FlinkRunner extends Runner[CR] {
       Some(taskManagerSettings.taskSlots),
       getTaskManagerResourceRequirements(podsConfig, TaskManagerPod),
       Some(EnvConfig(getEnvironmentVariables(podsConfig, TaskManagerPod)))
-      )
+    )
 
     val flinkConfig: Map[String, String] = Map(
         "state.backend"                  -> "filesystem",

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
@@ -68,28 +68,20 @@ object FlinkRunner extends Runner[CR] {
 
     import ctx.flinkRunnerSettings._
 
-    def combine(envVars: Option[List[EnvVar]], javaOptions: Option[String]): Option[List[EnvVar]] =
-      Some(envVars.toList.flatten ++ javaOptions.map(EnvVar("env.java.opts",_)))
 
     val jobManagerConfig = JobManagerConfig(
       Some(jobManagerSettings.replicas),
       getJobManagerResourceRequirements(podsConfig, JobManagerPod),
-      Some(EnvConfig(combine(
-        getEnvironmentVariables(podsConfig, JobManagerPod),
-        getJavaOptions(podsConfig, JobManagerPod))
-    )))
+      Some(EnvConfig(getEnvironmentVariables(podsConfig, JobManagerPod))
+    ))
 
     val scale = deployment.replicas
 
     val taskManagerConfig = TaskManagerConfig(
       Some(taskManagerSettings.taskSlots),
       getTaskManagerResourceRequirements(podsConfig, TaskManagerPod),
-      Some(EnvConfig(combine(
-            getEnvironmentVariables(podsConfig, TaskManagerPod),
-            getJavaOptions(podsConfig, TaskManagerPod))
+      Some(EnvConfig(getEnvironmentVariables(podsConfig, TaskManagerPod)
       )))
-
-
 
     val flinkConfig: Map[String, String] = Map(
         "state.backend"                  -> "filesystem",

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
@@ -78,7 +78,7 @@ class FlinkRunnerSpec extends WordSpecLike with OptionValues with MustMatchers w
       replicas = None
     )
 
-    "read values from pod configuration and put it in both " in {
+    "read environment variables and resource requirements from pod configuration and configure taskmanager and jobmanager " in {
 
       val crd = FlinkRunner.resource(
         deployment = deployment,

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
@@ -152,9 +152,8 @@ class FlinkRunnerSpec extends WordSpecLike with OptionValues with MustMatchers w
         namespace = namespace
       )
 
-      crd.spec.flinkConfig mustBe Vector(
-        EnvVar("env.java.opts",EnvVar.StringValue("-XX:MaxRAMPercentage=40.0"))
-      )
+      crd.spec.flinkConfig.get("env.java.opts") mustBe Some("-XX:MaxRAMPercentage=40.0")
+
     }
 
     "create a valid FlinkApplication CR" in {

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
@@ -155,7 +155,7 @@ class FlinkRunnerSpec extends WordSpecLike with OptionValues with MustMatchers w
       crd.spec.flinkConfig.get("env.java.opts") mustBe Some("-XX:MaxRAMPercentage=40.0")
     }
 
-    "read env.java.opts from runtime Flink conf should override pod JAVA_OPTS value" in {
+    "configure env.java.opts from runtime Flink conf, overriding what is provided as JAVA_OPTS value in the pod configuration" in {
 
       val crd = FlinkRunner.resource(
         deployment = deployment,

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
@@ -124,8 +124,10 @@ class FlinkRunnerSpec extends WordSpecLike with OptionValues with MustMatchers w
       )
       crd.spec.jobManagerConfig.envConfig.get.env.get mustBe Vector(EnvVar("FOO",EnvVar.StringValue("BAR")))
       crd.spec.taskManagerConfig.envConfig.get.env.get mustBe Vector(EnvVar("FOO",EnvVar.StringValue("BAR")))
-      crd.spec.taskManagerConfig.resources.get.requests mustBe Map("memory" -> "512M")
-      crd.spec.taskManagerConfig.resources.get.limits mustBe Map("memory" -> "1024M")
+      crd.spec.jobManagerConfig.resources.get.requests mustBe Map(Resource.memory -> "512M")
+      crd.spec.taskManagerConfig.resources.get.requests mustBe Map(Resource.memory -> "512M")
+      crd.spec.jobManagerConfig.resources.get.limits mustBe Map(Resource.memory -> "1024M")
+      crd.spec.taskManagerConfig.resources.get.limits mustBe Map(Resource.memory -> "1024M")
     }
 
     "read values from pod configuration in JAVA_OPTS and put it in Flink conf " +
@@ -142,9 +144,6 @@ class FlinkRunnerSpec extends WordSpecLike with OptionValues with MustMatchers w
               |       env = [
               |          { name = "JAVA_OPTS"
               |            value = "-XX:MaxRAMPercentage=40.0"
-              |          },{
-              |            name = "FOO"
-              |            value = "BAR"
               |          }
               |        ]
               |}

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
@@ -85,27 +85,29 @@ class FlinkRunnerSpec extends WordSpecLike with OptionValues with MustMatchers w
         app = app,
         configSecret = Secret(
           metadata = ObjectMeta(),
-          data = Map(cloudflow.operator.event.ConfigInputChangeEvent.PodsConfigDataKey ->
-            """
-              | kubernetes.pods.pod.containers.container {
-              |       env = [
-              |          { name = "JAVA_OPTS"
-              |            value = "-XX:MaxRAMPercentage=40.0"
-              |          },{
-              |            name = "FOO"
-              |            value = "BAR"
-              |          }
-              |        ]
-              |        resources {
-              |            requests {
-              |              memory = "512M"
-              |            }
-              |            limits {
-              |              memory = "1024M"
-              |            }
-              |         }
+          data = Map(
+            cloudflow.operator.event.ConfigInputChangeEvent.PodsConfigDataKey ->
+                """
+              |kubernetes.pods.pod.containers.container {
+              |  env = [
+              |    { name = "JAVA_OPTS"
+              |      value = "-XX:MaxRAMPercentage=40.0"
+              |    },{
+              |      name = "FOO"
+              |      value = "BAR"
+              |    }
+              |   ]
+              |  resources {
+              |    requests {
+              |      memory = "512M"
+              |    }
+              |    limits {
+              |      memory = "1024M"
+              |    }
+              |  }
               |}
-              |        """.stripMargin.getBytes())
+              |        """.stripMargin.getBytes()
+          )
         ),
         namespace = namespace
       )
@@ -122,32 +124,33 @@ class FlinkRunnerSpec extends WordSpecLike with OptionValues with MustMatchers w
         Volume("secret-vol", Volume.Secret("flink-streamlet")),
         Runner.DownwardApiVolume
       )
-      crd.spec.jobManagerConfig.envConfig.get.env.get mustBe Vector(EnvVar("FOO",EnvVar.StringValue("BAR")))
-      crd.spec.taskManagerConfig.envConfig.get.env.get mustBe Vector(EnvVar("FOO",EnvVar.StringValue("BAR")))
-      crd.spec.jobManagerConfig.resources.get.requests mustBe Map(Resource.memory -> "512M")
+      crd.spec.jobManagerConfig.envConfig.get.env.get mustBe Vector(EnvVar("FOO", EnvVar.StringValue("BAR")))
+      crd.spec.taskManagerConfig.envConfig.get.env.get mustBe Vector(EnvVar("FOO", EnvVar.StringValue("BAR")))
+      crd.spec.jobManagerConfig.resources.get.requests mustBe Map(Resource.memory  -> "512M")
       crd.spec.taskManagerConfig.resources.get.requests mustBe Map(Resource.memory -> "512M")
-      crd.spec.jobManagerConfig.resources.get.limits mustBe Map(Resource.memory -> "1024M")
-      crd.spec.taskManagerConfig.resources.get.limits mustBe Map(Resource.memory -> "1024M")
+      crd.spec.jobManagerConfig.resources.get.limits mustBe Map(Resource.memory    -> "1024M")
+      crd.spec.taskManagerConfig.resources.get.limits mustBe Map(Resource.memory   -> "1024M")
     }
 
-    "read values from pod configuration key JAVA_OPTS and " +
-      "put it in Flink conf in env.java.opts" in {
+    "read values from pod configuration key JAVA_OPTS and put it in Flink conf in env.java.opts" in {
 
       val crd = FlinkRunner.resource(
         deployment = deployment,
         app = app,
         configSecret = Secret(
           metadata = ObjectMeta(),
-          data = Map(cloudflow.operator.event.ConfigInputChangeEvent.PodsConfigDataKey ->
-            """
-              | kubernetes.pods.pod.containers.container {
-              |       env = [
-              |          { name = "JAVA_OPTS"
-              |            value = "-XX:MaxRAMPercentage=40.0"
-              |          }
-              |        ]
+          data = Map(
+            cloudflow.operator.event.ConfigInputChangeEvent.PodsConfigDataKey ->
+                """
+              |kubernetes.pods.pod.containers.container {
+              |  env = [
+              |    { name = "JAVA_OPTS"
+              |      value = "-XX:MaxRAMPercentage=40.0"
+              |    }
+              |  ]
               |}
-              |        """.stripMargin.getBytes())
+              |        """.stripMargin.getBytes()
+          )
         ),
         namespace = namespace
       )
@@ -164,19 +167,19 @@ class FlinkRunnerSpec extends WordSpecLike with OptionValues with MustMatchers w
           metadata = ObjectMeta(),
           data = Map(
             cloudflow.operator.event.ConfigInputChangeEvent.PodsConfigDataKey ->
-            """
-              | kubernetes.pods.pod.containers.container {
-              |       env = [
-              |          { name = "JAVA_OPTS"
-              |            value = "-XX:MaxRAMPercentage=40.0"
-              |          }
-              |        ]
+                """
+              |kubernetes.pods.pod.containers.container {
+              |  env = [
+              |    { name = "JAVA_OPTS"
+              |      value = "-XX:MaxRAMPercentage=40.0"
+              |    }
+              |   ]
               |}
               |        """.stripMargin.getBytes(),
             cloudflow.operator.event.ConfigInputChangeEvent.RuntimeConfigDataKey ->
-              """
+                """
                 |flink {
-                |            env.java.opts = "-XX:-DisableExplicitGC"
+                |  env.java.opts = "-XX:-DisableExplicitGC"
                 |}
                 |        """.stripMargin.getBytes()
           )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Being able to pass JAVA_OPTS as env in a flink streamlet 
as per https://github.com/lightbend/cloudflow/issues/624

### Why are the changes needed?
to allow to add env.java.opts in a Flink streamlet in a consistent manner respect to the rest of the streamlets


### Does this PR introduce any user-facing change?
yes, as the possibility of passing that variable


### How was this patch tested?
through the test `"read values from pod configuration in JAVA_OPTS and put it in Flink conf " +
      "as env.java.opts" in `
in `FlinkRunnerSpec`
