### PR TITLE
[fix] Cloudflow flink subproject compilation

### DIFF
--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContextImpl.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContextImpl.scala
@@ -52,7 +52,7 @@ class FlinkStreamletContextImpl(
           topic.kafkaConsumerProperties
 
     val properties = new ju.Properties()
-    properties.putAll(propsMap.asJava)
+    properties.putAll(propsMap.asJava: ju.Map[_, _])
 
     val consumer = new FlinkKafkaConsumer[Array[Byte]](
       srcTopic,
@@ -87,7 +87,7 @@ class FlinkStreamletContextImpl(
           topic.kafkaProducerProperties
 
     val properties = new ju.Properties()
-    properties.putAll(propsMap.asJava)
+    properties.putAll(propsMap.asJava: ju.Map[_, _])
 
     stream.addSink(
       new FlinkKafkaProducer[Out](


### PR DESCRIPTION
Quick fix for the following compilation errors on a clean build(keeping all to default) :

```
[error] /Users/andreatp/workspace/cloudflow/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContextImpl.scala:55:16: ambiguous reference to overloaded definition,
[error] both method putAll in class Properties of type (x$1: java.util.Map[_, _])Unit
[error] and  method putAll in class Hashtable of type (x$1: java.util.Map[_ <: Object, _ <: Object])Unit
[error] match argument types (java.util.Map[String,String])
[error]     properties.putAll(propsMap.asJava)
[error]                ^
[error] /Users/andreatp/workspace/cloudflow/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContextImpl.scala:90:16: ambiguous reference to overloaded definition,
[error] both method putAll in class Properties of type (x$1: java.util.Map[_, _])Unit
[error] and  method putAll in class Hashtable of type (x$1: java.util.Map[_ <: Object, _ <: Object])Unit
[error] match argument types (java.util.Map[String,String])
[error]     properties.putAll(propsMap.asJava)
[error]                ^
```