### PR TITLE
Multi out support as non-public API

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,12 +1,12 @@
 # https://github.com/actions/labeler
 name: "Pull Request Labeler"
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@master
+      - uses: actions/labeler@main
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/MultiDataTest.java
+++ b/core/cloudflow-akka-tests/src/test/java/cloudflow/akkastream/MultiDataTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.akkastream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import org.junit.Test;
+import org.scalatestplus.junit.JUnitSuite;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/** Try the Java API to ensure types are sound for Java. */
+public class MultiDataTest extends JUnitSuite {
+
+  @Test
+  public void twoLists() {
+    MultiData2<String, Object> data =
+        MultiData2.create(Arrays.asList("A", "B"), Arrays.asList(456, 323, 32));
+    assertThat(data.getData1().size(), is(2));
+    assertThat(data.data1().size(), is(2));
+    assertThat(data.getData2().size(), is(3));
+    assertThat(data.data2().size(), is(3));
+  }
+
+  @Test
+  public void data1EmptyList() {
+    MultiData2<Object, String> data =
+        MultiData2.create(Collections.emptyList(), Arrays.asList("A", "B"));
+    assertThat(data.data2().size(), is(2));
+  }
+
+  @Test
+  public void data2EmptyList() {
+    MultiData2<String, Object> data =
+        MultiData2.create(Arrays.asList("A", "B"), Collections.emptyList());
+    assertThat(data.data1().size(), is(2));
+  }
+
+  @Test
+  public void data1() {
+    MultiData2<String, Object> data = MultiData2.createData1(Arrays.asList("ET", "TG", "WE"));
+    assertThat(data.data1().size(), is(3));
+    assertThat(data.data2().size(), is(0));
+  }
+
+  @Test
+  public void data2() {
+    MultiData2<Object, String> data = MultiData2.createData2(Arrays.asList("A", "B", "C", "D"));
+    assertThat(data.data1().size(), is(0));
+    assertThat(data.data2().size(), is(4));
+  }
+}

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/SplitterLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/SplitterLogic.scala
@@ -21,10 +21,12 @@ import akka.japi.Pair
 import akka.kafka._
 import akka.stream.javadsl._
 import akka.kafka.ConsumerMessage._
+import akka.stream.scaladsl
 import cloudflow._
 import cloudflow.akkastream._
 import cloudflow.akkastream.javadsl._
-import cloudflow.akkastream.javadsl.util.{ Either ⇒ JEither }
+import cloudflow.akkastream.javadsl.util.{ Either => JEither }
+import cloudflow.akkastream.scaladsl.FlowWithCommittableContext
 import cloudflow.streamlets._
 
 /**
@@ -38,6 +40,7 @@ object Splitter {
    * A Sink that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
+  @deprecated("prefer providing Outlets, this variant can't guarantee at-least-once", "2.10.12")
   def sink[I, L, R](
       flow: FlowWithContext[I, Committable, JEither[L, R], Committable, NotUsed],
       left: Sink[Pair[L, Committable], NotUsed],
@@ -66,15 +69,18 @@ object Splitter {
       committerSettings: CommitterSettings,
       context: AkkaStreamletContext
   ): Sink[Pair[I, Committable], NotUsed] =
-    sink[I, L, R](
-      flow,
-      context.committableSink(leftOutlet, committerSettings).asJava.contramap[Pair[L, Committable]] { pair ⇒
-        (pair.first, pair.second)
-      },
-      context.committableSink(rightOutlet, committerSettings).asJava.contramap[Pair[R, Committable]] { pair ⇒
-        (pair.first, pair.second)
-      }
-    )
+    akka.stream.javadsl.Flow
+      .create[Pair[I, Committable]]()
+      .map(_.toScala)
+      .to(
+        akkastream.util.scaladsl.Splitter
+          .sink[I, L, R](
+            flow.via(toEitherFlow).asScala,
+            leftOutlet,
+            rightOutlet,
+            committerSettings
+          )(context)
+      )
 
   /**
    * Java API

--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/SplitterLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/SplitterLogic.scala
@@ -16,6 +16,8 @@
 
 package cloudflow.akkastream.util.scaladsl
 
+import scala.collection.immutable
+
 import akka._
 import akka.kafka._
 import akka.stream._
@@ -24,6 +26,7 @@ import akka.stream.scaladsl._
 import akka.kafka.ConsumerMessage._
 import cloudflow.streamlets._
 import cloudflow.akkastream._
+import cloudflow.akkastream.internal.MultiProducer
 import cloudflow.akkastream.scaladsl._
 
 /**
@@ -34,6 +37,7 @@ object Splitter {
   /**
    * A Graph that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    */
+  @deprecated("prefer providing Outlets, this variant can't guarantee at-least-once", "2.10.12")
   def graph[I, L, R](
       flow: FlowWithCommittableContext[I, Either[L, R]],
       left: Sink[(L, Committable), NotUsed],
@@ -62,6 +66,7 @@ object Splitter {
    * A Sink that splits elements based on a flow of type `FlowWithCommittableContext[I, Either[L, R]]`.
    * At-least-once semantics are used.
    */
+  @deprecated("prefer providing Outlets, this variant can't guarantee at-least-once", "2.10.12")
   def sink[I, L, R](
       flow: FlowWithCommittableContext[I, Either[L, R]],
       left: Sink[(L, Committable), NotUsed],
@@ -78,7 +83,7 @@ object Splitter {
       rightOutlet: CodecOutlet[R]
   )(implicit context: AkkaStreamletContext): Sink[(I, Committable), NotUsed] = {
     val defaultSettings = CommitterSettings(context.system)
-    sink[I, L, R](flow, context.committableSink(leftOutlet, defaultSettings), context.committableSink(rightOutlet, defaultSettings))
+    sink[I, L, R](flow, leftOutlet, rightOutlet, defaultSettings)
   }
 
   /**
@@ -91,7 +96,10 @@ object Splitter {
       rightOutlet: CodecOutlet[R],
       committerSettings: CommitterSettings
   )(implicit context: AkkaStreamletContext): Sink[(I, Committable), NotUsed] =
-    sink[I, L, R](flow, context.committableSink(leftOutlet, committerSettings), context.committableSink(rightOutlet, committerSettings))
+    flow
+      .map(MultiData2.fromEither(_))
+      .asFlow
+      .to(MultiProducer.sink2(leftOutlet, rightOutlet, committerSettings))
 }
 
 /**

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -17,6 +17,8 @@
 package cloudflow.akkastream
 
 import scala.concurrent.Future
+import scala.collection.immutable
+
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.cluster.sharding.typed.scaladsl.Entity
@@ -60,6 +62,10 @@ trait AkkaStreamletContext extends StreamletContext {
 
   private[akkastream] def committableSink[T](outlet: CodecOutlet[T], committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed]
   private[akkastream] def committableSink[T](committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed]
+
+  private[akkastream] def flexiFlow[T](
+      outlet: CodecOutlet[T]
+  ): Flow[(immutable.Seq[_ <: T], _ <: Committable), (Unit, Committable), NotUsed]
 
   @deprecated("Use `committableSink` instead.", "1.3.4")
   private[akkastream] def sinkWithOffsetContext[T](outlet: CodecOutlet[T],

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/MultiData.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/MultiData.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.akkastream
+
+import scala.collection.immutable
+import scala.jdk.CollectionConverters._
+
+/**
+ * Data class to support sending to multiple outlets from a single originating message.
+ */
+final class MultiData2[O1, O2] private (val data1: immutable.Seq[O1], val data2: immutable.Seq[O2]) {
+
+  def withData1[O](data: immutable.Seq[O]) = new MultiData2[O, O2](data, data2)
+  def withData2[O](data: immutable.Seq[O]) = new MultiData2[O1, O](data1, data)
+
+  def getData1(): java.util.Collection[O1] = data1.asJavaCollection
+  def getData2(): java.util.Collection[O2] = data2.asJavaCollection
+
+  override def toString: String =
+    "MultiData2(" +
+        s"data1=${data1.mkString(",")}, " +
+        s"data2=${data2.mkString(",")}" +
+        ")"
+}
+
+object MultiData2 {
+
+  def apply[O1, O2](data1: immutable.Seq[O1], data2: immutable.Seq[O2]) = new MultiData2(data1, data2)
+  def createData1[O1, O2](data: immutable.Seq[O1]): MultiData2[O1, O2]  = new MultiData2(data, immutable.Seq.empty)
+  def createData2[O1, O2](data: immutable.Seq[O2]): MultiData2[O1, O2]  = new MultiData2(immutable.Seq.empty, data)
+
+  def fromEither[O1, O2](data: Either[O1, O2]): MultiData2[O1, O2] =
+    data match {
+      case Left(l)  => MultiData2.createData1(immutable.Seq(l))
+      case Right(r) => MultiData2.createData2(immutable.Seq(r))
+    }
+
+  def create[O1, O2](data1: java.util.Collection[O1], data2: java.util.Collection[O2]) = new MultiData2(asScala(data1), asScala(data2))
+  def createData1[O](data: java.util.Collection[O]): MultiData2[O, Object]             = new MultiData2(asScala(data), immutable.Seq.empty)
+  def createData2[O](data: java.util.Collection[O]): MultiData2[Object, O]             = new MultiData2(immutable.Seq.empty, asScala(data))
+
+  private def asScala[O](data: java.util.Collection[O]): immutable.Seq[O] = data.asScala.toIndexedSeq
+}

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/internal/MultiProducer.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/internal/MultiProducer.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.akkastream.internal
+
+import akka.NotUsed
+import akka.annotation.InternalApi
+import akka.kafka.CommitterSettings
+import akka.kafka.ConsumerMessage.Committable
+import akka.stream.scaladsl.{ Flow, GraphDSL, Sink, Unzip, ZipWith }
+import akka.stream.{ FlowShape, Graph }
+import cloudflow.akkastream.{ AkkaStreamletContext, MultiData2 }
+import cloudflow.streamlets.CodecOutlet
+
+import scala.collection.immutable
+
+@InternalApi
+private[akkastream] object MultiProducer {
+
+  /**
+   * Produce to two outlets and ensure "at-least-once" semantics by committing first after all messages
+   * have been written to the designated outlets.
+   */
+  def flow2[O1, O2](
+      outlet1: CodecOutlet[O1],
+      outlet2: CodecOutlet[O2]
+  )(implicit context: AkkaStreamletContext): Flow[(MultiData2[O1, O2], Committable), (Unit, Committable), NotUsed] =
+    Flow
+      .fromGraph(graph2(context.flexiFlow(outlet1), context.flexiFlow(outlet2)))
+
+  /**
+   * Produce to two outlets and ensure "at-least-once" semantics by committing first after all messages
+   * have been written to the designated outlets.
+   */
+  def sink2[O1, O2](
+      outlet1: CodecOutlet[O1],
+      outlet2: CodecOutlet[O2],
+      committerSettings: CommitterSettings
+  )(implicit context: AkkaStreamletContext): Sink[(MultiData2[O1, O2], Committable), NotUsed] =
+    flow2(outlet1, outlet2)
+      .to(context.committableSink[Unit](committerSettings))
+
+  private def graph2[O1, O2](
+      outlet1: Flow[(immutable.Seq[O1], Committable), (Unit, Committable), _],
+      outlet2: Flow[(immutable.Seq[O2], Committable), (Unit, Committable), _]
+  ): Graph[akka.stream.FlowShape[(MultiData2[O1, O2], Committable), (Unit, Committable)], NotUsed] =
+    GraphDSL.create(outlet1, outlet2)((_, _) => NotUsed) { implicit builder: GraphDSL.Builder[NotUsed] => (o1, o2) =>
+      import GraphDSL.Implicits._
+
+      val spreadOut = builder.add(
+        Flow[(MultiData2[_ <: O1, _ <: O2], Committable)]
+          .map {
+            case (multi, committable) =>
+              ((multi.data1, committable), (multi.data2, committable))
+          }
+      )
+      val split = builder.add(Unzip[(immutable.Seq[O1], Committable), (immutable.Seq[O2], Committable)]())
+      val keepCommittable = builder.add(ZipWith[(_, Committable), (_, Committable), (Unit, Committable)]({
+        case ((_, committable), (_, _)) =>
+          ((), committable)
+
+      }))
+
+      // format: OFF
+      spreadOut ~> split.in
+                   split.out0 ~> o1 ~> keepCommittable.in0
+                   split.out1 ~> o2 ~> keepCommittable.in1
+      // format: ON
+      FlowShape(spreadOut.in, keepCommittable.out)
+    }
+
+}


### PR DESCRIPTION
This is a minimal variant of #773 and does not offer multi-out flows or sinks to the public Akka Streamlet API but fixes the Splitter API to guarantee at-least-once.

* Introduce a `MultiData2` type which serves as a tuple of sequences. The idea is that such a type would make the Java API and the Scala API more uniform.

* Introduce `MultiProducer` (as internal API) which produces to two outlets in parallel and ensures proper committing after all elements are produced.