### PR TITLE
Add (non-scalapb) javadsl for protobuf inlet/outlet

### DIFF
--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/proto/javadsl/ProtoCodec.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/proto/javadsl/ProtoCodec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.streamlets.proto.javadsl
+
+import cloudflow.streamlets._
+import com.google.protobuf.GeneratedMessageV3
+import scalapb.{ GeneratedMessage, GeneratedMessageCompanion }
+
+class ProtoCodec[T <: GeneratedMessageV3](clazz: Class[T]) extends Codec[T] {
+  val parser = clazz.getMethod("parseFrom", classOf[Array[Byte]])
+
+  def encode(value: T): Array[Byte] = value.toByteArray
+  def decode(bytes: Array[Byte]): T =
+    parser.invoke(clazz, bytes).asInstanceOf[T]
+}

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/proto/javadsl/ProtoInlet.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/proto/javadsl/ProtoInlet.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.streamlets.proto.javadsl
+
+import cloudflow.streamlets._
+import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.{ GeneratedMessageV3, TextFormat }
+
+final case class ProtoInlet[T <: GeneratedMessageV3](name: String, clazz: Class[T], hasUniqueGroupId: Boolean = false)
+    extends CodecInlet[T] {
+  // We know we can do this because of 'GeneratedMessageV3'
+  val descriptor = clazz.getMethod("getDescriptor").invoke(null).asInstanceOf[Descriptor]
+
+  val codec            = new ProtoCodec[T](clazz)
+  def schemaAsString   = TextFormat.printToUnicodeString(descriptor.toProto)
+  def schemaDefinition = ProtoUtil.createSchemaDefinition(descriptor)
+
+  def withUniqueGroupId: ProtoInlet[T] = if (hasUniqueGroupId) this else copy(hasUniqueGroupId = true)
+}

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/proto/javadsl/ProtoOutlet.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/proto/javadsl/ProtoOutlet.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.streamlets.proto.javadsl
+
+import cloudflow.streamlets._
+import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.{ GeneratedMessageV3, TextFormat }
+
+final case class ProtoOutlet[T <: GeneratedMessageV3](
+    name: String,
+    partitioner: T ⇒ String,
+    clazz: Class[T]
+) extends CodecOutlet[T] {
+  // We know we can do this because of 'GeneratedMessageV3'
+  val descriptor               = clazz.getMethod("getDescriptor").invoke(null).asInstanceOf[Descriptor]
+
+  override def codec: Codec[T] = new ProtoCodec(clazz)
+  override def schemaAsString           = TextFormat.printToUnicodeString(descriptor.toProto)
+  override def schemaDefinition         = ProtoUtil.createSchemaDefinition(descriptor)
+
+  /**
+   * Returns a CodecOutlet with the partitioner set.
+   */
+  override def withPartitioner(partitioner: T ⇒ String): ProtoOutlet[T] = copy(partitioner = partitioner)
+}

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/proto/javadsl/ProtoOutlet.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/proto/javadsl/ProtoOutlet.scala
@@ -26,11 +26,11 @@ final case class ProtoOutlet[T <: GeneratedMessageV3](
     clazz: Class[T]
 ) extends CodecOutlet[T] {
   // We know we can do this because of 'GeneratedMessageV3'
-  val descriptor               = clazz.getMethod("getDescriptor").invoke(null).asInstanceOf[Descriptor]
+  val descriptor = clazz.getMethod("getDescriptor").invoke(null).asInstanceOf[Descriptor]
 
-  override def codec: Codec[T] = new ProtoCodec(clazz)
-  override def schemaAsString           = TextFormat.printToUnicodeString(descriptor.toProto)
-  override def schemaDefinition         = ProtoUtil.createSchemaDefinition(descriptor)
+  override def codec: Codec[T]  = new ProtoCodec(clazz)
+  override def schemaAsString   = TextFormat.printToUnicodeString(descriptor.toProto)
+  override def schemaDefinition = ProtoUtil.createSchemaDefinition(descriptor)
 
   /**
    * Returns a CodecOutlet with the partitioner set.

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/proto/javadsl/ProtoUtil.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/proto/javadsl/ProtoUtil.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.streamlets.proto.javadsl
+
+import java.security.MessageDigest
+import java.util.Base64
+
+import cloudflow.streamlets.SchemaDefinition
+import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.TextFormat
+
+object ProtoUtil {
+  val Format = "proto"
+
+  def createSchemaDefinition(descriptor: Descriptor) = SchemaDefinition(
+    name = descriptor.getFullName,
+    schema = TextFormat.printToUnicodeString(descriptor.toProto),
+    fingerprint = fingerprintSha256(descriptor),
+    format = Format
+  )
+
+  private def fingerprintSha256(descriptor: Descriptor): String =
+    Base64
+      .getEncoder()
+      .encodeToString(MessageDigest.getInstance("SHA-256").digest(TextFormat.printToUnicodeString(descriptor.toProto).getBytes("UTF-8")))
+}

--- a/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/src/main/blueprint/blueprint.conf
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/src/main/blueprint/blueprint.conf
@@ -1,5 +1,12 @@
 blueprint {
   streamlets {
     grpc-ingress = sensordata.SensorDataIngress
+    logger = sensordata.Logger
+  }
+  topics {
+    sensor-data {
+      producers = [grpc-ingress.out]
+      consumers = [logger.in]
+    }
   }
 }

--- a/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/src/main/java/sensordata/Logger.java
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/src/main/java/sensordata/Logger.java
@@ -1,0 +1,40 @@
+package sensordata;
+
+import akka.stream.javadsl.RunnableGraph;
+
+import cloudflow.akkastream.AkkaStreamlet;
+import cloudflow.akkastream.AkkaStreamletLogic;
+import cloudflow.akkastream.javadsl.RunnableGraphStreamletLogic;
+import cloudflow.streamlets.StreamletShape;
+import cloudflow.streamlets.proto.javadsl.ProtoInlet;
+
+import sensordata.grpc.SensorData;
+
+public class Logger extends AkkaStreamlet {
+    private final ProtoInlet<SensorData> inlet = new ProtoInlet<SensorData>(
+            "in",
+            SensorData.class,
+            true
+    );
+
+    @Override
+    public StreamletShape shape() {
+        return StreamletShape.createWithInlets(inlet);
+    }
+    @Override
+    public AkkaStreamletLogic createLogic() {
+        return new RunnableGraphStreamletLogic(getContext()) {
+            @Override
+            public RunnableGraph<?> createRunnableGraph() {
+                return getSourceWithCommittableContext(inlet)
+                        .map(d -> {
+                            System.out.println("Saw " + d);
+                            return d;
+                        })
+                        .to(getCommittableSink());
+            }
+        };
+    }
+
+
+}

--- a/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/src/main/java/sensordata/SensorDataIngress.java
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/src/main/java/sensordata/SensorDataIngress.java
@@ -1,15 +1,16 @@
 package sensordata;
 
 import akka.grpc.javadsl.ServerReflection;
-
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
-
 import akka.japi.Function;
+
 import cloudflow.akkastream.*;
 import cloudflow.akkastream.util.javadsl.GrpcServerLogic;
 import cloudflow.streamlets.*;
+import cloudflow.streamlets.proto.javadsl.ProtoOutlet;
 
+import sensordata.grpc.SensorData;
 import sensordata.grpc.SensorDataService;
 import sensordata.grpc.SensorDataServiceHandlerFactory;
 
@@ -17,8 +18,11 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 public class SensorDataIngress extends AkkaServerStreamlet {
+    public final ProtoOutlet<SensorData> out =
+            new ProtoOutlet<SensorData>("out", RoundRobinPartitioner.getInstance(), SensorData.class);
+
     public StreamletShape shape() {
-        return StreamletShape.createEmpty();
+        return StreamletShape.createWithOutlets(out);
     }
 
     //tag::logic[]
@@ -26,7 +30,7 @@ public class SensorDataIngress extends AkkaServerStreamlet {
         return new GrpcServerLogic(this, getContext()) {
             public List<Function<HttpRequest, CompletionStage<HttpResponse>>> handlers() {
                 return List.of(
-                        SensorDataServiceHandlerFactory.partial(new SensorDataServiceImpl(), SensorDataService.name, system()),
+                        SensorDataServiceHandlerFactory.partial(new SensorDataServiceImpl(sinkRef(out)), SensorDataService.name, system()),
                         ServerReflection.create(List.of(SensorDataService.description), system()));
             }
         };

--- a/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/src/main/java/sensordata/SensorDataServiceImpl.java
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/src/main/java/sensordata/SensorDataServiceImpl.java
@@ -1,5 +1,6 @@
 package sensordata;
 
+import cloudflow.akkastream.WritableSinkRef;
 import sensordata.grpc.SensorData;
 import sensordata.grpc.SensorDataService;
 import sensordata.grpc.SensorReply;
@@ -8,8 +9,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public class SensorDataServiceImpl implements SensorDataService {
+    private final WritableSinkRef<SensorData> sinkRef;
+
+    public SensorDataServiceImpl(WritableSinkRef<SensorData> sinkRef) {
+        this.sinkRef = sinkRef;
+    }
+
     @Override
     public CompletionStage<SensorReply> provide(SensorData in) {
-        return CompletableFuture.completedFuture(SensorReply.newBuilder().setMessage("Received " + in.getPayload()).build());
+        return sinkRef.writeJava(in).thenApply(i -> SensorReply.newBuilder().setMessage("Received " + in.getPayload()).build());
     }
 }

--- a/examples/snippets/modules/ROOT/examples/akkastreams-grpc-scala/src/main/scala/Logger.scala
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-grpc-scala/src/main/scala/Logger.scala
@@ -4,7 +4,7 @@ import akka.stream.scaladsl.RunnableGraph
 import cloudflow.akkastream.AkkaStreamlet
 import cloudflow.akkastream.scaladsl.RunnableGraphStreamletLogic
 import cloudflow.streamlets.StreamletShape
-import cloudflow.streamlets.proto.javadsl.ProtoInlet
+import cloudflow.streamlets.proto.ProtoInlet
 import sensordata.grpc.SensorData
 
 class Logger extends AkkaStreamlet {

--- a/examples/snippets/modules/ROOT/examples/akkastreams-grpc-scala/src/main/scala/Logger.scala
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-grpc-scala/src/main/scala/Logger.scala
@@ -4,7 +4,7 @@ import akka.stream.scaladsl.RunnableGraph
 import cloudflow.akkastream.AkkaStreamlet
 import cloudflow.akkastream.scaladsl.RunnableGraphStreamletLogic
 import cloudflow.streamlets.StreamletShape
-import cloudflow.streamlets.proto.ProtoInlet
+import cloudflow.streamlets.proto.javadsl.ProtoInlet
 import sensordata.grpc.SensorData
 
 class Logger extends AkkaStreamlet {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a (non-scalapb) javadsl for protobuf-based in/outlets

### Why are the changes needed?

To provide a nicer API for Java users

### Does this PR introduce any user-facing change?


### How was this patch tested?

Locally with the akkastream-java-grpc example project