### PR TITLE
Fix 'make check-links' in docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -58,9 +58,9 @@ check-links:
 		-v ${ROOT_DIR}:/antora \
 		--rm \
 		--entrypoint /bin/sh \
-		-t ${antora_docker_image}:${antora_docker_image_tag} \
+		-t lightbend/antora-doc:0.1.0 \
 		--cache-dir=./.cache/antora \
-		-c 'find /antora/docs-source -name '*.adoc' -print0 | xargs -0 -n1 asciidoc-link-check -p -c docs-source/asciidoc-link-check-config.json'
+		-c 'find docs/docs-source -name '*.adoc' -print0 | xargs -0 -n1 asciidoc-link-check -p -c docs/docs-source/asciidoc-link-check-config.json'
 
 list-todos: html
 	docker run \

--- a/docs/docs-source/README.adoc
+++ b/docs/docs-source/README.adoc
@@ -27,7 +27,7 @@ That is, the _latest-greatest_ changes that aren't released yet.
 The corresponding URL mapping is: https://cloudflow.io/docs/dev/index.html
 
 Any other version, is addressed by its explicit version number. 
-For example: https://cloudflow.io/docs/v1.3.4/index.html
+For example: https://cloudflow.io/docs/1.3.3/index.html
 
 In general, the versions produced by our documentation process follow the current mapping to names and git branches:
 

--- a/docs/docs-source/asciidoc-link-check-config.json
+++ b/docs/docs-source/asciidoc-link-check-config.json
@@ -12,6 +12,8 @@
         { "pattern": "^https://repo\\.lightbend\\.com" },
         { "pattern": "^https://lightbend\\.bintray\\.com" },
         { "pattern": "^https://bintray\\.com/lightbend" },
-        { "pattern": "^http://maven\\.apache\\.org/SETTINGS/1\\.0\\.0$" }
+        { "pattern": "^http://maven\\.apache\\.org/SETTINGS/1\\.0\\.0$" },
+	{ "pattern": "^https://strimzi.io/charts/$" },
+	{ "pattern": "^http://heketi-storage.glusterfs.svc:8080$" }
     ]
 }

--- a/docs/docs-source/docs/modules/develop/pages/index.adoc
+++ b/docs/docs-source/docs/modules/develop/pages/index.adoc
@@ -1,5 +1,5 @@
 = Developing applications with Cloudflow
-:site.url: https://cloudflow.io/docs
+:site.url: https://cloudflow.io/docs/current
 :toc:
 :toc-title: ON THIS PAGE
 :toclevels: 2


### PR DESCRIPTION
### What changes were proposed in this pull request?

Go back to the custom lightbend docker image, as (unlike the upstream one) that includes the asciidoc-link-check tool

### Why are the changes needed?

To check for dead links in the docs

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

Running 'make check-links' manually