### PR TITLE
helm stable repo has moved; old one will go in 2 weeks

### DIFF
--- a/docs/docs-source/docs/modules/administration/pages/installation-prerequisites.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installation-prerequisites.adoc
@@ -49,7 +49,7 @@ We'll install the nfs chart in the `cloudflow` namespace, if it does not exist y
 
 Add the `Stable` Helm repository and update the local index:
 
-  helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+  helm repo add stable https://charts.helm.sh/stable
   helm repo update
 
 Install the NFS Server Provisioner using the following command:


### PR DESCRIPTION
When adding the old repo, you get this warning:

```
WARNING: "kubernetes-charts.storage.googleapis.com" is deprecated for "stable" and will be deleted Nov. 13, 2020.
WARNING: You should switch to "https://charts.helm.sh/stable"
```

see https://github.com/helm/charts/blob/master/README.md#deprecation-timeline