### PR TITLE
deleting secret after it has been checked it has been mounted

### DIFF
--- a/integration-tests/itest/deploy_test.go
+++ b/integration-tests/itest/deploy_test.go
@@ -48,6 +48,8 @@ var swissKnifeApp = cli.App{
 	Name:   "swiss-knife",
 }
 
+var clientset = k8s_secret.InitClient()
+
 var _ = Describe("Application deployment", func() {
 
 	Context("check that there's a cluster available with cloudflow installed", func() {
@@ -167,7 +169,6 @@ var _ = Describe("Application deployment", func() {
 	})
 
 	Context("Application swiss-knife is deployed and running", func() {
-		clientset := k8s_secret.InitClient()
 
 		It("should deploy a secret", func() {
 			_, err := k8s_secret.CreateSecret(SecretResourceFile, swissKnifeApp.Name, clientset)
@@ -353,8 +354,10 @@ var _ = Describe("Application deployment", func() {
 	})
 
 	Context("A deployed application can be undeployed", func() {
-		It("should undeploy the test app", func(done Done) {
-			err := cli.Undeploy(swissKnifeApp)
+		It("should delete test secrets and undeploy the test app", func(done Done) {
+			err := k8s_secret.DeleteSecrets(swissKnifeApp.Name, clientset)
+			Expect(err).NotTo(HaveOccurred())
+			err = cli.Undeploy(swissKnifeApp)
 			Expect(err).NotTo(HaveOccurred())
 			err = cli.PollUntilAppPresenceIs(swissKnifeApp, false)
 			Expect(err).NotTo(HaveOccurred())

--- a/integration-tests/itest/deploy_test.go
+++ b/integration-tests/itest/deploy_test.go
@@ -33,6 +33,7 @@ const (
 	UpdateSparkConfigurationFile   = "./resources/update_spark_config.conf"
 	UpdateMountingSecret           = "./resources/update_mounting_secret.conf"
 	SecretResourceFile             = "./resources/secret.yaml"
+	SecretResourceFileName         = "mysecret"
 	SecretResourceFilePassword     = "1f2d1e2e67df"
 	SecretResourceFileMountingPath = "/tmp/some/password"
 	UpdateSparkConfigOutput        = "locality=[5s]"
@@ -188,6 +189,11 @@ var _ = Describe("Application deployment", func() {
 			Expect(out).To(Equal(SecretResourceFilePassword))
 			close(done)
 		}, LongTimeout)
+
+		It("should delete this secret", func() {
+			err := k8s_secret.Delete(SecretResourceFileName, swissKnifeApp.Name, clientset)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	Context("Kubernetes configuration can be updated using the CLI", func() {

--- a/integration-tests/itest/deploy_test.go
+++ b/integration-tests/itest/deploy_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Application deployment", func() {
 		}, LongTimeout)
 
 		It("should delete this secret", func() {
-			err := k8s_secret.Delete(SecretResourceFileName, swissKnifeApp.Name, clientset)
+			err := k8s_secret.DeleteSecret(SecretResourceFileName, swissKnifeApp.Name, clientset)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/integration-tests/itest/deploy_test.go
+++ b/integration-tests/itest/deploy_test.go
@@ -67,6 +67,10 @@ var _ = Describe("Application deployment", func() {
 			err := ensureAppNotDeployed(swissKnifeApp)
 			Expect(err).NotTo(HaveOccurred())
 		})
+		It("should not have secrets remaining from previous runs of test app", func() {
+			err := k8s_secret.DeleteSecrets(swissKnifeApp.Name, clientset)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	Context("when I deploy an application", func() {

--- a/integration-tests/itest/k8s_secret/k8s_secret.go
+++ b/integration-tests/itest/k8s_secret/k8s_secret.go
@@ -1,12 +1,12 @@
-package k8s_secret 
+package k8s_secret
 
 import (
 	"context"
 	"fmt"
-	"strings"
 	"github.com/ghodss/yaml"
 	"io/ioutil"
-	
+	"strings"
+
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -30,7 +30,7 @@ func InitClient() *kubernetes.Clientset {
 	return clientset
 }
 
-func CreateSecret(path string, namespace string, clientset *kubernetes.Clientset)  (*coreV1.Secret, error) {
+func CreateSecret(path string, namespace string, clientset *kubernetes.Clientset) (*coreV1.Secret, error) {
 
 	secretsClient := clientset.CoreV1().Secrets(namespace)
 
@@ -53,7 +53,13 @@ func CreateSecret(path string, namespace string, clientset *kubernetes.Clientset
 	return secret, err
 }
 
-func ReadMountedSecret(namespace string, clientset *kubernetes.Clientset, podPartialName string, readFilePath string) (string, error){
+func Delete(secretName string, namespace string, clientset *kubernetes.Clientset) error {
+
+	secretsClient := clientset.CoreV1().Secrets(namespace)
+	return secretsClient.Delete(context.TODO(), secretName, metaV1.DeleteOptions{})
+}
+
+func ReadMountedSecret(namespace string, clientset *kubernetes.Clientset, podPartialName string, readFilePath string) (string, error) {
 
 	coreV1Client := clientset.CoreV1()
 	pods, err := coreV1Client.Pods(namespace).List(context.TODO(), metaV1.ListOptions{})
@@ -62,11 +68,11 @@ func ReadMountedSecret(namespace string, clientset *kubernetes.Clientset, podPar
 	}
 
 	for _, pod := range pods.Items {
-		if strings.Contains(pod.Name, podPartialName){
-			cmd := exec.Command("kubectl", "exec", pod.Name, "-n", namespace, "--","cat", readFilePath)
+		if strings.Contains(pod.Name, podPartialName) {
+			cmd := exec.Command("kubectl", "exec", pod.Name, "-n", namespace, "--", "cat", readFilePath)
 			out, err := cmd.CombinedOutput()
 			return string(out), err
 		}
 	}
-	return  "Not matching pods with that file mounted",nil
+	return "Not matching pods with that file mounted", nil
 }

--- a/integration-tests/itest/k8s_secret/k8s_secret.go
+++ b/integration-tests/itest/k8s_secret/k8s_secret.go
@@ -53,7 +53,7 @@ func CreateSecret(path string, namespace string, clientset *kubernetes.Clientset
 	return secret, err
 }
 
-func Delete(secretName string, namespace string, clientset *kubernetes.Clientset) error {
+func DeleteSecret(secretName string, namespace string, clientset *kubernetes.Clientset) error {
 
 	secretsClient := clientset.CoreV1().Secrets(namespace)
 	return secretsClient.Delete(context.TODO(), secretName, metaV1.DeleteOptions{})


### PR DESCRIPTION


### What changes were proposed in this pull request?
delete the secret created to mount secrets in volumes on integration test


### Why are the changes needed?
to be able to run integration tests multiple times, otherwise will raise an error stating the secret "mysecret" already exists


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
running multiple times in a row the integration test
