### PR TITLE
adding page for storage, fixing broken links and showing hidden prerequisites

### DIFF
--- a/docs/docs-source/docs/modules/ROOT/nav.adoc
+++ b/docs/docs-source/docs/modules/ROOT/nav.adoc
@@ -60,6 +60,7 @@ include::partial$include.adoc[]
 ** xref:administration:how-to-install-and-use-strimzi.adoc[Installing Kafka with Strimzi]
 ** xref:administration:installing-spark-operator.adoc[Adding Spark Support]
 ** xref:administration:installing-flink-operator.adoc[Adding Flink Support]
+** xref:administration:storage-requirements.adoc[Storage Requirements]
 ** xref:administration:upgrading-cloudflow.adoc[Upgrading Cloudflow]
 ** xref:administration:providing-external-access-to-cloudflow-services.adoc[Setting up external access]
 

--- a/docs/docs-source/docs/modules/ROOT/nav.adoc
+++ b/docs/docs-source/docs/modules/ROOT/nav.adoc
@@ -55,12 +55,12 @@ include::partial$include.adoc[]
 ** xref:cli:cloudflow_version.adoc[version]
 
 * xref:administration:index.adoc[Cloudflow administration]
-
+** xref:administration:installation-prerequisites.adoc[Installation Prerequisites]
 ** xref:administration:installing-cloudflow.adoc[Installing Cloudflow]
 ** xref:administration:how-to-install-and-use-strimzi.adoc[Installing Kafka with Strimzi]
 ** xref:administration:installing-spark-operator.adoc[Adding Spark Support]
 ** xref:administration:installing-flink-operator.adoc[Adding Flink Support]
-** xref:administration:storage-requirements.adoc[Storage Requirements]
+** xref:administration:installing-enterprise.adoc[Installing Cloudflow Enterprise components]
 ** xref:administration:upgrading-cloudflow.adoc[Upgrading Cloudflow]
 ** xref:administration:providing-external-access-to-cloudflow-services.adoc[Setting up external access]
 
@@ -68,4 +68,3 @@ include::partial$include.adoc[]
 ** xref:project-info:migration-1_3-2_0.adoc[Migration Guide 1.3.x to 2.0.x]
 
 * xref:api:index.adoc[Streamlet API Reference]
-

--- a/docs/docs-source/docs/modules/administration/pages/installation-prerequisites.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installation-prerequisites.adoc
@@ -74,7 +74,7 @@ standard (default)   kubernetes.io/gce-pd   2m57s
 
 NOTE: When installing Cloudflow, we will use the name `nfs` to indicate that Cloudflow should use the NFS storage class.
 
-NOTE:: The NFS storage class documented on is very portable and has been verified to work on GKE, EKS, AKS and Openshift.
+NOTE:: The documented NFS storage class is very portable and has been verified to work on GKE, EKS, AKS and Openshift.
 
 == More Storage Options
 

--- a/docs/docs-source/docs/modules/administration/pages/installation-prerequisites.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installation-prerequisites.adoc
@@ -74,6 +74,12 @@ standard (default)   kubernetes.io/gce-pd   2m57s
 
 NOTE: When installing Cloudflow, we will use the name `nfs` to indicate that Cloudflow should use the NFS storage class.
 
+NOTE:: The NFS storage class documented on is very portable and has been verified to work on GKE, EKS, AKS and Openshift.
+
+== More Storage Options
+
+Continue with xref:more-storage-options.adoc[]
+
 == Next: Installing Cloudflow
 
 Continue with xref:installing-cloudflow.adoc[]

--- a/docs/docs-source/docs/modules/administration/pages/installing-cloudflow.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-cloudflow.adoc
@@ -25,7 +25,7 @@ First, we add the Cloudflow Helm repository and update the local index:
 
 === Installing (with support for Spark or Flink)
 
-For use with Spark or Flink, the `persistentStorageClass` parameter sets the storage class to `nfs`. This storage class, as mentioned in xref:storage-requirements.adoc[], has to be of the type `ReadWriteMany`. In our example, we are using the `nfs` storage class.
+For use with Spark or Flink, the `persistentStorageClass` parameter sets the storage class to `nfs`. This storage class, as mentioned in xref:installation-prerequisites.adoc[], has to be of the type `ReadWriteMany`. In our example, we are using the `nfs` storage class.
 
   cloudflow_operator.persistentStorageClass=nfs
 

--- a/docs/docs-source/docs/modules/administration/pages/installing-cloudflow.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-cloudflow.adoc
@@ -25,7 +25,7 @@ First, we add the Cloudflow Helm repository and update the local index:
 
 === Installing (with support for Spark or Flink)
 
-For use with Spark or Flink, the `persistentStorageClass` parameter sets the storage class to `nfs`. This storage class, as mentioned in <<_storage_requirements>>, has to be of the type `ReadWriteMany`. In our example, we are using the `nfs` storage class.
+For use with Spark or Flink, the `persistentStorageClass` parameter sets the storage class to `nfs`. This storage class, as mentioned in xref:storage-requirements.adoc[], has to be of the type `ReadWriteMany`. In our example, we are using the `nfs` storage class.
 
   cloudflow_operator.persistentStorageClass=nfs
 

--- a/docs/docs-source/docs/modules/administration/pages/installing-enterprise.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-enterprise.adoc
@@ -56,4 +56,4 @@ This opens the Lightbend Console in your browser.
 
 == Upgrading Cloudflow
 
-If you need to upgrade Cloudflow to a newer version, xref:upgrading-cloudflow.adoc[upgrading Cloudflow] in the administration section will show you how.
+If you need to upgrade Cloudflow to a newer version, xref:upgrading-cloudflow.adoc[] in the administration section will show you how.

--- a/docs/docs-source/docs/modules/administration/pages/installing-flink-operator.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-flink-operator.adoc
@@ -29,7 +29,3 @@ cloudflow-patch-spark-mutatingwebhookconfig-66xxb   0/1     Completed   0       
 spark-operator-sparkoperator-56d6ffc8cd-cln67       1/1     Running     0          2m29s
 flink-operator-7999fdd879-phqlg                     1/1     Running     0          1m29s
 ----
-
-== Next: Storage Requirements
-
-Continue with xref:storage-requirements.adoc[]

--- a/docs/docs-source/docs/modules/administration/pages/installing-flink-operator.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-flink-operator.adoc
@@ -30,6 +30,6 @@ spark-operator-sparkoperator-56d6ffc8cd-cln67       1/1     Running     0       
 flink-operator-7999fdd879-phqlg                     1/1     Running     0          1m29s
 ----
 
-== Next: Installing Enterprise components
+== Next: Storage Requirements
 
-Continue with xref:installing-enterprise.adoc[]
+Continue with xref:storage-requirements.adoc[]

--- a/docs/docs-source/docs/modules/administration/pages/installing-spark-operator.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-spark-operator.adoc
@@ -170,7 +170,3 @@ spark-operator-sparkoperator-56d6ffc8cd-cln67       1/1     Running     0       
 If you plan to write applications that utilize Flink you will need to install the Flink operator before deploying your Cloudflow application.
 
 Continue with xref:installing-flink-operator.adoc[Adding Flink Support].
-
-== Next: Storage requirements 
-
-Continue with xref:storage-requirements.adoc[]

--- a/docs/docs-source/docs/modules/administration/pages/installing-spark-operator.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-spark-operator.adoc
@@ -171,6 +171,6 @@ If you plan to write applications that utilize Flink you will need to install th
 
 Continue with xref:installing-flink-operator.adoc[Adding Flink Support].
 
-== Next: Installing Enterprise components
+== Next: Storage requirements 
 
-Continue with xref:installing-enterprise.adoc[]
+Continue with xref:storage-requirements.adoc[]

--- a/docs/docs-source/docs/modules/administration/pages/more-storage-options.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/more-storage-options.adoc
@@ -1,0 +1,88 @@
+= More Storage Options
+:toc:
+:toc-title: ON THIS PAGE
+:toclevels: 2
+
+
+include::ROOT:partial$include.adoc[]
+
+
+== Verified storage and example configuration
+
+The following tabs describe the storage classes that Lightbend has verified and tested on Azure Kubernetes Service (AKS), Amazon Elastic Kubernetes Service (EKS) and RedHat OpenShift (3.11). They include examples of the required `.yaml` file that should be used to update the Kubernetes cluster. There's no need to set the namespace when updating the cluster. 
+
+
+[.tabset]
+AKS::
++
+--
+
+The `AzureFile` storage class supports `ReadWriteMany` access mode and is verified to work with Cloudflow on Azure Kubernetes Service (AKS).
+
+NOTE: An important thing to note here is that the `uid` and `gid` mount options should be configured to match those used by the Cloudflow application pods, e.g. they should both have the value `185`. If this is misconfigured it will lead to application runtime errors when Spark and/or Flink are not permitted to write their intermediate state to disk.
+
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: azurefile
+provisioner: kubernetes.io/azure-file
+mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=185
+    - gid=185
+    - mfsymlinks
+    - nobrl
+    - cache=none
+parameters:
+  skuName: Standard_LRS
+----
+
+For more information about configuring AzureFile, please read https://docs.microsoft.com/bs-cyrl-ba/azure/aks/azure-files-dynamic-pv[its documentation].
+
+--
+EKS::
++
+--
+
+Amazon Elastic File System (EFS) supports the `ReadWriteMany` access mode and is verified working with Cloudflow on Amazon Elastic Kubernetes Service (EKS).
+
+For more information about configuring Amazon Elastic File System, please read https://www.eksworkshop.com/beginner/190_efs/efs-provisioner/[its dcumentation].
+
+NOTE: You must configure the rules as discussed https://docs.aws.amazon.com/efs/latest/ug/accessing-fs-create-security-groups.html[here] in security groups to enable traffic between an EC2 instance of the Kubernetes Cluster and a mount target (and thus the file system). If you do not do this, Cloudflow will not be able to use EFS.
+
+--
+
+Openshift::
++
+--
+
+GlusterFS provisioner supports the `ReadWriteMany` access mode and is verified working with Cloudflow on Redhat Openshift.
+
+The GlusterFS installation will create the following storage class. Note that the name of the storage class has here been set to `glusterfs`, this may be different in your installation.
+
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: glusterfs-storage
+parameters:
+  resturl: http://heketi-storage.glusterfs.svc:8080
+  restuser: admin
+  secretName: heketi-storage-admin-secret
+  secretNamespace: glusterfs
+provisioner: kubernetes.io/glusterfs
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+----
+
+For more information about configuring GlusterFS on Openshift, please read https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/persistent_storage_glusterfs.html[its documentation].
+
+--
+
+== What's next
+
+With this overview of storage, it's time to check xref:installing-cloudflow.adoc[].


### PR DESCRIPTION
# What changes were proposed in this pull request?

adding storage requirements page that it was present in https://developer.lightbend.com/docs/cloudflow/current/install/storage.html

Fix the broken link that aimed to it but should aim to prerequisites

Showing the page that @olofwalker created as prerequisites for Kafka and storage

Fix indentation that was missing in the creation of the AKS storage (it was throwing an error when `apply`)


### Why are the changes needed?
to fix the link


### Does this PR introduce any user-facing change?
yes, the doc


### How was this patch tested?
running `make local-preview`
