### PR TITLE
operator: remove some Strimzi left-over settings

### DIFF
--- a/core/cloudflow-operator/src/main/resources/application.conf
+++ b/core/cloudflow-operator/src/main/resources/application.conf
@@ -22,9 +22,6 @@ cloudflow {
     kafka {
       bootstrap-servers = ${?KAFKA_BOOTSTRAP_SERVERS}
 
-      strimzi-cluster-name = ${?KAFKA_STRIMZI_CLUSTER_NAME}
-      strimzi-topic-operator-namespace = ${?KAFKA_STRIMZI_TOPIC_OPERATOR_NAMESPACE}
-
       partitions-per-topic = 53
       partitions-per-topic = ${?KAFKA_PARTITIONS_PER_TOPIC}
 

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Settings.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Settings.scala
@@ -169,9 +169,7 @@ final case class Settings(config: Config) extends Extension {
   val kafka = KafkaSettings(
     config.as[Option[String]](s"$root.kafka.bootstrap-servers"),
     partitionsPerTopic,
-    replicationFactor,
-    config.as[Option[String]](s"$root.kafka.strimzi-topic-operator-namespace"),
-    config.as[Option[String]](s"$root.kafka.strimzi-cluster-name")
+    replicationFactor
   )
 
   val akkaRunnerSettings        = getAkkaRunnerSettings(config, s"$root.deployment.akka-runner", runner.AkkaRunner.runtime)
@@ -202,13 +200,7 @@ final case class Settings(config: Config) extends Extension {
   }
 }
 
-final case class KafkaSettings(
-    bootstrapServers: Option[String],
-    partitionsPerTopic: Int,
-    replicationFactor: Int,
-    strimziTopicOperatorNamespace: Option[String] = None,
-    strimziClusterName: Option[String] = None
-)
+final case class KafkaSettings(bootstrapServers: Option[String], partitionsPerTopic: Int, replicationFactor: Int)
 
 final case class Resources(request: String, limit: String)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the `strimzi-cluster-name` and `strimzi-topic-operator-namespace` settings which are not used anymore.