### PR TITLE
fix the CI for external contributors

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,7 +49,9 @@ jobs:
         SBT_OPTS: -Xms512M -Xmx2048M -Xss2M -XX:MaxMetaspaceSize=1024M
       run: |
         export PATH="$HOME/opt/sbt/bin:$PATH"
-        cd scripts
+        cd core
+        sbt publishLocal
+        cd ../scripts
         ./build-all.sh test
 
 


### PR DESCRIPTION
User's repositories are not appropriately tagged, and this results in missing jars.