### PR TITLE
Add MultiOutlet; base Splitter on it

### DIFF
--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/SplitterLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/SplitterLogic.scala
@@ -38,6 +38,7 @@ object Splitter {
    * A Sink that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
+  @deprecated("prefer providing Outlets, this variant can't guarantee at-least-once", "2.10.12")
   def sink[I, L, R](
       flow: FlowWithContext[I, Committable, JEither[L, R], Committable, NotUsed],
       left: Sink[Pair[L, Committable], NotUsed],
@@ -59,6 +60,7 @@ object Splitter {
    * A Sink that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
+  @deprecated("prefer providing Outlets, this variant can't guarantee at-least-once", "2.10.12")
   def sink[I, L, R](
       flow: FlowWithContext[I, Committable, JEither[L, R], Committable, NotUsed],
       leftOutlet: CodecOutlet[L],
@@ -87,7 +89,10 @@ object Splitter {
       rightOutlet: CodecOutlet[R],
       context: AkkaStreamletContext
   ): Sink[Pair[I, Committable], NotUsed] =
-    sink[I, L, R](flow, leftOutlet, rightOutlet, CommitterSettings(context.system), context)
+    akkastream.util.scaladsl.Splitter
+      .sink[I, L, R](flow.via(toEitherFlow).asScala, leftOutlet, rightOutlet, CommitterSettings(context.system))(context)
+      .contramap[Pair[I, Committable]](_.toScala)
+      .asJava
 
   private def toEitherFlow[L, R] =
     FlowWithContext

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/MultiOutlet.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/MultiOutlet.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.akkastream.util.scaladsl
+
+import akka.NotUsed
+import akka.kafka.CommitterSettings
+import akka.kafka.ConsumerMessage.Committable
+import akka.stream.scaladsl.{ Flow, GraphDSL, Sink, Unzip, ZipWith }
+import akka.stream.{ FlowShape, Graph }
+import cloudflow.akkastream.AkkaStreamletContext
+import cloudflow.streamlets.CodecOutlet
+
+import scala.collection.immutable
+
+object MultiOutlet {
+
+  /**
+   * Produce to two outlets and ensure "at-least-once" semantics by committing first after all messages
+   * have been written to the designated outlets.
+   */
+  def sink2[O1, O2](
+      outlet1: CodecOutlet[O1],
+      outlet2: CodecOutlet[O2],
+      committerSettings: CommitterSettings
+  )(implicit context: AkkaStreamletContext): Sink[((immutable.Seq[O1], immutable.Seq[O2]), Committable), NotUsed] =
+    Flow
+      .fromGraph(graph2(context.flexiFlow(outlet1), context.flexiFlow(outlet2)))
+      .to(context.committableSink[Unit](committerSettings))
+
+  /**
+   * Produce to three outlets and ensure "at-least-once" semantics by committing first after all messages
+   * have been written to the designated outlets.
+   */
+  def sink3[O1, O2, O3](
+      outlet1: CodecOutlet[O1],
+      outlet2: CodecOutlet[O2],
+      outlet3: CodecOutlet[O3],
+      committerSettings: CommitterSettings
+  )(implicit context: AkkaStreamletContext): Sink[((immutable.Seq[O1], immutable.Seq[O2], immutable.Seq[O3]), Committable), NotUsed] =
+    Flow
+      .fromGraph(graph3(context.flexiFlow(outlet1), context.flexiFlow(outlet2), context.flexiFlow(outlet3)))
+      .to(context.committableSink[Unit](committerSettings))
+
+  private def graph2[O1, O2](
+      outlet1: Flow[(immutable.Seq[O1], Committable), (_, Committable), _],
+      outlet2: Flow[(immutable.Seq[O2], Committable), (_, Committable), _]
+  ): Graph[akka.stream.FlowShape[((immutable.Seq[O1], immutable.Seq[O2]), Committable), (Unit, Committable)], NotUsed] =
+    GraphDSL.create(outlet1, outlet2)((_, _) => NotUsed) { implicit builder: GraphDSL.Builder[NotUsed] => (o1, o2) =>
+      import GraphDSL.Implicits._
+
+      val spreadOut = builder.add(
+        Flow[((immutable.Seq[O1], immutable.Seq[O2]), Committable)]
+          .map {
+            case ((seq1, seq2), committable) =>
+              ((seq1, committable), (seq2, committable))
+          }
+      )
+      val split = builder.add(Unzip[(immutable.Seq[O1], Committable), (immutable.Seq[O2], Committable)]())
+      val keepCommittable = builder.add(ZipWith[(_, Committable), (_, Committable), (Unit, Committable)]({
+        case ((_, committable), (_, _)) =>
+          ((), committable)
+
+      }))
+
+      // format: OFF
+      spreadOut ~> split.in
+                   split.out0 ~> o1 ~> keepCommittable.in0
+                   split.out1 ~> o2 ~> keepCommittable.in1
+      // format: ON
+      FlowShape(spreadOut.in, keepCommittable.out)
+    }
+
+  private def graph3[O1, O2, O3](
+      outlet1: Flow[(immutable.Seq[O1], Committable), (_, Committable), _],
+      outlet2: Flow[(immutable.Seq[O2], Committable), (_, Committable), _],
+      outlet3: Flow[(immutable.Seq[O3], Committable), (_, Committable), _]
+  ): Graph[akka.stream.FlowShape[((immutable.Seq[O1], immutable.Seq[O2], immutable.Seq[O3]), Committable), (Unit, Committable)], NotUsed] =
+    GraphDSL.create(outlet1, outlet2, outlet3)((_, _, _) => NotUsed) { implicit builder: GraphDSL.Builder[NotUsed] => (o1, o2, o3) =>
+      import GraphDSL.Implicits._
+
+      val spreadOut = builder.add(
+        Flow[((immutable.Seq[O1], immutable.Seq[O2], immutable.Seq[O3]), Committable)]
+          .map {
+            case ((seq1, seq2, seq3), committable) =>
+              ((seq1, committable), ((seq2, committable), (seq3, committable)))
+          }
+      )
+      val split1 =
+        builder.add(Unzip[(immutable.Seq[O1], Committable), ((immutable.Seq[O2], Committable), (immutable.Seq[O3], Committable))]())
+      val split2 = builder.add(Unzip[(immutable.Seq[O2], Committable), (immutable.Seq[O3], Committable)]())
+      val keepCommittable = builder.add(ZipWith[(_, Committable), (_, Committable), (_, Committable), (Unit, Committable)]({
+        case ((_, committable), (_, _), (_, _)) =>
+          ((), committable)
+      }))
+      // format: OFF
+      spreadOut ~> split1.in
+                   split1.out0 ~> o1 ~> keepCommittable.in0
+                   split1.out1 ~> split2.in
+                                  split2.out0 ~> o2 ~> keepCommittable.in1
+                                  split2.out1 ~> o3 ~> keepCommittable.in2
+      // format: ON
+      FlowShape(spreadOut.in, keepCommittable.out)
+    }
+
+}

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -25,6 +25,7 @@ import akka.kafka.CommitterSettings
 import akka.stream.scaladsl._
 import cloudflow.streamlets._
 
+import scala.collection.immutable
 import scala.concurrent.duration.{ DurationInt, FiniteDuration }
 
 /**
@@ -60,6 +61,8 @@ trait AkkaStreamletContext extends StreamletContext {
 
   private[akkastream] def committableSink[T](outlet: CodecOutlet[T], committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed]
   private[akkastream] def committableSink[T](committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed]
+
+  private[akkastream] def flexiFlow[T](outlet: CodecOutlet[T]): Flow[(immutable.Seq[T], Committable), (Unit, Committable), NotUsed]
 
   @deprecated("Use `committableSink` instead.", "1.3.4")
   private[akkastream] def sinkWithOffsetContext[T](outlet: CodecOutlet[T],


### PR DESCRIPTION
### What changes were proposed in this pull request?

The current Akka Streamlet APIs make it impossible to achieve at-least-once processing with multiple outlets.

Users should not use multiple `committableSink`s in a streamlet as later elements might reach the outlet and committing before earlier elements when a stream diverges (eg. with `Partition`).

The existing `Splitter.sink`s may in rare cases backpressure for producing values to one outlet but still produce to the other outlet and commit the offset. If the streamlet/Pod is restarted before the earlier messages have been produced, they will not be reprocessed after the restart. 

### Why are the changes needed?

To make correct committing when producing to multiple outlets easier, this PR introduces the `MultiOutlet.sink`. It accepts a collection per outlet and will commit first after all messages are produced to the outlets.

### Does this PR introduce any user-facing change?

* Deprecate the `Spliter.sink` variant accepting `Sink`s
* Introduce `MultiOutlet.sink2` (and `sink3`) which produce to multiple outlets

Optional
* Introduce `flexiFlow` which produces to an outlet without terminating the stream. (The name stems from Alpakka Kafka, a different name might make more sense in Cloudflow.)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
