### PR TITLE
Enable HTTP2 by default

### DIFF
--- a/core/cloudflow-akka/src/main/resources/akka.conf
+++ b/core/cloudflow-akka/src/main/resources/akka.conf
@@ -1,0 +1,8 @@
+# Akka settings that have a different upstream (reference.conf) default, but are overridden by
+# default on Cloudflow (both locally and on k8s).
+# These new defaults can still be overridden in the streamlet-specific configuration.
+akka {
+  http {
+    server.preview.enable-http2 = on
+  }
+}

--- a/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/src/main/resources/application.conf
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/src/main/resources/application.conf
@@ -1,1 +1,0 @@
-akka.http.server.preview.enable-http2 = on

--- a/examples/snippets/modules/ROOT/examples/akkastreams-grpc-scala/src/main/resources/application.conf
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-grpc-scala/src/main/resources/application.conf
@@ -1,1 +1,0 @@
-akka.http.server.preview.enable-http2 = on


### PR DESCRIPTION
Refs #666

### What changes were proposed in this pull request?

This PR enabled HTTP2 by default by introducing an `akka.conf` with takes precedence over the `reference.conf`, but can be overridden by streamlet-specific configuration.

### Why are the changes needed?

This makes it easier to run gRPC services, since those needs HTTP2, and with this change HTTP2 is enabled by default.

### Does this PR introduce any user-facing change?

Any Akka HTTP endpoint in an Akka Streams-streamlet will now have HTTP2 enabled (alongside HTTP/1.1).

### How was this patch tested?

Running the `akkastreams-grpc-scala` example locally