### PR TITLE
cloudflow.runtimes.flink.config support for local run

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -239,6 +239,7 @@ lazy val flink =
             FlinkStreaming,
             FlinkKafka,
             FlinkAvro,
+            FlinkWeb,
             ScalaTest
           ),
       libraryDependencies ~= { _.map(_.exclude("org.slf4j", "slf4j-log4j12")) }

--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/BlueprintSpec.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/BlueprintSpec.scala
@@ -613,7 +613,6 @@ class BlueprintSpec extends WordSpec with MustMatchers with EitherValues with Op
         .connect(Topic("fooos"), processorRef.in)
         .connect(Topic("foos-processed"), processorRef.out)
         .connect(Topic("foos-processed2"), processorRef.out)
-      println(blueprint.topics.map(_.verified))
       blueprint.problems mustBe Vector(
         PortBoundToManyTopics("bar.in", Vector("foos", "fooos")),
         PortBoundToManyTopics("bar.out", Vector("foos-processed", "foos-processed2"))

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -97,8 +97,7 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
         .entrySet()
         .forEach {
           // According to https://ci.apache.org/projects/flink/flink-docs-stable/ops/config.html
-          // Values can be Int, Bool, Duration and String
-          // TODO We are not supporting Duration yet
+          // Values can be Int, Bool, Duration and String (Duration can be passed as String, like "1 s", "1 m", etc)
           entry =>
             val key = entry.getKey
             entry.getValue.valueType() match {

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -19,15 +19,15 @@ package cloudflow.flink
 import java.nio.file.Path
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Future, Promise}
-import scala.util.{Failure, Try}
+import scala.concurrent.{ Future, Promise }
+import scala.util.{ Failure, Try }
 import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
 import org.apache.flink.api.common.JobExecutionResult
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.client.program.OptimizerPlanEnvironment
 import org.apache.flink.streaming.api.CheckpointingMode
-import org.apache.flink.streaming.api.datastream.{DataStreamSink, DataStream => JDataStream}
+import org.apache.flink.streaming.api.datastream.{ DataStreamSink, DataStream => JDataStream }
 import org.apache.flink.streaming.api.environment.CheckpointConfig
 import org.apache.flink.streaming.api.scala._
 import cloudflow.streamlets.BootstrapInfo._
@@ -96,12 +96,15 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
       case true =>
         // Copy all of the Flink parameters to configuration
         val configuration = new Configuration()
-        config.atPath(ClusterFlinkJobExecutor.flinkConfigPrefix).entrySet().forEach(
-          // According to https://ci.apache.org/projects/flink/flink-docs-stable/ops/config.html
-          // Values can be Int, bool, duratio and String
-          // For now treat everything as String
-          entry => configuration.setString(entry.getKey, entry.getValue.toString)
-        )
+        config
+          .atPath(ClusterFlinkJobExecutor.flinkConfigPrefix)
+          .entrySet()
+          .forEach(
+            // According to https://ci.apache.org/projects/flink/flink-docs-stable/ops/config.html
+            // Values can be Int, bool, duratio and String
+            // For now treat everything as String
+            entry => configuration.setString(entry.getKey, entry.getValue.toString)
+          )
         // Ensures that filesystem is initialized with right configuration
         FileSystem.initialize(configuration, null)
         StreamExecutionEnvironment.createLocalEnvironment(1, configuration)

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -160,6 +160,7 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
    * Different strategy for execution of Flink jobs in local mode and in cluster
    */
   sealed trait FlinkJobExecutor extends Serializable {
+    // Is this a path that we want to use?
     val flinkConfigPrefix = "cloudflow.runtimes.flink.config.flink"
     def execute(): StreamletExecution
   }

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -147,7 +147,8 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
           else if (configuration.contains(RestOptions.PORT)) {
             configuration.getInteger(RestOptions.PORT)
           } else RestOptions.PORT.defaultValue()
-        val host = configuration.getString(RestOptions.BIND_ADDRESS)
+        val host = Option(configuration.getString(RestOptions.BIND_ADDRESS)).getOrElse("localhost")
+
         log.info(s"Enabled local Flink Web UI at port $host:$port")
         localEnv
       } else {
@@ -188,9 +189,8 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
     checkpointConfig
   }
 
-  private def isWebEnabled(config: Config, path: String): Boolean = {
+  private def isWebEnabled(config: Config, path: String): Boolean =
     config.as[Option[Boolean]](s"$path.${ClusterFlinkJobExecutor.enableLocalWeb}").getOrElse(false)
-  }
 
   protected def createLogic(): FlinkStreamletLogic
 

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -131,10 +131,10 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
         // Note here that a local web support is set through configuration by setting
         // "local.web" either in the streamlet or Flink runtime context. We are not checking the value, but rather
         // the fact that variable is defines.
-        enableWeb match {
-          case true => StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(configuration)
-          case _    => StreamExecutionEnvironment.createLocalEnvironment(1, configuration)
-        }
+        if(enableWeb)
+          StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(configuration)
+        else
+          StreamExecutionEnvironment.createLocalEnvironment(1, configuration)
       case false =>
         StreamExecutionEnvironment.getExecutionEnvironment
     }

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -131,7 +131,7 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
         // Note here that a local web support is set through configuration by setting
         // "local.web" either in the streamlet or Flink runtime context. We are not checking the value, but rather
         // the fact that variable is defines.
-        if(enableWeb)
+        if (enableWeb)
           StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(configuration)
         else
           StreamExecutionEnvironment.createLocalEnvironment(1, configuration)

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -149,7 +149,7 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
           } else RestOptions.PORT.defaultValue()
         val host = Option(configuration.getString(RestOptions.BIND_ADDRESS)).getOrElse("localhost")
 
-        log.info(s"Enabled local Flink Web UI at port $host:$port")
+        log.info(s"Enabled local Flink Web UI at $host:$port")
         localEnv
       } else {
         StreamExecutionEnvironment.createLocalEnvironment(1, configuration)

--- a/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
+++ b/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
@@ -137,6 +137,7 @@ object LocalRunner extends StreamletLoader {
       val patchedRunnerConfig = runnerConfig
         .withFallback(streamletParamConfig)
         .withFallback(baseConfig)
+        .withFallback(localConfig)
         .withValue("cloudflow.local", ConfigValueFactory.fromAnyRef(true))
 
       (streamletInstance, patchedRunnerConfig)

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -72,6 +72,7 @@ object Library {
   val FlinkStreaming         = "org.apache.flink"      %% "flink-streaming-scala"    % Version.Flink
   val FlinkAvro              = "org.apache.flink"       % "flink-avro"               % Version.Flink
   val FlinkKafka             = "org.apache.flink"      %% "flink-connector-kafka"    % Version.Flink
+  val FlinkWeb               = "org.apache.flink"      %% "flink-runtime-web"        % Version.Flink
 
   val FastClasspathScanner  = "io.github.lukehutch"   %  "fast-classpath-scanner"   % "2.21"
   val ScalaCheck            = "org.scalacheck"        %% "scalacheck"               % "1.14.0"

--- a/examples/taxi-ride/build.sbt
+++ b/examples/taxi-ride/build.sbt
@@ -24,7 +24,8 @@ lazy val taxiRidePipeline = appModule("taxi-ride-pipeline")
   .enablePlugins(CloudflowApplicationPlugin)
   .settings(commonSettings)
   .settings(
-    name := "taxi-ride-fare"
+    name := "taxi-ride-fare",
+    runLocalConfigFile := Some("taxi-ride-pipeline/src/main/resources/local.conf"),
   )
 
 lazy val datamodel = appModule("datamodel")

--- a/examples/taxi-ride/taxi-ride-pipeline/src/main/resources/local.conf
+++ b/examples/taxi-ride/taxi-ride-pipeline/src/main/resources/local.conf
@@ -1,0 +1,7 @@
+cloudflow.runtimes.flink.config {
+  flink {
+    local.web = on
+    rest.port = 5000
+    execution.checkpointing.interval = "5 s"
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Existing setupExecutionEnvironment is limited in the sense, that it does not update configuration in the environment, for example, Azure access key. Instead here we are assuming that all of the configurations necessary are specified in Streamlet config under the path "cloudflow.runtimes.flink.config.flink". In the case of local run, all of the parameters under this path are used to populate Flink configuration and build the environment based on them. In the case of cluster execution the same parameters will be included into flink-conf.yaml
Additionally, if "local.web" configuration is set in Flink.runtime or streamlet configuration, local environment is started with web support.
-->


### Why are the changes needed?
Example are:

> EY request to run local with checkpointing to Azure

> EY request for local Web UI for local run.


### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Local runs
