### PR TITLE
Merge default named Kafka cluster config as fallback to any global topic config

### DIFF
--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/event/ConfigurationScopeLayeringSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/event/ConfigurationScopeLayeringSpec.scala
@@ -104,17 +104,17 @@ class ConfigurationScopeLayeringSpec
           "in" -> Topic(
                 "metrics",
                 config = ConfigFactory.parseString("""
-                  |bootstrap.servers = "inline-config-kafka-bootstrap:9092"
-                  |connection-config {
-                  |  connection.foo.bar = "inline-baz"
-                  |}
-                  |producer-config {
-                  |  producer.foo.bar = "inline-baz"
-                  |}
-                  |consumer-config {
-                  |  consumer.foo.bar = "inline-baz"
-                  |}
-                  |""".stripMargin)
+                                                 |bootstrap.servers = "inline-config-kafka-bootstrap:9092"
+                                                 |connection-config {
+                                                 |  connection.foo.bar = "inline-baz"
+                                                 |}
+                                                 |producer-config {
+                                                 |  producer.foo.bar = "inline-baz"
+                                                 |}
+                                                 |consumer-config {
+                                                 |  consumer.foo.bar = "inline-baz"
+                                                 |}
+                                                 |""".stripMargin)
               )
         ),
         volumeMounts = None,
@@ -122,44 +122,44 @@ class ConfigurationScopeLayeringSpec
       )
 
       val appConfig = ConfigFactory.parseString("""
-        |cloudflow.topics.invalid-metrics {
-        |  bootstrap.servers = "app-cluster:9092"
-        |  connection-config {
-        |    connection.foo.bar = "app-baz"
-        |  }
-        |  producer-config {
-        |    producer.foo.bar = "app-baz"
-        |  }
-        |  consumer-config {
-        |    consumer.foo.bar = "app-baz"
-        |  }
-        |}
-        |""".stripMargin)
+                                                  |cloudflow.topics.invalid-metrics {
+                                                  |  bootstrap.servers = "app-cluster:9092"
+                                                  |  connection-config {
+                                                  |    connection.foo.bar = "app-baz"
+                                                  |  }
+                                                  |  producer-config {
+                                                  |    producer.foo.bar = "app-baz"
+                                                  |  }
+                                                  |  consumer-config {
+                                                  |    consumer.foo.bar = "app-baz"
+                                                  |  }
+                                                  |}
+                                                  |""".stripMargin)
 
       val defaultClusterConfig = ConfigFactory.parseString("""
-        |bootstrap.servers = "default-named-cluster:9092"
-        |connection-config {
-        |  connection.foo.bar = "default-baz"
-        |}
-        |producer-config {
-        |  producer.foo.bar = "default-baz"
-        |}
-        |consumer-config {
-        |  consumer.foo.bar = "default-baz"
-        |}
+                                                             |bootstrap.servers = "default-named-cluster:9092"
+                                                             |connection-config {
+                                                             |  connection.foo.bar = "default-baz"
+                                                             |}
+                                                             |producer-config {
+                                                             |  producer.foo.bar = "default-baz"
+                                                             |}
+                                                             |consumer-config {
+                                                             |  consumer.foo.bar = "default-baz"
+                                                             |}
       """.stripMargin)
 
       val nonDefaultClusterConfig = ConfigFactory.parseString("""
-        |bootstrap.servers = "non-default-named-cluster:9092"
-        |connection-config {
-        |  connection.foo.bar = "non-default-baz"
-        |}
-        |producer-config {
-        |  producer.foo.bar = "non-default-baz"
-        |}
-        |consumer-config {
-        |  consumer.foo.bar = "non-default-baz"
-        |}
+                                                                |bootstrap.servers = "non-default-named-cluster:9092"
+                                                                |connection-config {
+                                                                |  connection.foo.bar = "non-default-baz"
+                                                                |}
+                                                                |producer-config {
+                                                                |  producer.foo.bar = "non-default-baz"
+                                                                |}
+                                                                |consumer-config {
+                                                                |  consumer.foo.bar = "non-default-baz"
+                                                                |}
       """.stripMargin)
 
       val clusterSecretConfigs = Map("default" -> defaultClusterConfig, "non-default-named-cluster" -> nonDefaultClusterConfig)

--- a/docs/docs-source/docs/modules/administration/pages/installing-flink-operator.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-flink-operator.adoc
@@ -5,6 +5,8 @@
 
 include::ROOT:partial$include.adoc[]
 
+NOTE: See xref:installation-prerequisites.adoc#_storage_requirements_for_use_with_spark_or_flink[Storage requirements (for use with Spark or Flink)] to setup Storage Requirements for Flink applications.
+
 If you plan to write applications that utilize Flink you will need to install the Lyft Flink operator before deploying your Cloudflow application.
 
 Install the Lyft Flink operator using the following Helm command:
@@ -19,7 +21,7 @@ helm install flink-operator \
 
 NOTE: The above Helm command uses a Helm chart for the Lyft Flink operator that is hosted https://github.com/lightbend/flink-operator[here].
 
-This completes the installation of the Flink operator. 
+This completes the installation of the Flink operator.
 
 ----
 $ kubectl get pods -n cloudflow

--- a/docs/docs-source/docs/modules/administration/pages/installing-spark-operator.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-spark-operator.adoc
@@ -5,6 +5,8 @@
 
 include::ROOT:partial$include.adoc[]
 
+NOTE: See xref:installation-prerequisites.adoc#_storage_requirements_for_use_with_spark_or_flink[Storage requirements (for use with Spark or Flink)] to setup Storage Requirements for Spark applications.
+
 If you plan to write applications that utilize Spark, you will need to install the Spark operator before deploying your Cloudflow application.
 
 The only Cloudflow compatible Spark operator is a fork maintained by Lightbend.
@@ -155,7 +157,7 @@ Now we can apply the changes to the webhook:
 
   kubectl apply -f spark-mutating-webhook.yaml --namespace cloudflow
 
-That completes the installation of the Spark operator. You can check the result with the following command: 
+That completes the installation of the Spark operator. You can check the result with the following command:
 
 ----
 $ kubectl get pods -n cloudflow


### PR DESCRIPTION
Fixes #790 

Bonus: link to storage pre-reqs in admin docs for Spark and Flink support