### PR TITLE
Kafka 2.4.0 support removed in Strimzi 0.20.0

### DIFF
--- a/docs/docs-source/docs/modules/administration/pages/how-to-install-and-use-strimzi.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/how-to-install-and-use-strimzi.adoc
@@ -85,7 +85,7 @@ spec:
       deleteClaim: false
       size: 100Gi
       type: persistent-claim
-    version: 2.4.0
+    version: 2.5.1
   zookeeper:
     livenessProbe:
       initialDelaySeconds: 15


### PR DESCRIPTION
Strimzi 0.20.0 was released two days ago: https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.20.0

One of the changes was removal of Kafka 2.4.x support: https://github.com/strimzi/strimzi-kafka-operator/issues/3470

After installing a fresh Strimzi using `helm install`, executing the YAML as-is with `version 2.4.0` now yields the following error message in the output of `kubectl logs`:

```
2020-10-25 20:12:08 ERROR AbstractOperator:238 - Reconciliation #3(timer) Kafka(cloudflow/cloudflow-strimzi): createOrUpdate failed
io.strimzi.operator.cluster.model.InvalidResourceException: Version 2.4.0 is not supported. Supported versions are: 2.5.0, 2.5.1, 2.6.0.
```

This is a fatal problem; Kafka is not installed in the cluster.

I figured Kafka 2.5.1 is the "safest" option here.