### PR TITLE
operator: separate Flink and Spark storage settings

### DIFF
--- a/core/cloudflow-operator/src/main/resources/application.conf
+++ b/core/cloudflow-operator/src/main/resources/application.conf
@@ -109,6 +109,8 @@ cloudflow {
         # Do not specify max heap, this is calculated by memory-overhead
         java-opts = ""
         java-opts = ${?SPARK_EXECUTOR_JAVA_OPTS}
+
+        persistent-storage = ${cloudflow.platform.deployment.persistent-storage}
       }
 
       flink-runner {
@@ -160,6 +162,8 @@ cloudflow {
           java-opts = ""
           java-opts = ${?FLINK_TASKMANAGER_JAVA_OPTS}
         }
+
+        persistent-storage = ${cloudflow.platform.deployment.persistent-storage}
       }
 
       persistent-storage {

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/DeploymentContext.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/DeploymentContext.scala
@@ -29,15 +29,13 @@ case class DeploymentContext(kafkaContext: KafkaContext,
                              akkaRunnerSettings: AkkaRunnerSettings,
                              sparkRunnerSettings: SparkRunnerSettings,
                              flinkRunnerSettings: FlinkRunnerSettings,
-                             persistentStorageSettings: PersistentStorageSettings,
                              podName: String,
                              podNamespace: String) {
-  import kafkaContext._
   def infoMessage = s"""
    | pod-name:                         ${podName}
    | pod-namespace                     ${podNamespace}
    |
-   | kafka-bootstrap-servers:          ${bootstrapServers}
+   | kafka-bootstrap-servers:          ${kafkaContext.bootstrapServers}
   """
 }
 
@@ -87,6 +85,7 @@ final case class SparkPodSettings(
 final case class SparkRunnerSettings(
     driverSettings: SparkPodSettings,
     executorSettings: SparkPodSettings,
+    persistentStorageSettings: PersistentStorageSettings,
     prometheusRules: String
 ) extends RunnerSettings
 
@@ -111,5 +110,6 @@ final case class FlinkRunnerSettings(
     parallelism: Int,
     jobManagerSettings: FlinkJobManagerSettings,
     taskManagerSettings: FlinkTaskManagerSettings,
+    persistentStorageSettings: PersistentStorageSettings,
     prometheusRules: String
 ) extends RunnerSettings

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Settings.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Settings.scala
@@ -96,10 +96,9 @@ object Settings extends ExtensionId[Settings] with ExtensionIdProvider {
     val driverPath   = s"$root.deployment.spark-runner-driver"
     val executorPath = s"$root.deployment.spark-runner-executor"
 
-    val driverConfig   = config.getConfig(driverPath)
-    val executorConfig = config.getConfig(executorPath)
-    // TODO correct path
-    val persistentStorageSettings = config.as[PersistentStorageSettings](s"$root.deployment.persistent-storage")
+    val driverConfig              = config.getConfig(driverPath)
+    val executorConfig            = config.getConfig(executorPath)
+    val persistentStorageSettings = executorConfig.as[PersistentStorageSettings]("persistent-storage")
 
     SparkRunnerSettings(
       getSparkPodSettings(driverConfig),
@@ -112,11 +111,10 @@ object Settings extends ExtensionId[Settings] with ExtensionIdProvider {
   private def getFlinkRunnerSettings(config: Config, root: String, runnerStr: String): FlinkRunnerSettings = {
     val flinkRunnerConfig = config.getConfig(s"$root.deployment.flink-runner")
 
-    val jobManagerConfig  = flinkRunnerConfig.getConfig("jobmanager")
-    val taskManagerConfig = flinkRunnerConfig.getConfig("taskmanager")
-    val parallelism       = flinkRunnerConfig.as[Int]("parallelism")
-    // TODO correct path
-    val persistentStorageSettings = config.as[PersistentStorageSettings](s"$root.deployment.persistent-storage")
+    val jobManagerConfig          = flinkRunnerConfig.getConfig("jobmanager")
+    val taskManagerConfig         = flinkRunnerConfig.getConfig("taskmanager")
+    val parallelism               = flinkRunnerConfig.as[Int]("parallelism")
+    val persistentStorageSettings = flinkRunnerConfig.as[PersistentStorageSettings]("persistent-storage")
 
     FlinkRunnerSettings(
       parallelism,

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Settings.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Settings.scala
@@ -98,10 +98,13 @@ object Settings extends ExtensionId[Settings] with ExtensionIdProvider {
 
     val driverConfig   = config.getConfig(driverPath)
     val executorConfig = config.getConfig(executorPath)
+    // TODO correct path
+    val persistentStorageSettings = config.as[PersistentStorageSettings](s"$root.deployment.persistent-storage")
 
     SparkRunnerSettings(
       getSparkPodSettings(driverConfig),
       getSparkPodSettings(executorConfig),
+      persistentStorageSettings,
       getPrometheusRules(runnerStr)
     )
   }
@@ -112,11 +115,14 @@ object Settings extends ExtensionId[Settings] with ExtensionIdProvider {
     val jobManagerConfig  = flinkRunnerConfig.getConfig("jobmanager")
     val taskManagerConfig = flinkRunnerConfig.getConfig("taskmanager")
     val parallelism       = flinkRunnerConfig.as[Int]("parallelism")
+    // TODO correct path
+    val persistentStorageSettings = config.as[PersistentStorageSettings](s"$root.deployment.persistent-storage")
 
     FlinkRunnerSettings(
       parallelism,
       FlinkJobManagerSettings(jobManagerConfig.as[Int]("replicas"), getFlinkPodResourceSettings(jobManagerConfig)),
       FlinkTaskManagerSettings(taskManagerConfig.as[Int]("task-slots"), getFlinkPodResourceSettings(taskManagerConfig)),
+      persistentStorageSettings,
       getPrometheusRules(runnerStr)
     )
   }
@@ -172,10 +178,9 @@ final case class Settings(config: Config) extends Extension {
     replicationFactor
   )
 
-  val akkaRunnerSettings        = getAkkaRunnerSettings(config, s"$root.deployment.akka-runner", runner.AkkaRunner.runtime)
-  val sparkRunnerSettings       = getSparkRunnerSettings(config, root, runner.SparkRunner.runtime)
-  val flinkRunnerSettings       = getFlinkRunnerSettings(config, root, runner.FlinkRunner.runtime)
-  val persistentStorageSettings = config.as[PersistentStorageSettings](s"$root.deployment.persistent-storage")
+  val akkaRunnerSettings  = getAkkaRunnerSettings(config, s"$root.deployment.akka-runner", runner.AkkaRunner.runtime)
+  val sparkRunnerSettings = getSparkRunnerSettings(config, root, runner.SparkRunner.runtime)
+  val flinkRunnerSettings = getFlinkRunnerSettings(config, root, runner.FlinkRunner.runtime)
 
   val api = ApiSettings(
     getNonEmptyString(config, s"$root.api.bind-interface"),
@@ -193,7 +198,6 @@ final case class Settings(config: Config) extends Extension {
       akkaRunnerSettings,
       sparkRunnerSettings,
       flinkRunnerSettings,
-      persistentStorageSettings,
       podName,
       podNamespace
     )

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/FlinkRunner.scala
@@ -111,7 +111,11 @@ object FlinkRunner extends Runner[CR] {
                                        ownerReferences: List[OwnerReference])(
       implicit ctx: DeploymentContext
   ): Seq[Action[ObjectResource]] =
-    Vector(CreatePersistentVolumeClaimAction(persistentVolumeClaim(app.spec.appId, namespace, labels, ownerReferences)))
+    Vector(
+      CreatePersistentVolumeClaimAction(
+        persistentVolumeClaim(app.spec.appId, namespace, labels, ctx.flinkRunnerSettings.persistentStorageSettings, ownerReferences)
+      )
+    )
 
   def resource(
       deployment: StreamletDeployment,

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/Runner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/Runner.scala
@@ -110,7 +110,11 @@ trait Runner[T <: ObjectResource] {
   def serviceAccountAction(namespace: String, labels: CloudflowLabels, ownerReferences: List[OwnerReference]): Seq[Action[ObjectResource]] =
     Vector(Action.createOrUpdate(roleBinding(namespace, labels, ownerReferences), roleBindingEditor))
 
-  def persistentVolumeClaim(appId: String, namespace: String, labels: CloudflowLabels, ownerReferences: List[OwnerReference])(
+  def persistentVolumeClaim(appId: String,
+                            namespace: String,
+                            labels: CloudflowLabels,
+                            persistentStorageSettings: PersistentStorageSettings,
+                            ownerReferences: List[OwnerReference])(
       implicit ctx: DeploymentContext
   ): PersistentVolumeClaim = {
     val metadata = ObjectMeta(
@@ -125,11 +129,11 @@ trait Runner[T <: ObjectResource] {
       volumeMode = Some(VolumeMode.Filesystem),
       resources = Some(
         Resource.Requirements(
-          limits = Map(Resource.storage   -> ctx.persistentStorageSettings.resources.limit),
-          requests = Map(Resource.storage -> ctx.persistentStorageSettings.resources.request)
+          limits = Map(Resource.storage   -> persistentStorageSettings.resources.limit),
+          requests = Map(Resource.storage -> persistentStorageSettings.resources.request)
         )
       ),
-      storageClassName = Some(ctx.persistentStorageSettings.storageClassName),
+      storageClassName = Some(persistentStorageSettings.storageClassName),
       selector = None
     )
     PersistentVolumeClaim(metadata = metadata, spec = Some(pvcSpec), status = None)

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/SparkRunner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/runner/SparkRunner.scala
@@ -126,7 +126,11 @@ object SparkRunner extends Runner[CR] with PatchProvider[SpecPatch] {
                                        ownerReferences: List[OwnerReference])(
       implicit ctx: DeploymentContext
   ): Seq[Action[ObjectResource]] =
-    Vector(CreatePersistentVolumeClaimAction(persistentVolumeClaim(app.spec.appId, namespace, labels, ownerReferences)))
+    Vector(
+      CreatePersistentVolumeClaimAction(
+        persistentVolumeClaim(app.spec.appId, namespace, labels, ctx.sparkRunnerSettings.persistentStorageSettings, ownerReferences)
+      )
+    )
 
   def resource(
       deployment: StreamletDeployment,

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/TestDeploymentContext.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/TestDeploymentContext.scala
@@ -53,6 +53,10 @@ trait TestDeploymentContext {
           memoryOverhead = Some("1024m"),
           javaOptions = Some("-Xmx1024")
         ),
+        PersistentStorageSettings(
+          resources = Resources("1G", "2G"),
+          storageClassName = "storage"
+        ),
         "(prometheus rules)"
       ),
       flinkRunnerSettings = FlinkRunnerSettings(
@@ -71,11 +75,11 @@ trait TestDeploymentContext {
                                                          cpuLimit = Some("1"),
                                                          memoryLimit = Some("1024m")
                                                        )),
+        PersistentStorageSettings(
+          resources = Resources("1G", "2G"),
+          storageClassName = "storage"
+        ),
         "(prometheus rules)"
-      ),
-      PersistentStorageSettings(
-        resources = Resources("1G", "2G"),
-        storageClassName = "storage"
       ),
       podName = "cloudflow-operator",
       podNamespace = "cloudflow"

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/runner/FlinkRunnerSpec.scala
@@ -277,6 +277,7 @@ class FlinkRunnerSpec extends WordSpecLike with OptionValues with MustMatchers w
           2,
           jobManagerSettings = FlinkJobManagerSettings(1, FlinkPodResourceSettings()),
           taskManagerSettings = FlinkTaskManagerSettings(2, FlinkPodResourceSettings()),
+          persistentStorageSettings = PersistentStorageSettings(cloudflow.operator.Resources("15G", "30G"), storageClassName = "nfs"),
           prometheusRules = "sample rules"
         )
       )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make the default storage claim settings for Flink and Spark independent of each other.

### Why are the changes needed?

The storage claims need to become easier adjustable per application.
