### PR TITLE
added to the jvm args in the right order

### DIFF
--- a/external/multi-base-images/flink/Dockerfile
+++ b/external/multi-base-images/flink/Dockerfile
@@ -56,6 +56,10 @@ RUN set -ex; \
   chmod -R 777 $FLINK_HOME
 
 ADD config.sh $FLINK_HOME/bin/
+ADD flink-console.sh $FLINK_HOME/bin/
+
+RUN chmod 777 $FLINK_HOME/bin/flink-console.sh; \
+    chown 501:dialout $FLINK_HOME/bin/flink-console.sh
 
 # Update entrypoint
 COPY flink-entrypoint.sh /opt/

--- a/external/multi-base-images/flink/config.sh
+++ b/external/multi-base-images/flink/config.sh
@@ -409,7 +409,8 @@ fi
 
 
 # Here we are not asking if this FLINK_ENV_JAVA_OPTS exist as any other case above and below
-# because we know they do. We did 'export' it in the file of this folder flink-entrypoint.sh
+# because we know it does. We did 'export' it in the file ./flink-entrypoint.sh that indirectly 
+# executes this script through /opt/flink/bin/taskmanager.sh.
 FLINK_ENV_JAVA_OPTS_CONFIG=$(readFromConfig ${KEY_ENV_JAVA_OPTS} "${DEFAULT_ENV_JAVA_OPTS}" "${YAML_CONF}") 
 
 # What we need to make sure is that we don't add more than once as this script can run multiple times

--- a/external/multi-base-images/flink/config.sh
+++ b/external/multi-base-images/flink/config.sh
@@ -405,9 +405,20 @@ if [ -z "${FLINK_PID_DIR}" ]; then
     FLINK_PID_DIR=$(readFromConfig ${KEY_ENV_PID_DIR} "${DEFAULT_ENV_PID_DIR}" "${YAML_CONF}")
 fi
 
-if [ -z "${FLINK_ENV_JAVA_OPTS}" ]; then
-    FLINK_ENV_JAVA_OPTS=$(readFromConfig ${KEY_ENV_JAVA_OPTS} "${DEFAULT_ENV_JAVA_OPTS}" "${YAML_CONF}")
 
+
+
+# Here we are not asking if this FLINK_ENV_JAVA_OPTS exist as any other case above and below
+# because we know they do. We did 'export' it in the file of this folder flink-entrypoint.sh
+FLINK_ENV_JAVA_OPTS_CONFIG=$(readFromConfig ${KEY_ENV_JAVA_OPTS} "${DEFAULT_ENV_JAVA_OPTS}" "${YAML_CONF}") 
+
+# What we need to make sure is that we don't add more than once as this script can run multiple times
+# e.g. /opt/flink/bin/taskmanager.sh -> /opt/flink/bin/flink-console.sh (both call this script)
+# so if the opts from the config still haven't added, we do.
+if [ -z "${FLINK_ENV_JAVA_OPTS##*$FLINK_ENV_JAVA_OPTS_CONFIG*}" ];then 
+    echo "${FLINK_ENV_JAVA_OPTS_CONFIG} have already been added to JVM Options"
+else
+    FLINK_ENV_JAVA_OPTS="${FLINK_ENV_JAVA_OPTS} ${FLINK_ENV_JAVA_OPTS_CONFIG}"
     # Remove leading and ending double quotes (if present) of value
     FLINK_ENV_JAVA_OPTS="$( echo "${FLINK_ENV_JAVA_OPTS}" | sed -e 's/^"//'  -e 's/"$//' )"
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?
adding params from CF config JAVA_OPTS to the java process in a flink pod


### Why are the changes needed?
To pass the params from the config. Previously wasn't working


### Does this PR introduce any user-facing change?
no


### How was this patch tested?
building the Docker image, deploying it in GKE, and checking that PID 1 had `-Dlog4j.configuration=file:///mnt/lo
gging/log4j2.xml -XX:MaxRAMPercentage=60.0`. Plus that its position would be after the other params so they will override. 
```1 cloudflo  0:18 /opt/java/openjdk/bin/java -Xms256m -Xmx256m -Dlog4j.configuration=file:/opt/flink/conf/log4j-console.properties -Dlogback.configurationFile=file:
/opt/flink/conf/logback-console.xml -javaagent:/prometheus/jmx_prometheus_javaagent.jar=2050:/etc/cloudflow-runner/prometheus.yaml -Dlog4j.configuration=file:///mnt/lo
gging/log4j2.xml -XX:MaxRAMPercentage=60.0 -classpath /opt/cloudflow/akka-actor_2.12-2.5.31.jar:/opt/cloudflow/akka-discovery_2.12-2.5.31.jar:/opt/cloudflow/akka-grpc-
runtime_2.12-1.0.1.jar:/opt/cloudflow/akka-http-core_2.12-10.1.12.jar:/opt/cloudflow/ak``` 
