### PR TITLE
Respond with '200' on the root of gRPC routes

### DIFF
--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/GrpcServerLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/GrpcServerLogic.scala
@@ -23,7 +23,9 @@ import akka.annotation.ApiMayChange
 import akka.japi.Function
 import akka.grpc.javadsl.ServiceHandler
 import akka.http.javadsl.model.{ HttpRequest, HttpResponse }
-import akka.http.javadsl.server.{ Directives, Route }
+import akka.http.javadsl.model.StatusCodes.OK
+import akka.http.javadsl.server.Route
+import akka.http.javadsl.server.Directives._
 import cloudflow.akkastream.{ AkkaStreamletContext, Server }
 
 @ApiMayChange
@@ -33,6 +35,11 @@ abstract class GrpcServerLogic(server: Server, context: AkkaStreamletContext) ex
   override def createRoute(): Route = {
     import scala.collection.JavaConverters._
     val handler = ServiceHandler.concatOrNotFound(handlers().asScala: _*)
-    Directives.handle(request => handler(request))
+
+    concat(
+      pathEndOrSingleSlash(() => complete(OK, "")),
+      handle(request => handler(request))
+    )
+
   }
 }

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/GrpcServerLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/GrpcServerLogic.scala
@@ -16,20 +16,27 @@
 
 package cloudflow.akkastream.util.scaladsl
 
+import scala.collection.immutable
+import scala.concurrent.Future
+
 import akka.annotation.ApiMayChange
 import akka.grpc.scaladsl.ServiceHandler
-
-import scala.collection.immutable
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.server.directives.RouteDirectives
+import akka.http.scaladsl.server.Directives._
 import cloudflow.akkastream.{ AkkaStreamletContext, Server }
-
-import scala.concurrent.Future
 
 @ApiMayChange
 abstract class GrpcServerLogic(server: Server)(implicit context: AkkaStreamletContext) extends HttpServerLogic(server) {
   def handlers(): immutable.Seq[PartialFunction[HttpRequest, Future[HttpResponse]]]
 
-  override def route(): Route = RouteDirectives.handle(ServiceHandler.concatOrNotFound(handlers(): _*))
+  override def route(): Route =
+    concat(
+      pathEndOrSingleSlash {
+        complete(OK, "")
+      },
+      handle(ServiceHandler.concatOrNotFound(handlers(): _*))
+    )
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

For gRPC ingresses, serve an empty '200' on the root path.

### Why are the changes needed?

GKE loadbalancers check for a '200' answer on the root for health checks by
default.

When using the PLAINTEXT_UPGRADE mode of grpc-java (i.e. with an insecure Nginx
ingress), the body must be empty for the 'upgrade' to work.

### How was this patch tested?

Manually on GKE