### PR TITLE
Fixed Flink filesystem initialization.

### DIFF
--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkKafkaCodecSerde.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkKafkaCodecSerde.scala
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.connectors.kafka._
-import cloudflow.streamlets.{ CodecOutlet, RoundRobinPartitioner }
+import cloudflow.streamlets._
 import org.apache.flink.api.java.typeutils.TypeExtractor
 
 private[flink] class FlinkKafkaCodecSerializationSchema[T: TypeInformation](outlet: CodecOutlet[T], topic: String)

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -140,7 +140,7 @@ abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Seri
       config,
       streamletPath
     )
-    // Ensures that if file syetem back end is used, it is initialized with right configuration
+    // Ensures that if file system back end is used, it is initialized with the right configuration
     if ("filesystem" == configuration.getString(ConfigOptions.key("state.backend").stringType().defaultValue("")))
       FileSystem.initialize(configuration, null)
 

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
@@ -38,7 +38,7 @@ object CloudflowBasePlugin extends AutoPlugin {
   final val DepJarsDir: String               = "dep-jars"
   final val OptAppDir                        = "/opt/cloudflow/"
   final val ScalaVersion                     = "2.12"
-  final val CloudflowVersion                 = BuildInfo.version
+  final val CloudflowVersion                 = "2.0.10"
 
   // NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   // The UID and GID of the `jboss` user is used in different parts of Cloudflow

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
@@ -38,7 +38,7 @@ object CloudflowBasePlugin extends AutoPlugin {
   final val DepJarsDir: String               = "dep-jars"
   final val OptAppDir                        = "/opt/cloudflow/"
   final val ScalaVersion                     = "2.12"
-  final val CloudflowVersion                 = "2.0.10"
+  final val CloudflowVersion                 = BuildInfo.version
 
   // NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   // The UID and GID of the `jboss` user is used in different parts of Cloudflow


### PR DESCRIPTION

### What changes were proposed in this pull request?
<!--
Flink does not always push complete configuration to Filesystem for checkpointing/savepointing creation. To overcome this problem, Filesystem is created by using configuration directly
-->


### Why are the changes needed?
<!--
The change is necessary to correctly process Azure blob checkpointing creation for EY engagement
-->


### Does this PR introduce any user-facing change?
<!--
No
-->


### How was this patch tested?
<!--
It was tested with EY Azure access configuration 
-->
Note, while testing. We tested with negative results, ensuring that execution fails correctly, when Azure account was not available. We also noticed, that due to the nature of the Flink operator, the observed results can be slightly deceiving. The job submission failed (as expected), but the cluster created for the job started and was running fine. The thing to remember here is that the fact of pods running correctly DOES NOT mean that the job is successfully deployed. You can use , for example

kubectl -n taxi-ride-fare describe FlinkApplication taxi-ride-fare-logger

to see the state of job submission