### PR TITLE
Fix an issue detecting a CRD version.

### DIFF
--- a/kubectl-cloudflow/cmd/deploy_command.go
+++ b/kubectl-cloudflow/cmd/deploy_command.go
@@ -398,7 +398,7 @@ func validateStreamletRunnersDependencies(applicationSpec cfapp.CloudflowApplica
 		if len(versions) == 0 {
 			return fmt.Errorf("cannot detect the installed version of the CRD '%s'", prettyName)
 		}
-		return fmt.Errorf("'%s' is installed but the wrong version, required '%s', installed '%s'", prettyName, expectedVersion, strings.Join(versionsArray, (",")))
+		return fmt.Errorf("'%s' is installed but does not support the required version of the CRD, required '%s', installed '%s'", prettyName, expectedVersion, strings.Join(versionsArray, (",")))
 	}
 
 	runnersInApplicationSpec := make(map[string]bool)

--- a/kubectl-cloudflow/cmd/deploy_command.go
+++ b/kubectl-cloudflow/cmd/deploy_command.go
@@ -384,7 +384,7 @@ func validateStreamletRunnersDependencies(applicationSpec cfapp.CloudflowApplica
 	runnerTypes["flink"] = RunnerRequirements{"flinkapplications.flink.k8s.io", version.RequiredFlinkVersion}
 
 	validateRunnerType := func(crdName string, prettyName string, expectedVersion string) error {
-		versionBytes, err := exec.Command("kubectl", "get", "crds", crdName, "-o", "jsonpath='{$.spec.versions[*].name}'").Output()
+		versionBytes, err := exec.Command("kubectl", "get", "crds", crdName, "-o", "jsonpath={$.spec.versions[*].name}").Output()
 		versions := strings.Trim(string(versionBytes), " ")
 		if err != nil {
 			return fmt.Errorf("cannot detect that '%s' is installed, please install '%s' before continuing (%v)", prettyName, prettyName, err.Error())


### PR DESCRIPTION
The previous iteration of this code worked on the assumption that there
is a singular `version` field in the CRD, this is not true in newer
versions of K8s. This version extracts all the `versions[].name`'s in
the cluster and checks if any of those versions match the desired
one. The desired version has to be the stored version, if we write a
supported, but not the current version of the CR, it will get converted and
usable by the operator.

Have also added a better error message when the plugin cannot detect a
version, this is most likely to happen when you have an older cluster.

This version has been tested on k8s 1.18