### PR TITLE
Recommend using 'draft PRs' rather than [WIP] titles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,7 +2,7 @@
 Thanks for sending a pull request!  Here are some tips for you:
   1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
   2. Ensure you have added or run the appropriate tests for your PR.
-  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
+  3. If the PR is unfinished, open it as a 'Draft'.
   4. Be sure to keep the PR description updated to reflect all changes.
   5. Please write your PR title to summarize what this PR proposes.
   6. If possible, provide a concise example to reproduce the issue for a faster review.


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the PR template, recommend using the github 'Draft PR' feature rather than
adding a "[WIP]" marker to the title.