### PR TITLE
Add Spark trigger support

### DIFF
--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -57,7 +57,7 @@ class TestSparkStreamletContext(override val streamletRef: String,
       stream: Dataset[Out],
       outPort: CodecOutlet[Out],
       outputMode: OutputMode,
-      optional_trigger: Option[Trigger] = None
+      optionalTrigger: Option[Trigger] = None
   )(implicit encoder: Encoder[Out], typeTag: TypeTag[Out]): StreamingQuery = {
     // RateSource can only work with a microBatch query because it contains no data at time zero.
     // Trigger.Once requires data at start to work.

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -61,7 +61,7 @@ class TestSparkStreamletContext(override val streamletRef: String,
   )(implicit encoder: Encoder[Out], typeTag: TypeTag[Out]): StreamingQuery = {
     // RateSource can only work with a microBatch query because it contains no data at time zero.
     // Trigger.Once requires data at start to work.
-    val trigger = optional_trigger match {
+    val trigger = optionalTrigger match {
       case Some(t) => t
       case _ =>
         if (isRateSource(stream)) {

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -61,14 +61,12 @@ class TestSparkStreamletContext(override val streamletRef: String,
   )(implicit encoder: Encoder[Out], typeTag: TypeTag[Out]): StreamingQuery = {
     // RateSource can only work with a microBatch query because it contains no data at time zero.
     // Trigger.Once requires data at start to work.
-    val trigger = optionalTrigger match {
-      case Some(t) => t
-      case _ =>
-        if (isRateSource(stream)) {
-          Trigger.ProcessingTime(ProcessingTimeInterval)
-        } else {
-          Trigger.Once()
-        }
+    val trigger = optionalTrigger.getOrElse {
+      if (isRateSource(stream)) {
+        Trigger.ProcessingTime(ProcessingTimeInterval)
+      } else {
+        Trigger.Once()
+      }
     }
     val streamingQuery = outletTaps
       .find(_.portName == outPort.name)

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -224,10 +224,10 @@ abstract class SparkStreamletLogic(implicit val context: SparkStreamletContext) 
   final def writeStream[Out](stream: Dataset[Out],
                              outPort: CodecOutlet[Out],
                              outputMode: OutputMode,
-                             trigger: Trigger = Trigger.ProcessingTime(0L))(
+                             optional_trigger: Option[Trigger] = None)(
       implicit encoder: Encoder[Out],
       typeTag: TypeTag[Out]
-  ): StreamingQuery = context.writeStream(stream, outPort, outputMode, trigger)
+  ): StreamingQuery = context.writeStream(stream, outPort, outputMode, optional_trigger)
 
   final def config: Config = context.config
 

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -224,7 +224,7 @@ abstract class SparkStreamletLogic(implicit val context: SparkStreamletContext) 
   final def writeStream[Out](stream: Dataset[Out],
                              outPort: CodecOutlet[Out],
                              outputMode: OutputMode,
-                             optional_trigger: Option[Trigger] = None)(
+                             optionalTrigger: Option[Trigger] = None)(
       implicit encoder: Encoder[Out],
       typeTag: TypeTag[Out]
   ): StreamingQuery = context.writeStream(stream, outPort, outputMode, optional_trigger)

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -227,7 +227,7 @@ abstract class SparkStreamletLogic(implicit val context: SparkStreamletContext) 
                              optionalTrigger: Option[Trigger] = None)(
       implicit encoder: Encoder[Out],
       typeTag: TypeTag[Out]
-  ): StreamingQuery = context.writeStream(stream, outPort, outputMode, optional_trigger)
+  ): StreamingQuery = context.writeStream(stream, outPort, outputMode, optionalTrigger)
 
   final def config: Config = context.config
 

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -27,7 +27,7 @@ import scala.util.{ Failure, Try }
 import akka.actor.{ ActorSystem, Cancellable, Scheduler }
 import com.typesafe.config.Config
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.streaming.{ OutputMode, StreamingQuery }
+import org.apache.spark.sql.streaming.{ OutputMode, StreamingQuery, Trigger }
 import org.apache.spark.sql.{ Dataset, Encoder, SparkSession }
 import cloudflow.streamlets.BootstrapInfo._
 import cloudflow.streamlets._
@@ -221,10 +221,13 @@ abstract class SparkStreamletLogic(implicit val context: SparkStreamletContext) 
   /**
    * Write a `StreamingQuery` into outlet using the specified `OutputMode`
    */
-  final def writeStream[Out](stream: Dataset[Out], outPort: CodecOutlet[Out], outputMode: OutputMode)(
+  final def writeStream[Out](stream: Dataset[Out],
+                             outPort: CodecOutlet[Out],
+                             outputMode: OutputMode,
+                             trigger: Trigger = Trigger.ProcessingTime(0L))(
       implicit encoder: Encoder[Out],
       typeTag: TypeTag[Out]
-  ): StreamingQuery = context.writeStream(stream, outPort, outputMode)
+  ): StreamingQuery = context.writeStream(stream, outPort, outputMode, trigger)
 
   final def config: Config = context.config
 

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamletContext.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamletContext.scala
@@ -52,7 +52,7 @@ abstract case class SparkStreamletContext(
    * @param stream stream used to write the result of execution of the `StreamingQuery`
    * @param outPort the port used to write the result of execution of the `StreamingQuery`
    * @param outputMode the output mode used to write. Valid values Append, Update, Complete
-   * @param trigger Execution trigger (see https://dzone.com/articles/spark-trigger-options for details)
+   * @param trigger Execution trigger (see http://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#triggers for details)
    *
    * @return the `StreamingQuery` that starts executing
    */

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamletContext.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamletContext.scala
@@ -56,7 +56,7 @@ abstract case class SparkStreamletContext(
    *
    * @return the `StreamingQuery` that starts executing
    */
-  def writeStream[Out](stream: Dataset[Out], outPort: CodecOutlet[Out], outputMode: OutputMode, trigger: Trigger)(
+  def writeStream[Out](stream: Dataset[Out], outPort: CodecOutlet[Out], outputMode: OutputMode, trigger: Option[Trigger])(
       implicit encoder: Encoder[Out],
       typeTag: TypeTag[Out]
   ): StreamingQuery

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamletContext.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamletContext.scala
@@ -18,7 +18,7 @@ package cloudflow.spark
 
 import scala.reflect.runtime.universe._
 import org.apache.spark.sql.{ Dataset, Encoder, SparkSession }
-import org.apache.spark.sql.streaming.{ OutputMode, StreamingQuery }
+import org.apache.spark.sql.streaming.{ OutputMode, StreamingQuery, Trigger }
 import cloudflow.streamlets.{ CodecInlet, CodecOutlet }
 import cloudflow.streamlets._
 
@@ -52,10 +52,13 @@ abstract case class SparkStreamletContext(
    * @param stream stream used to write the result of execution of the `StreamingQuery`
    * @param outPort the port used to write the result of execution of the `StreamingQuery`
    * @param outputMode the output mode used to write. Valid values Append, Update, Complete
+   * @param trigger Execution trigger (see https://dzone.com/articles/spark-trigger-options for details)
    *
    * @return the `StreamingQuery` that starts executing
    */
-  def writeStream[Out](stream: Dataset[Out], outPort: CodecOutlet[Out], outputMode: OutputMode)(implicit encoder: Encoder[Out],
-                                                                                                typeTag: TypeTag[Out]): StreamingQuery
+  def writeStream[Out](stream: Dataset[Out], outPort: CodecOutlet[Out], outputMode: OutputMode, trigger: Trigger)(
+      implicit encoder: Encoder[Out],
+      typeTag: TypeTag[Out]
+  ): StreamingQuery
 
 }

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/kafka/SparkStreamletContextImpl.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/kafka/SparkStreamletContextImpl.scala
@@ -89,7 +89,7 @@ class SparkStreamletContextImpl(
     val checkpointLocation = checkpointDir(outPort.name)
     val queryName          = s"$streamletRef.$outPort"
 
-    optional_trigger match {
+    optionalTrigger match {
       case Some(trigger) =>
         encodedStream.writeStream
           .outputMode(outputMode)

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/kafka/SparkStreamletContextImpl.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/kafka/SparkStreamletContextImpl.scala
@@ -73,7 +73,7 @@ class SparkStreamletContextImpl(
     case (key, value) => s"kafka.$key" -> value
   }
 
-  def writeStream[Out](stream: Dataset[Out], outPort: CodecOutlet[Out], outputMode: OutputMode, optional_trigger: Option[Trigger] = None)(
+  def writeStream[Out](stream: Dataset[Out], outPort: CodecOutlet[Out], outputMode: OutputMode, optionalTrigger: Option[Trigger] = None)(
       implicit encoder: Encoder[Out],
       typeTag: TypeTag[Out]
   ): StreamingQuery = {


### PR DESCRIPTION
Adding Spark streaming execution trigger as a parameter for sparklet execution
As described https://dzone.com/articles/spark-trigger-options,  Spark  Structured Streaming supports different trigger options available in Spark Structured Streaming. Setting the right trigger for a stream will decide how quick your stream reads the next set of records. The trigger option enables you to control the latency and throughput of the job.

In the current implementation, no option was set for the execution trigger which means that Spark will try to process the next set of records as soon as it’s done with the current micro batch. The default behavior of write streams in Spark Structured Streaming is the micro batch. In a micro batch, incoming records are grouped into small windows and processed in a periodic fashion.

### Why are the changes needed?
Although processing as soon as possible, is sometimes a good option, but the most widely used and recommended practice in Spark Structured Streaming. The trigger option of processing time gives you better control over how often micro batch jobs should get triggered. For example, if you set a trigger interval of “20 seconds” then for every 20 seconds a micro batch will process a batch of records. Based on the speed at which you want your job to process the records you can fine-tune the trigger interval and throughput of the job as well.
Another very useful processing option is continuous stream processing was introduced in Spark 2.3 as an experimental feature. As of Spark 2.4.0, it’s still experimental. It enables you to process records in milliseconds which would otherwise take seconds in micro batch. In this trigger option, records are not processed in micro batch, but, instead, a long-running task is created per write stream and processed as quickly as possible.

The ability to pass an explicit Trigger allows to better utilize Spark streaming capabilities and better utilize sparklets

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Re running all the tests