### PR TITLE
Update documentation to remove incorrect Flink version

### DIFF
--- a/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -187,5 +187,7 @@ Flink needs `flink-azure-fs-hadoop` support to be built into your Streamlet in o
 
 [source, scala]
 ----
-libraryDependencies += "org.apache.flink" % "flink-azure-fs-hadoop" % "1.11.1"
+libraryDependencies += "org.apache.flink" % "flink-azure-fs-hadoop" % FlinkVersion
 ----
+
+NOTE: Please ensure you replace FlinkVersion with the current version of Flink used by Cloudflow, which you can find in https://github.com/lightbend/cloudflow/blob/01044fba8b4a7a6334bade74e29a780021a3a274/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowFlinkPlugin.scala[CloudflowFlinkPlugin.scala]

--- a/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -187,7 +187,5 @@ Flink needs `flink-azure-fs-hadoop` support to be built into your Streamlet in o
 
 [source, scala]
 ----
-libraryDependencies += "org.apache.flink" % "flink-azure-fs-hadoop" % FlinkVersion
+libraryDependencies += "org.apache.flink" % "flink-azure-fs-hadoop" % cloudflow.sbt.CloudflowFlinkPlugin.FlinkVersion
 ----
-
-NOTE: Please ensure you replace FlinkVersion with the current version of Flink used by Cloudflow, which you can find in https://github.com/lightbend/cloudflow/blob/01044fba8b4a7a6334bade74e29a780021a3a274/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowFlinkPlugin.scala[CloudflowFlinkPlugin.scala]


### PR DESCRIPTION
This removes an incorrect library version from the Flink documentation and replaces it with a future proof way for the user find the Flink version.