### PR TITLE
Fix newline stripping in bootstrap-install-script

### DIFF
--- a/installer/release/bootstrap-install-script.sh.template
+++ b/installer/release/bootstrap-install-script.sh.template
@@ -81,7 +81,7 @@ fi
 kubectlOutput=$(kubectl get sc -o jsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.provisioner}{"\t"}{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}')
 
 # A map where `key` is storage class and `value` is provisioner
-declare -A clusterStorageClassProvisioner=(); while read -r a b c; do clusterStorageClassProvisioner["$a"]="$b"; done <<< $kubectlOutput
+declare -A clusterStorageClassProvisioner=(); while read -r a b c; do clusterStorageClassProvisioner["$a"]="$b"; done <<< "$kubectlOutput"
 if [ $? -ne 0 ]; then
     print_error_message "The bootstrap install script has failed to connect to the cluster; please check your connect and try again."
     exit 1


### PR DESCRIPTION
Fix for newlines being stripped from kubectl output in installer bootstrap script

### What changes were proposed in this pull request?
Update bootstrap-install-script.sh.template to wrap kubectlOutput in quotes.


### Why are the changes needed?
In certain shells, newlines in the kubectl output were being stripped, resulting in only the first storage class being available for selection.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Tested locally and via Azure DevOps agent, where the issue was originally noticed.
