### PR TITLE
Higher timeout setting for subscription to response entity.

### DIFF
--- a/core/cloudflow-operator/src/main/resources/application.conf
+++ b/core/cloudflow-operator/src/main/resources/application.conf
@@ -180,7 +180,7 @@ akka.http.client.parsing.max-to-strict-bytes = 64m
 akka.http.client.parsing.max-chunk-size = 16m
 akka.http.host-connection-pool.client.parsing.max-content-length = 64m
 akka.http.host-connection-pool.client.parsing.max-to-strict-bytes = 64m
-
+akka.http.host-connection-pool.response-entity-subscription-timeout = 60 seconds
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   loglevel = "DEBUG"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Increase timeout for subscribing to response in the operator.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Some users report:

```
TimeoutException: Response entity was not subscribed after 1 second. Make sure to read the response entity body or call `discardBytes()` on it. 
```
It could be, because of some backpressure (the idea is that flatMapConcat in [WatchSource](https://github.com/doriordan/skuber/blob/b551d675cbe2dd19c56442786d4e0143f64e3048/client/src/main/scala/skuber/api/watch/WatchSource.scala#L68), after doing request could result in some time between request and starting to read from response), or where at times the operator gets less resources in k8s, it just takes a little more time.
This PR sets the timeout to 60s.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- [x] GKE.