### PR TITLE
AKS script typo, CLUSTER_VERSION -> K8S_VERSION

### DIFF
--- a/installer/create-cluster-aks.sh
+++ b/installer/create-cluster-aks.sh
@@ -113,7 +113,7 @@ az aks create --resource-group "$RESOURCE_GROUP_NAME" \
   --enable-addons monitoring \
   --enable-cluster-autoscaler \
   --generate-ssh-keys \
-  --kubernetes-version "$CLUSTER_VERSION" \
+  --kubernetes-version "$K8S_VERSION" \
   --node-vm-size $NODE_VM_SIZE \
   --min-count 1 \
   --max-count 7


### PR DESCRIPTION
minor typo in [installer/create-cluster-aks.sh](https://github.com/lightbend/cloudflow/blob/master/installer/create-cluster-aks.sh)

```
--kubernetes-version "$CLUSTER_VERSION" 

should be

--kubernetes-version "$K8S_VERSION"
```