### PR TITLE
Add methods to change Spark session and Flink streaming env from the streamlet.

### DIFF
--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -81,7 +81,9 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
     } yield {
       val updatedConfig = streamletDefinition.config.withFallback(config)
       new FlinkStreamletContextImpl(streamletDefinition,
-                                    updateExecutionEnvironment(createExecutionEnvironment(updatedConfig, streamletDefinition.streamletRef)),
+                                    updateStreamExecutionEnvironment(
+                                      createStreamExecutionEnvironment(updatedConfig, streamletDefinition.streamletRef)
+                                    ),
                                     updatedConfig)
     }).recoverWith {
       case th ⇒ Failure(new Exception(s"Failed to create context from $config", th))
@@ -120,14 +122,14 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
    * Override this method to modify the org.apache.flink.streaming.api.scala.StreamExecutionEnvironment used in this FlinkStreamlet.
    * By default this method does not modify the StreamExecutionEnvironment.
    */
-  def updateExecutionEnvironment(env: StreamExecutionEnvironment): StreamExecutionEnvironment =
+  def updateStreamExecutionEnvironment(env: StreamExecutionEnvironment): StreamExecutionEnvironment =
     env
 
   /**
    * Creates the Flink StreamExecutionEnvironment and by default sets up exactly-once checkpointing.
    * @see [[setupExecutionEnvironment]] to modify the StreamExecutionEnvironment that is created by this method.
    */
-  protected def createExecutionEnvironment(config: Config, streamlet: String): StreamExecutionEnvironment = {
+  protected def createStreamExecutionEnvironment(config: Config, streamlet: String): StreamExecutionEnvironment = {
 
     val localMode     = config.as[Option[Boolean]]("cloudflow.local").getOrElse(false)
     val runtimePath   = ClusterFlinkJobExecutor.flinkRuntime

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -81,7 +81,7 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
     } yield {
       val updatedConfig = streamletDefinition.config.withFallback(config)
       new FlinkStreamletContextImpl(streamletDefinition,
-                                    createExecutionEnvironment(updatedConfig, streamletDefinition.streamletRef),
+                                    updateExecutionEnvironment(createExecutionEnvironment(updatedConfig, streamletDefinition.streamletRef)),
                                     updatedConfig)
     }).recoverWith {
       case th ⇒ Failure(new Exception(s"Failed to create context from $config", th))
@@ -115,6 +115,13 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
     }
     configuration
   }
+
+  /**
+   * Override this method to modify the org.apache.flink.streaming.api.scala.StreamExecutionEnvironment used in this FlinkStreamlet.
+   * By default this method does not modify the StreamExecutionEnvironment.
+   */
+  def updateExecutionEnvironment(env: StreamExecutionEnvironment): StreamExecutionEnvironment =
+    env
 
   /**
    * Creates the Flink StreamExecutionEnvironment and by default sets up exactly-once checkpointing.

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -69,7 +69,7 @@ trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable 
   override protected final def createContext(config: Config): SparkStreamletContext =
     (for {
       streamletConfig ← StreamletDefinition.read(config)
-      session         ← makeSparkSession(makeSparkConfig)
+      session         ← makeSparkSession(makeSparkConfig).map(updateSparkSession)
     } yield {
       val updatedConfig = streamletConfig.config.withFallback(config)
       new kafka.SparkStreamletContextImpl(streamletConfig, session, updatedConfig)
@@ -165,6 +165,13 @@ trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable 
       .set("spark.sql.codegen.wholeStage", "false")
       .set("spark.shuffle.compress", "false")
   }
+
+  /**
+   * Override this method to modify the org.apache.spark.SparkSession used in this SparkStreamlet.
+   * By default this method does not modify the session.
+   */
+  def updateSparkSession(session: SparkSession): SparkSession =
+    session
 
   private def makeSparkSession(sparkConfig: SparkConf): Try[SparkSession] = Try {
     val session = SparkSession


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Added updateSparkSession and updateStreamExecutionEnvironment, so the user can programmatically change respectively how the spark session and flink stream execution environment are set up.
