### PR TITLE
Edit Apache Flink entry script to prevent task manager memory setting overriding

### DIFF
--- a/external/multi-base-images/flink/flink-entrypoint.sh
+++ b/external/multi-base-images/flink/flink-entrypoint.sh
@@ -32,6 +32,8 @@ drop_privs_cmd() {
 }
 
 # Add in extra configs set by the operator
+echo "taskmanager.memory.flink.size: 1024mb" >> "$FLINK_HOME/conf/flink-conf.yaml"
+
 if [ -n "$FLINK_PROPERTIES" ]; then
     echo "$FLINK_PROPERTIES" >> $FLINK_HOME/flink-conf-tmp.yaml
 fi
@@ -45,7 +47,6 @@ fi
 echo "web.upload.dir: $FLINK_HOME" >> "$FLINK_HOME/conf/flink-conf.yaml"
 echo "jobmanager.web.upload.dir: $FLINK_HOME" >> "$FLINK_HOME/conf/flink-conf.yaml"
 
-echo "taskmanager.memory.flink.size: 1024mb" >> "$FLINK_HOME/conf/flink-conf.yaml"
 
 # Add JMX metric reporter to config
 echo "metrics.reporters: jmx" >> "$FLINK_HOME/conf/flink-conf.yaml"


### PR DESCRIPTION
### What changes were proposed in this pull request?
The change Fixes #805 so now Apache Flink is able to use calculated memory values for Task Manager pods and they will not be overrided by the hard-coded value of 1024 mb. 


### Why are the changes needed?
Before the fix all Apache Flink deployments were limited to use only 1024 Mb of `taskmanager.memory.flink.size` which is not enough for the majority of use cases.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
The change was tested on a local OpenShift cluster.
