### PR TITLE
Patch config labels uppercase

### DIFF
--- a/kubectl-cloudflow/config/config.go
+++ b/kubectl-cloudflow/config/config.go
@@ -343,11 +343,11 @@ func labelHasPrefix(label string) bool {
 
 func validateLabel(name string, prefix string) error {
 	// See https://github.com/kubernetes/kubernetes/issues/71140, IsDNS1123Subdomain and IsDNS1123Label do not allow uppercase letters.
-	labelPattern := regexp.MustCompile(`^[a-z0-9]{1}[a-z0-9\.\_\-]{0,61}[a-z0-9]{1}$`)
+	labelPattern := regexp.MustCompile(`^[a-z0-9A-Z]{1}[a-z0-9\.\_\-]{0,61}[a-z0-9A-Z]{1}$`)
 
 	// TODO a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
-	labelPrefixPattern := regexp.MustCompile(`^[a-z0-9\.]{0,252}[a-z0-9]{0,1}$`)
-	labelSingleCharFormat := regexp.MustCompile(`^[a-z]{1}$`)
+	labelPrefixPattern := regexp.MustCompile(`^[a-z0-9A-Z\.]{0,252}[a-z0-9A-Z]{0,1}$`)
+	labelSingleCharFormat := regexp.MustCompile(`^[a-zA-Z]{1}$`)
 	illegalLabelPrefixPattern := regexp.MustCompile(`^[0-9\-]`)
 	malformedLabelMsg := "label '%s' is malformed. Please review the constraints at https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set"
 

--- a/kubectl-cloudflow/config/config.go
+++ b/kubectl-cloudflow/config/config.go
@@ -362,8 +362,8 @@ func validateLabel(name string, prefix string) error {
 }
 
 func validateLabelValue(labelValue string, label string) error {
-	labelValuePattern := regexp.MustCompile(`^[a-z0-9]{1}[a-z0-9\.\_\-]{0,61}[a-z0-9]{1}$`)
-	labelValueSingleCharFormat := regexp.MustCompile(`^[a-z0-9]{1}$`)
+	labelValuePattern := regexp.MustCompile(`^[a-z0-9A-Z]{1}[a-z0-9A-Z\.\_\-]{0,61}[a-z0-9A-Z]{1}$`)
+	labelValueSingleCharFormat := regexp.MustCompile(`^[a-z0-9A-Z]{1}$`)
 	// check for HOCON error that is not caught by go/akka library
 	if strings.ContainsAny(labelValue, "{") || len(labelValue) == 0 {
 		return fmt.Errorf("label '%s' has a value that can't be parsed: '%s'", label, labelValue)

--- a/kubectl-cloudflow/config/kubernetes_config_test.go
+++ b/kubectl-cloudflow/config/kubernetes_config_test.go
@@ -29,6 +29,26 @@ func Test_validateConfigLabels(t *testing.T) {
 	`)
 	assert.Empty(t, validateConfig(labelConfigSection, spec))
 
+	labelConfigSectionUppercase := newConfig(`
+	cloudflow.streamlets.my-streamlet.kubernetes.pods.pod {
+		labels {
+			key1 = value1
+			key2 = value2
+		} containers.container {
+			resources {
+				requests {
+					cpu = 2
+					memory = "512M"
+				}
+				limits {
+					memory = "1024M"
+				}
+			}
+		}
+	}
+	`)
+	assert.Empty(t, validateConfig(labelConfigSectionUppercase, spec))
+
 	badLabelConfigValueEmpty := newConfig(`
 	cloudflow.runtimes.flink.kubernetes.pods {
 		task-manager {

--- a/kubectl-cloudflow/config/kubernetes_config_test.go
+++ b/kubectl-cloudflow/config/kubernetes_config_test.go
@@ -14,16 +14,6 @@ func Test_validateConfigLabels(t *testing.T) {
 		labels {
 			key1 = value1
 			key2 = value2
-		} containers.container {
-			resources {
-				requests {
-					cpu = 2
-					memory = "512M"
-				}
-				limits {
-					memory = "1024M"
-				}
-			}
 		}
 	}
 	`)
@@ -32,18 +22,8 @@ func Test_validateConfigLabels(t *testing.T) {
 	labelConfigSectionUppercase := newConfig(`
 	cloudflow.streamlets.my-streamlet.kubernetes.pods.pod {
 		labels {
-			key1 = value1
-			key2 = value2
-		} containers.container {
-			resources {
-				requests {
-					cpu = 2
-					memory = "512M"
-				}
-				limits {
-					memory = "1024M"
-				}
-			}
+			key1 = VALUE1 
+			KEY2 = value2
 		}
 	}
 	`)


### PR DESCRIPTION

### What changes were proposed in this pull request?
patch to accept uppercase letters labels


### Why are the changes needed?
Allow add uppercase letters as per kubernetes documentation is allowed


### Does this PR introduce any user-facing change?
yes

### How was this patch tested?
in a unit test on config_test.go
