### PR TITLE
Add link to installer docs

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -1,7 +1,11 @@
 # Cloudflow Installer
+
 ## Introduction
 
-**NOTE** Please use https://github.com/lightbend/cloudflow-helm-charts instead, which supercedes this project. The Cloudflow Installer operator project is going to be removed in the near future.
+The Cloudflow Installer operator is being replaced by [helm charts](https://github.com/lightbend/cloudflow-helm-charts) and is going to be removed in the near future.
+
+After [Starting a Kubernetes Cluster](start-cluster.md), follow the installation
+instructions from the [Cloudflow documentation](https://cloudflow.io/docs/current/administration/index.html).
 
 ### Prerequisite
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Link from the README of the (now deprecated) installer operator to the cloudflow.io documentation for how to use the helm-based installation procedure.

### Why are the changes needed?

This README used to be a starting point for starting a cloudflow project from scratch. This gives people a path to the current procedure.