### PR TITLE
Add documentation for using Azure Blob storage from Flink (local and deployed to Cloudflow

### DIFF
--- a/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -166,7 +166,7 @@ In the above example the `runLocalConfigFile` setting is shown to point to a loc
 
 Flink supports several file systems for reading and writing data and for its state backend. In this section, we will look at how to use Microsoft's Azure Blob Storage for these purposes.
 
-Please refer to the Flink documentation here https://ci.apache.org/projects/flink/flink-docs-stable/ops/filesystems/azure.html
+Please refer to the Flink documentation https://ci.apache.org/projects/flink/flink-docs-stable/ops/filesystems/azure.html[Azure Blob Storage]
 
 To make this work in a Cloudflow context there are a couple of things you need to do as follows.
 
@@ -178,7 +178,7 @@ In the configuration file, you need to specify that the `state.backend` is `file
 ----
 cloudflow.runtimes.flink.config {
   flink.state.backend = filesystem
-  flink.state.checkpoints.dir = "<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>"
+  flink.state.checkpoints.dir = "wasbs://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>"
   flink.fs.azure.account.key.<your-azure-acount>.blob.core.windows.net = "<blob-access-key>"
 }
 ----

--- a/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -161,3 +161,55 @@ lazy val taxiRidePipeline = appModule("taxi-ride-pipeline")
 NOTE: If you set `execution.checkpointing.interval` you need to set all other relevant checkpointing settings, the default checkpointing will not be used if `execution.checkpointing.interval` is set.
 
 In the above example the `runLocalConfigFile` setting is shown to point to a local.conf in the taxi-ride-fare example project.
+
+== Azure Blob Storage
+
+Flink supports a number of file systems for reading and writing data and for its state backend. In this section we will look at how to use Microsoft's Azure Blob Storage for these purposes.
+
+Please refer to the Flink documentation here https://ci.apache.org/projects/flink/flink-docs-stable/ops/filesystems/azure.html
+
+To make this work in a Cloudflow context there are a couple of things you need to do as follows.
+
+=== Checkpoints
+
+In the configuration file you need to specify that the `state.backend` is `filesystem`, set `state.checkpoints.dir` to match the the location of your Blob, and provide your access key.
+
+[source,hocon]
+----
+cloudflow.runtimes.flink.config {
+  flink.state.backend = filesystem
+  flink.state.checkpoints.dir = "<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>"
+  flink.fs.azure.account.key.<your-azure-acount>.blob.core.windows.net = "<blob-access-key>"
+}
+----
+
+Whether you are running locally or deploying to a Cloudflow cluster, this part of the configuration is the same.
+
+==== Deployment
+
+When your Flink streamlet is deployed it will run in a Docker container which includes a normal Flink installation. In order to use Azure Blob Storage as filesystem we need to enable a plugin `flink-azure-fs-hadoop`. As detailed in the Flink documentation, all plugins need to be copied from the `/opt/` folder into a directory of their own in `/plugins.`.
+
+To facilitate this, in your _Streamlet_ `build.sbt` you must add the following instructions to make sure that the plugin is copied to the right place when the container is built.
+
+[source, scala]
+----
+lazy val yourStreamlet = appModule("yourStreamlet")
+  .enablePlugins(CloudflowFlinkPlugin)
+  .settings(
+    extraDockerInstructions ++= Seq(
+      sbtdocker.Instructions.User("root"),
+      sbtdocker.Instructions.Run("mkdir -p ./plugins/azure-fs-hadoop"),
+      sbtdocker.Instructions.Run("cp /opt/flink/opt/flink-azure-fs-hadoop-1.10.0.jar ./plugins/azure-fs-hadoop/"),
+      sbtdocker.Instructions.Run("chown -R flink:flink ./plugins/azure-fs-hadoop"))
+  )
+  ...
+----
+
+==== Running Locally
+
+Cloudflow does not build containers for running locally, instead it will run Flink embedded in the JVM. In order to make sure the `flink-fs-azure-hadoop.jar` is included in the application you need to explicitly add it to your build file as follows.
+
+[source, scala]
+----
+libraryDependencies += "org.apache.flink" % "flink-azure-fs-hadoop" % "1.11.1"
+----

--- a/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -200,8 +200,8 @@ lazy val yourStreamlet = appModule("yourStreamlet")
       sbtdocker.Instructions.User("root"),
       sbtdocker.Instructions.Run("mkdir -p ./plugins/azure-fs-hadoop"),
       sbtdocker.Instructions.Run("cp /opt/flink/opt/flink-azure-fs-hadoop-1.10.0.jar ./plugins/azure-fs-hadoop/"),
-      sbtdocker.Instructions.Run("chown -R flink:flink ./plugins/azure-fs-hadoop"))
-  )
+      sbtdocker.Instructions.Run("chown -R flink:flink ./plugins/azure-fs-hadoop"),
+      sbtdocker.Instructions.User("cloudflow")))
   ...
 ----
 

--- a/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -164,7 +164,7 @@ In the above example the `runLocalConfigFile` setting is shown to point to a loc
 
 == Azure Blob Storage
 
-Flink supports a number of file systems for reading and writing data and for its state backend. In this section we will look at how to use Microsoft's Azure Blob Storage for these purposes.
+Flink supports several file systems for reading and writing data and for its state backend. In this section, we will look at how to use Microsoft's Azure Blob Storage for these purposes.
 
 Please refer to the Flink documentation here https://ci.apache.org/projects/flink/flink-docs-stable/ops/filesystems/azure.html
 
@@ -172,7 +172,7 @@ To make this work in a Cloudflow context there are a couple of things you need t
 
 === Checkpoints
 
-In the configuration file you need to specify that the `state.backend` is `filesystem`, set `state.checkpoints.dir` to match the the location of your Blob, and provide your access key.
+In the configuration file, you need to specify that the `state.backend` is `filesystem`, set `state.checkpoints.dir` to match the location of your Blob, and provide your access key.
 
 [source,hocon]
 ----
@@ -187,7 +187,7 @@ Whether you are running locally or deploying to a Cloudflow cluster, this part o
 
 ==== Deployment
 
-When your Flink streamlet is deployed it will run in a Docker container which includes a normal Flink installation. In order to use Azure Blob Storage as filesystem we need to enable a plugin `flink-azure-fs-hadoop`. As detailed in the Flink documentation, all plugins need to be copied from the `/opt/` folder into a directory of their own in `/plugins.`.
+When your Flink streamlet is deployed it will run in a Docker container which includes a normal Flink installation. To use Azure Blob Storage as filesystem we need to enable a plugin `flink-azure-fs-hadoop`. As detailed in the Flink documentation, all plugins need to be copied from the `/opt/` folder into a directory of their own in `/plugins.`.
 
 To facilitate this, in your _Streamlet_ `build.sbt` you must add the following instructions to make sure that the plugin is copied to the right place when the container is built.
 
@@ -207,7 +207,7 @@ lazy val yourStreamlet = appModule("yourStreamlet")
 
 ==== Running Locally
 
-Cloudflow does not build containers for running locally, instead it will run Flink embedded in the JVM. In order to make sure the `flink-fs-azure-hadoop.jar` is included in the application you need to explicitly add it to your build file as follows.
+Cloudflow does not build containers when running locally and it will instead embed Flink directly into the sandbox application. To include the `flink-fs-azure-hadoop.jar` you need to explicitly add it to your _Streamlet_ build file as follows.
 
 [source, scala]
 ----

--- a/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -183,31 +183,7 @@ cloudflow.runtimes.flink.config {
 }
 ----
 
-Whether you are running locally or deploying to a Cloudflow cluster, this part of the configuration is the same.
-
-==== Deployment
-
-When your Flink streamlet is deployed it will run in a Docker container which includes a normal Flink installation. To use Azure Blob Storage as filesystem we need to enable a plugin `flink-azure-fs-hadoop`. As detailed in the Flink documentation, all plugins need to be copied from the `/opt/` folder into a directory of their own in `/plugins.`.
-
-To facilitate this, in your _Streamlet_ `build.sbt` you must add the following instructions to make sure that the plugin is copied to the right place when the container is built.
-
-[source, scala]
-----
-lazy val yourStreamlet = appModule("yourStreamlet")
-  .enablePlugins(CloudflowFlinkPlugin)
-  .settings(
-    extraDockerInstructions ++= Seq(
-      sbtdocker.Instructions.User("root"),
-      sbtdocker.Instructions.Run("mkdir -p ./plugins/azure-fs-hadoop"),
-      sbtdocker.Instructions.Run("cp /opt/flink/opt/flink-azure-fs-hadoop-1.10.0.jar ./plugins/azure-fs-hadoop/"),
-      sbtdocker.Instructions.Run("chown -R flink:flink ./plugins/azure-fs-hadoop"),
-      sbtdocker.Instructions.User("cloudflow")))
-  ...
-----
-
-==== Running Locally
-
-Cloudflow does not build containers when running locally and it will instead embed Flink directly into the sandbox application. To include the `flink-fs-azure-hadoop.jar` you need to explicitly add it to your _Streamlet_ build file as follows.
+Flink needs `flink-azure-fs-hadoop` support to be built into your Streamlet in order to be able to use Azure as a filesystem backend. To faciliate this simply add the following library dependency to the `build.sbt`.
 
 [source, scala]
 ----


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add documentation for using Azure Blob storage from Flink (local and deployed to Cloudflow

### Why are the changes needed?

This complements the additional documentation and Flink config fixes that @blublinsky made already

### Does this PR introduce any user-facing change?

No, this is purely a documentation update

### How was this patch tested?

Built locally and checked it
