### PR TITLE
[WIP] Automatically run JFrog Xray Vulnerability Report

### DIFF
--- a/installer/release/.gitignore
+++ b/installer/release/.gitignore
@@ -1,1 +1,2 @@
 bootstrap-install-script-*.sh
+*.pdf

--- a/installer/release/Makefile
+++ b/installer/release/Makefile
@@ -3,6 +3,7 @@ SHELL:=/bin/bash
 include definitions.mk
 
 all: bootstrap-install-script
+.PHONY: image-tags push-images create-report
 
 bootstrap-install-script: bootstrap-install-script-${version}.sh
 
@@ -74,3 +75,16 @@ bootstrap-install-script-${version}.sh: bootstrap-install-script.sh.template clo
 	{ print } \
 	' bootstrap-install-script.sh.template > bootstrap-install-script-${version}.sh
 	chmod +x bootstrap-install-script-${version}.sh
+
+image-tags:
+	echo "${cloudflow_operator_image_name} ${cloudflow_installer_image_tag}"
+	echo "${cloudflow_spark_operator_image_name} ${cloudflow_spark_operator_image_tag}"
+	echo "${cloudflow_flink_operator_image_name} ${cloudflow_flink_operator_image_tag}"
+	echo "${kafka_image_name} ${kafka_image_tag}"
+	echo "${strimzi_operator_image_name} ${strimzi_operator_image_tag}"
+
+push-images:
+	make -f image-tags.mk -s image-tags | xargs -n2 ./scripts/push-image-to-jfrog.sh
+
+create-report: push-images
+	make -f image-tags.mk -s image-tags | ./scripts/generate-jfrog-report-json.sh ${version}

--- a/installer/release/scripts/generate-jfrog-report-json.sh
+++ b/installer/release/scripts/generate-jfrog-report-json.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+CF_VERSION=$1
+
+REPORT_ID=$(awk 'NF { gsub(/\./, "-", $1); print "/"$1"/"$2"/*"}' | jq --raw-input --slurp "{
+  \"name\": \"cloudflow-infra-$CF_VERSION\",
+  \"resources\": {
+    \"repositories\": [
+      {
+        \"name\": \"docker-local\",
+        \"include_path_patterns\": split(\"\n\") | map(select(. != \"\"))
+      }
+    ]
+  }
+}" | curl -s -H "Content-Type: application/json" \
+    -XPOST -d @- \
+    --user ${JFROG_USER}:${JFROG_API_TOKEN} \
+    https://lightbendcloudflow.jfrog.io/xray/api/v1/reports/vulnerabilities | jq .report_id)
+
+
+echo -n "Running report 'cloudflow-infra-$CF_VERSION' ($REPORT_ID)."
+REPORT_STATUS=$(curl -s --user ${JFROG_USER}:${JFROG_API_TOKEN} \
+    https://lightbendcloudflow.jfrog.io/xray/api/v1/reports/${REPORT_ID} | jq .status)
+
+while [ "$REPORT_STATUS" == "pending" ] || [ "$REPORT_STATUS" == "running" ]; do
+    echo -n ".";
+    REPORT_STATUS=$(curl -s --user ${JFROG_USER}:${JFROG_API_TOKEN} \
+        https://lightbendcloudflow.jfrog.io/xray/api/v1/reports/${REPORT_ID} | jq .status);
+    sleep 1;
+done
+echo -e "\nReport completed. Downloading pdf"
+curl --user ${JFROG_USER}:${JFROG_API_TOKEN} \
+    --output cloudflow-infra-$CF_VERSION-vuln-report.zip \
+    "https://lightbendcloudflow.jfrog.io/xray/api/v1/reports/export/${REPORT_ID}?file_name=cloudflow-infra-$CF_VERSION-vuln-report&format=pdf"
+
+unzip cloudflow-infra-$CF_VERSION-vuln-report.zip
+rm cloudflow-infra-$CF_VERSION-vuln-report.zip

--- a/installer/release/scripts/push-image-to-jfrog.sh
+++ b/installer/release/scripts/push-image-to-jfrog.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+TAG=$1
+VERSION=$2
+
+JFROG_TAG=lightbendcloudflow-docker-local.jfrog.io/${TAG//./-}:$VERSION
+
+docker pull $TAG:$VERSION
+docker tag $TAG:$VERSION $JFROG_TAG
+docker push $JFROG_TAG


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a first effort at automating JFrog Xray vulnerability reporting on a subset of the docker images for a Cloudflow deployment. Raising at this point to get some feedback on the approach, to see if it's viable before improving and exploring how to include the full range of relevant images. This approach is using make only to leverage the existing image/version definitions, and it could be refactored and moved elsewhere.
I've attached a sample of the PDF output, which can also be seen directly in the JFrog console: https://lightbendcloudflow.jfrog.io/ui/reports
[cloudflow-infra-2.0.9-vuln-report.pdf](https://github.com/lightbend/cloudflow/files/5167584/cloudflow-infra-2.0.9-vuln-report.pdf)


### Why are the changes needed?
Intended to streamline the process of reporting on vulnerabilities.

### Does this PR introduce any user-facing change?
No, intended only to be part of manual release and/or CI/CD processes

### How was this patch tested?
Only locally so far
