### PR TITLE
Update to Akka HTTP 10.2.0 for core cloudflow-akka

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -407,7 +407,7 @@ lazy val operator =
       // skuber version 2.4.0 depends on akka-http 10.1.9 : hence overriding
       // with akka-http 10.1.12 to use akka 2.6
       // remove this override once skuber is updated
-      dependencyOverrides += AkkaHttp,
+      dependencyOverrides += AkkaHttpOperator,
       buildOptions in docker := BuildOptions(
             cache = true,
             removeIntermediateContainers = BuildOptions.Remove.OnSuccess,

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/HttpServerLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/HttpServerLogic.scala
@@ -137,22 +137,21 @@ abstract class HttpServerLogic(
    */
   def route(): Route
 
-  protected def flow = Route.handlerFlow(route())
-
   def run() =
     startServer(
       context,
-      flow,
+      route(),
       containerPort
     )
 
   protected def startServer(
       context: AkkaStreamletContext,
-      handler: Flow[HttpRequest, HttpResponse, _],
+      route: Route,
       port: Int
   ): Unit =
     Http()
-      .bindAndHandle(handler, "0.0.0.0", port)
+      .newServerAt("0.0.0.0", port)
+      .bind(route)
       .map { binding ⇒
         context.signalReady()
         system.log.info(s"Bound to ${binding.localAddress.getHostName}:${binding.localAddress.getPort}")

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -4,16 +4,18 @@ import sbt._
 object Version {
 
   val Akka          = "2.6.6"
-  val AkkaHttp      = "10.1.12"
+  val AkkaHttp      = "10.2.0"
   val AkkaMgmt      = "1.0.8"
   val AlpakkaKafka  = "2.0.3"
   val Scala         = "2.12.11"
   val Spark         = "2.4.5"
   val Flink         = "1.10.0"
   val EmbeddedKafka = "2.5.0" 
-  // skuber depends on 2.5.29
-  val AkkaOperator  = "2.5.29"
 
+  // We've postponed updating Akka and Akka HTTP for the operator
+  // because of https://github.com/lightbend/cloudflow/issues/610
+  val AkkaOperator     = "2.5.29"
+  val AkkaHttpOperator = "10.1.12"
 }
 
 object Library {
@@ -32,6 +34,7 @@ object Library {
   val AkkaSlf4jOperator         = "com.typesafe.akka" %% "akka-slf4j"                % Version.AkkaOperator
   val AkkaStreamOperator        = "com.typesafe.akka" %% "akka-stream"               % Version.AkkaOperator
   val AkkaStreamTestkitOperator = "com.typesafe.akka" %% "akka-stream-testkit"       % Version.AkkaOperator
+  val AkkaHttpOperator          = "com.typesafe.akka" %% "akka-http"                 % Version.AkkaHttpOperator
 
   val AkkaCluster           = "com.typesafe.akka"     %% "akka-cluster"              % Version.Akka
   val AkkaManagement        = "com.lightbend.akka.management" %% "akka-management"   % Version.AkkaMgmt


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update core cloudflow-akka to Akka HTTP 10.2.0 and use the new 'newServerAt' API.

### Why are the changes needed?

In particular this means you can now configure HTTP/2 on the `HttpServerLogic`, which is useful for gRPC.

### Does this PR introduce any user-facing change?

This removes the `Flow` from the protected methods in `HttpServerLogic`, instead relying only on `Route` (which matches better with HTTP/2).

### How was this patch tested?

`sbt test`