### PR TITLE
Create endpoints with type NodePort

### DIFF
--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/EndpointActions.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/EndpointActions.scala
@@ -21,12 +21,11 @@ import scala.concurrent._
 import scala.collection.immutable._
 import akka.actor.ActorSystem
 import play.api.libs.json._
-
 import skuber._
 import skuber.api.client._
 import skuber.json.format._
-
 import cloudflow.blueprint.deployment._
+import skuber.Service.Type.NodePort
 
 /**
  * Creates a sequence of resource actions for the endpoint changes
@@ -80,7 +79,7 @@ object EndpointActions {
         labels = labels(Name.ofService(streamletDeploymentName)),
         ownerReferences = ownerReferences
       ),
-      spec = Some(Service.Spec(ports = List(servicePort)))
+      spec = Some(Service.Spec(ports = List(servicePort), _type = NodePort))
     ).withSelector(CloudflowLabels.Name -> Name.ofPod(streamletDeploymentName))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Create endpoint service nodes with type NodePort instead of ClusterIP

### Why are the changes needed?

To allow them to be exposed via gce loadbalancers as well

### How was this patch tested?

Not fully tested yet, first wanted to discuss whether this is a good idea in
theory before validating it in practice ;).