### PR TITLE
Force incompatible change, users must update kubectl cloudflow and op…

### DIFF
--- a/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/deployment/ApplicationDescriptor.scala
+++ b/core/cloudflow-blueprint/src/main/scala/cloudflow/blueprint/deployment/ApplicationDescriptor.scala
@@ -44,7 +44,7 @@ object ApplicationDescriptor {
    * The version of the Application Descriptor Format.
    * This version is also hardcoded in (versions of) kubectl-cloudflow in `domain.SupportedApplicationDescriptorVersion`.
    */
-  val Version = "4"
+  val Version = "5"
 
   val PrometheusAgentKey = "prometheus"
 

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Operator.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Operator.scala
@@ -33,7 +33,7 @@ import scala.concurrent.duration._
 import scala.util._
 
 object Operator {
-  val ProtocolVersion              = "2"
+  val ProtocolVersion              = "3"
   val ProtocolVersionKey           = "protocol-version"
   val ProtocolVersionConfigMapName = "cloudflow-protocol-version"
   def ProtocolVersionConfigMap(ownerReferences: List[OwnerReference]) = ConfigMap(

--- a/kubectl-cloudflow/version/version.go
+++ b/kubectl-cloudflow/version/version.go
@@ -22,7 +22,7 @@ var ReleaseTag = "SNAPSHOT"
 
 // ProtocolVersion is the protocol version, which is shared between the cloudflow-operator and kubectl-cloudflow. The cloudflow-operator creates
 // a configmap on bootstrap that kubectl-cloudflow reads to verify that it is compatible.
-const ProtocolVersion = "2"
+const ProtocolVersion = "3"
 
 // ProtocolVersionKey is the key of the protocol version in the configmap
 const ProtocolVersionKey = "protocol-version"
@@ -41,7 +41,7 @@ const RequiredFlinkVersion = "v1beta1"
 
 // SupportedApplicationDescriptorVersion is the Application Descriptor Version that this version of kubectl-cloudflow supports.
 // This version must match up with the version that is added by sbt-cloudflow, which is hardcoded in `cloudflow.blueprint.deployment.ApplicationDescriptor`.
-const SupportedApplicationDescriptorVersion = "4"
+const SupportedApplicationDescriptorVersion = "5"
 
 // FailOnProtocolVersionMismatch fails and exits if the protocol version of kubectl-cloudflow does not match with the cloudflow operator protocol version.
 func FailOnProtocolVersionMismatch() {


### PR DESCRIPTION
…erator.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Since there were some issues in upgrade to 2.0.11, in the next version it will be required to update sbt-cloudflow, kubectl cloudflow and the cloudflow operator to the next version.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, the user has to update the cloudflow-operator, rebuild and deploy apps. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
