### PR TITLE
Mention CLOUDFLOW_VERSION in the docs to run the examples

### DIFF
--- a/docs/docs-source/docs/modules/get-started/pages/run-in-sandbox.adoc
+++ b/docs/docs-source/docs/modules/get-started/pages/run-in-sandbox.adoc
@@ -8,7 +8,10 @@ include::ROOT:partial$include.adoc[]
 Now that we have the application code implemented, let's build the application and exercise its functionality locally without requiring deploying it in a cluster.
 
 == Run the Streamlets Locally
-The `sbt runLocal` command allows you to run your application on your local machine without a Kubernetes cluster. 
+The `sbt runLocal` command allows you to run your application on your local machine without a Kubernetes cluster.
+
+NOTE: If you are trying to run the examples contained in the upstream cloudflow repository remember to run
+`export CLOUDFLOW_VERSION={cloudflow-version}` before invoking `sbt`.
 
 . From the `sbt` shell, invoke `runLocal`:
 +

--- a/docs/shared-content-source/docs/modules/develop/pages/cloudflow-local-sandbox.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/cloudflow-local-sandbox.adoc
@@ -20,6 +20,9 @@ It is automatically available when an application enables support for Akka, Spar
 
 The _Sandbox_ is accessible as an `sbt` task called `runLocal` in the root build of your Cloudflow application.
 
+NOTE: If you are trying to run the examples contained in the upstream cloudflow repository remember to run
+`export CLOUDFLOW_VERSION={cloudflow-version}` before invoking `sbt`.
+
 It can be called directly from the command line, as we show here:
 
 [source,bash]


### PR DESCRIPTION
Include the mention of the `CLOUDFLOW_VERSION` in the documentation.