### PR TITLE
docs: update the helm-base installation instructions

### DIFF
--- a/docs/docs-source/docs/modules/administration/pages/how-to-install-and-use-strimzi.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/how-to-install-and-use-strimzi.adoc
@@ -22,14 +22,13 @@ Make sure you have the following prerequisites installed before continuing:
 
 In this guide, we will use Helm to install Strimzi.
 
-IMPORTANT: We are going to create Strimzi in the `cloudflow` namespace in this guide. Make sure that the namespace 'cloudflow' exists before continuing. To create the `cloudflow` namespace, execute `kubectl create ns cloudflow`.
+We are going to create Strimzi in the `cloudflow` namespace in this guide. Make sure that the namespace `cloudflow` exists before continuing. To create the `cloudflow` namespace, execute
 
-Add the Strimzi Helm repository.
+  kubectl create ns cloudflow
+
+Add the Strimzi Helm repository and update the local index.
 
   helm repo add strimzi https://strimzi.io/charts/
-
-Update the repository list
-
   helm repo update
 
 Install the latest version of Strimzi.
@@ -50,6 +49,7 @@ To create a Kafka cluster using Strimzi, we have to create a `CustomResource` of
 
 Create the YAML file containing the custom resource using the following snippet:
 
+[source,shell script]
 ----
 cat > kafka-cluster.yaml << EOF
 apiVersion: kafka.strimzi.io/v1beta1

--- a/docs/docs-source/docs/modules/administration/pages/installing-cloudflow.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-cloudflow.adoc
@@ -27,31 +27,26 @@ Kafka is used by Cloudflow to store data streams. Before installing Cloudflow, y
 
 The Kafka broker bootstrap configuration string is a comma-separated list of host/port pairs used by Cloudflow to establish the connection to the Kafka cluster. The configuration string should have the following format:
 
-broker-1-address:broker-1-port, broker-2-address;broker-2-port
+    broker-1-address:broker-1-port, broker-2-address;broker-2-port
 
 If you want to test Cloudflow and need a Kafka cluster, we recommend using Strimzi, a third-party Kafka operator that can create and manage Kafka clusters. 
 
-The following chapter is a guide on how to configure and install a Kafka cluster using Strimzi: 
+See xref:how-to-install-and-use-strimzi.adoc[Installing Kafka with Strimzi] as a guide on how to configure and install a Kafka cluster using Strimzi.
 
-. xref:how-to-install-and-use-strimzi.adoc[Installing Kafka with Strimzi]
+=== Storage requirements (for use with Spark or Flink)
 
-=== Storage requirements
-
-If you plan to write Cloudflow applications using Spark or Flink, the Kubernetes cluster will need to have a storage class of the `ReadWriteMany` type installed. The name of the `ReadWriteMany` storage class name is required when installing Cloudflow.
+**If you plan to write Cloudflow applications using Spark or Flink**, the Kubernetes cluster will need to have a storage class of the `ReadWriteMany` type installed. The name of the `ReadWriteMany` storage class name is required when installing Cloudflow.
 
 For testing purposes, we suggest using the NFS Server Provisioner, which can be found here: https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner[NFS Server Provisioner Helm chart]
 
-We'll install the nfs chart in the `cloudflow` namespace, so create the namespace first:
+We'll install the nfs chart in the `cloudflow` namespace, if it does not exist yet, create the `cloudflow` namespace:
 
   kubectl create ns cloudflow
 
 
-Add the `Stable` Helm repository:
+Add the `Stable` Helm repository and update the local index:
 
   helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-
-Update the Helm repository:
-
   helm repo update
 
 Install the NFS Server Provisioner using the following command:
@@ -89,30 +84,44 @@ The first step is to create the namespace, if it does not exist yet, to install 
 
 IMPORTANT: Many subsequent commands will assume that the namespace is `cloudflow`.
 
-First, we add the Cloudflow Helm repository:
+First, we add the Cloudflow Helm repository and update the local index:
 
   helm repo add cloudflow-helm-charts https://lightbend.github.io/cloudflow-helm-charts/
-
-The `repo update` command ensures Helm has an up-to-date index of all Helm charts.
-
   helm repo update
 
-Before installing Cloudflow, let's go over the custom parameters we are supplying with the command:
+=== Installing (with support for Spark or Flink)
+
+For use with Spark or Flink, the `persistentStorageClass` parameter sets the storage class to `nfs`. This storage class, as mentioned in <<_storage_requirements>>, has to be of the type `ReadWriteMany`. In our example, we are using the `nfs` storage class.
 
   cloudflow_operator.persistentStorageClass=nfs
 
-The `persistentStorageClass` parameter sets the storage class to use with Spark and Flink applications. This storage class, as previously mentioned, has to be of the type `ReadWriteMany`. In our example, we are using the `nfs` storage class.
+The `kafkaBootstrapservers` parameter sets the address and port of the Kafka cluster that Cloudflow will use. In this example, we have used the address of a Strimzi created Kafka cluster located in the `cloudflow` namespace.
 
   cloudflow_operator.kafkaBootstrapservers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
 
+The following command installs Cloudflow using the Helm chart:
+
+  helm install cloudflow cloudflow-helm-charts/cloudflow --namespace cloudflow \
+    --set strimzi.enabled=true \
+    --set cloudflow_operator.persistentStorageClass=nfs \
+    --set cloudflow_operator.kafkaBootstrapservers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
+
+
+=== Installing (no support for Spark or Flink)
+
 The `kafkaBootstrapservers` parameter sets the address and port of the Kafka cluster that Cloudflow will use. In this example, we have used the address of a Strimzi created Kafka cluster located in the `cloudflow` namespace.
+
+  cloudflow_operator.kafkaBootstrapservers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
 
 The following command installs Cloudflow using the Helm chart:
 
-  helm install cloudflow cloudflow-helm-charts/cloudflow --namespace cloudflow --set \
-  strimzi.enabled=true --set cloudflow_operator.persistentStorageClass=nfs --set cloudflow_operator.kafkaBootstrapservers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
+  helm install cloudflow cloudflow-helm-charts/cloudflow --namespace cloudflow \
+    --set strimzi.enabled=true \
+    --set cloudflow_operator.kafkaBootstrapservers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
 
-Check the status of the install process using `kubectl`. When the Cloudflow operator pod is in `Running` status, the installation is complete.
+=== Verifying the installation
+
+Check the status of the installation process using `kubectl`. When the Cloudflow operator pod is in `Running` status, the installation is complete.
 
 ----
 $ kubectl get pods -n cloudflow
@@ -129,9 +138,7 @@ If you plan to write applications that utilize Spark, you will need to install t
   $ kubectl cloudflow deploy cloudflow/examples/call-record-aggregator/target/call-record-aggregator.json
   [Error] cannot detect that 'Spark' is installed, please install 'Spark' before continuing (exit status 1)
 
-The following chapter is a guide on how to configure and install the Spark Operator: 
-
-. xref:installing-spark-operator.adoc[Adding Spark Support]
+To install the Spark Operator see xref:installing-spark-operator.adoc[Adding Spark Support].
 
 == Adding Flink support
 
@@ -140,21 +147,16 @@ If you plan to write applications that utilize Flink you will need to install th
   $ kubectl cloudflow deploy cloudflow/examples/taxi-ride/target/taxi-ride-fare.json
   [Error] cannot detect that Flink is installed, please install Flink before continuing (exit status 1)
 
-The following chapter is a guide on how to configure and install the Spark Operator: 
-
-. xref:installing-flink-operator.adoc[Adding Flink Support]
+To install the Flink Operator see xref:installing-flink-operator.adoc[Adding Flink Support].
 
 == Installing Enterprise components
 If you have a commercial agreement with Lightbend, you are eligible to install the Cloudflow Enterprise components. 
 
 Before installing, you need to make sure you have the credentials required to download the Helm chart from the Lightbend commercial repository.
 
-Add the Lightbend Helm repository.
+Add the Lightbend Helm repository and update the local index:
 
   helm repo add lightbend https://repo.lightbend.com/helm-charts/
-
-Update Helm to make sure all charts are up-to-date
-
   helm repo update
 
 Install the components, note that you set the `$USERNAME` and `$PASSWORD` environment variables before executing this command. 
@@ -168,12 +170,13 @@ We recommend using the following command to create an environment variable for u
 TIP: If you want to see the password typed in, remove the `-s` (for silent) flag.
 
 Once configured, we can execute the Helm command to install the Cloudflow enterprise components. Note how we use the `$USERNAME` and `$PASSWORD` in the Helm command.
- 
+
+[source,shell script,subs="attributes+"]
 ----
 helm upgrade cloudflow-enterprise-components lightbend/cloudflow-enterprise-components \
   --install \
   --namespace cloudflow \
-  --set enterpriseOperatorVersion=2.0.8 \
+  --set enterpriseOperatorVersion={cloudflow-version} \
   --set enterprise-suite.imageCredentials.username="$USERNAME" \
   --set enterprise-suite.imageCredentials.password="$PASSWORD"
 ----
@@ -197,6 +200,4 @@ You should now see the Lightbend console in your browser.
 
 == Upgrading Cloudflow
 
-If you need to upgrade Cloudflow to a newer version, the following chapter in the administration section will show you how:
-
-. xref::administration:upgrading-cloudflow.adoc[upgrading Cloudflow].
+If you need to upgrade Cloudflow to a newer version, xref:upgrading-cloudflow.adoc[upgrading Cloudflow] in the administration section will show you how.

--- a/docs/docs-source/docs/modules/administration/pages/installing-flink-operator.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-flink-operator.adoc
@@ -5,15 +5,16 @@
 
 include::ROOT:partial$include.adoc[]
 
-The Flink operator used is a fork currently maintained by Lightbend and is the only Cloudflow compatible version.
+The only Cloudflow compatible Flink operator is a fork currently maintained by Lightbend.
 
 Install the Flink operator using the following Helm command:
 
 ----
 helm install flink-operator \
-https://github.com/lightbend/flink-operator/releases/download/v0.8.2/flink-operator-0.8.2.tgz \
---namespace cloudflow --set operatorImageName="lightbend/flinkk8soperator" --set \
-operatorVersion="v0.5.0"
+  https://github.com/lightbend/flink-operator/releases/download/v0.8.2/flink-operator-0.8.2.tgz \
+  --namespace cloudflow \
+  --set operatorImageName="lightbend/flinkk8soperator" \
+  --set operatorVersion="v0.5.0"
 ----
 
 This completes the installation of the Flink operator. 

--- a/docs/docs-source/docs/modules/administration/pages/installing-spark-operator.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-spark-operator.adoc
@@ -5,15 +5,12 @@
 
 include::ROOT:partial$include.adoc[]
 
-The Spark operator image used is a fork maintained by Lightbend and is presently the only Cloudflow compatible version.
+The only Cloudflow compatible Spark operator is a fork maintained by Lightbend.
 See https://github.com/apache/spark/pull/24748[Backported Fix for Spark 2.4.5] for more details.
 
-Add the Spark Helm chart repository.
+Add the Spark Helm chart repository and update the local index.
 
   helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-
-As we have seen before, we need to update the Helm repo before installing Spark.
-  
   helm repo update
 
 Before installing the Helm chart, we will need to prepare a `value.yaml` file, it overrides the default values in the Spark Helm chart.
@@ -59,9 +56,18 @@ EOF
 
 Now we can install the Spark operator using Helm. Note that we use a specific version of the Spark operator Helm chart.
 
-  helm install spark-operator incubator/sparkoperator --namespace cloudflow --values="spark-values.yaml"  --version "0.6.7"
+[source,shell script,subs="attributes"]
+----
+  helm install spark-operator incubator/sparkoperator \
+    --namespace cloudflow
+    --values="spark-values.yaml"
+    --version "0.6.7"
+----
 
-IMPORTANT: If you are installing the Spark operator on *OpenShift*, you need to apply the following `rolebinding` to the cluster:
+[IMPORTANT]
+.*OpenShift* requires a role-binding
+====
+If you are installing the Spark operator on *OpenShift*, you need to apply the following `rolebinding` to the cluster:
 
 ----
 cat > spark-rolebinding.yaml << EOF
@@ -84,6 +90,7 @@ EOF
 To apply the `spark-rolebinding.yaml` file execute the following command. Note that this has *only* to be performed if you are installing Cloudflow on Openshift:
 
   oc apply -f spark-rolebinding.yaml
+====
 
 After the Spark operator installation completes, we need to adjust its webhook configuration:
 

--- a/docs/docs-source/docs/modules/administration/pages/upgrading-cloudflow.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/upgrading-cloudflow.adoc
@@ -7,10 +7,30 @@ include::ROOT:partial$include.adoc[]
 
 Upgrading Cloudflow after a new release is done using the Helm upgrade command, the command will upgrade Cloudflow to the latest version.
 
-	helm upgrade cloudflow cloudflow-helm-charts/cloudflow --namespace cloudflow --set cloudflow_operator.persistentStorageClass=nfs --set cloudflow_operator.kafkaBootstrapservers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
+=== Upgrading (with support for Spark or Flink)
+
+If the the Cloudflow installation uses Spark or Flink, pass the persistent storage option:
+----
+  helm upgrade cloudflow cloudflow-helm-charts/cloudflow \
+    --namespace cloudflow \
+    --set cloudflow_operator.persistentStorageClass=nfs
+    --set cloudflow_operator.kafkaBootstrapservers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
+----
+
+=== Upgrading (no support for Spark or Flink)
+
+Upgrade a Cloudflow installation without support for Spark or Flink with:
+----
+  helm upgrade cloudflow cloudflow-helm-charts/cloudflow \
+    --namespace cloudflow \
+    --set cloudflow_operator.kafkaBootstrapservers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
+----
 
 To upgrade Cloudflow to a specific version, add the _--version_ flag. For example:
 
-	helm upgrade cloudflow cloudflow-helm-charts/cloudflow --namespace cloudflow --set cloudflow_operator.persistentStorageClass=nfs --set cloudflow_operator.kafkaBootstrapservers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092 --version="2.0.8"
+[source,shell script,subs="attributes"]
+----
+  --version="{cloudflow-version}"
+----
 
 IMPORTANT: A typical upgrade of Cloudflow does not affect the running Cloudflow applications. However, it is essential to make sure to read the release notes to make sure there are no breaking changes.

--- a/docs/docs-source/docs/modules/get-started/pages/deploy-to-k8s-cluster.adoc
+++ b/docs/docs-source/docs/modules/get-started/pages/deploy-to-k8s-cluster.adoc
@@ -5,7 +5,7 @@
 
 include::ROOT:partial$include.adoc[]
 
-If you have not already installed Cloudflow on a Kubernetes Cluster, please xref:installing-cloudflow.adoc[install Cloudflow] first.
+If you have not already installed Cloudflow on a Kubernetes Cluster, please xref:administration:installing-cloudflow.adoc[install Cloudflow] first.
 
 Once the application is built you need to publish the docker images to a container registry that stores, manages and secures your application images. 
 In this example we will use a Docker Hub registry.
@@ -15,11 +15,11 @@ Follow these steps to complete the process of publishing:
 * Set up the target environment of publishing in your local build process. 
 Create a file named `target-env.sbt` in the root of your project folder (the same level where you have `build.sbt`). The file needs to have the following 2 lines:
 
-```
-// Google Cloud Registry
+[source,sbt]
+----
 ThisBuild / cloudflowDockerRegistry := Some("docker.io")
 ThisBuild / cloudflowDockerRepository := Some("<your docker hub username>")
-```
+----
 
 Replace `<docker hub username>` with your Docker Hub username.
 Publish the docker image of your project to the above registry. 


### PR DESCRIPTION
### What changes were proposed in this pull request?

I followed the new helm-based installation documentation and tried to streamline it a bit.

This makes a clearer separation of when the persistent storage class needs to be passed when installing the Cloudflow operator.

### Why are the changes needed?
- Hopefully easier to follow the instructions.
- Fixed some links.