### PR TITLE
Cloudflow spark operator doesn't allow version updates

### DIFF
--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -47,6 +47,7 @@ prepare-cluster:
 	helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator | true
 	helm repo update
 	yq write spark-values.yaml operatorVersion "${version}-cloudflow-spark-2.4.5-1.1.2-scala-2.12" > generated-spark-values.yaml
+	helm uninstall spark-operator --namespace cloudflow | true
 	helm upgrade -i spark-operator incubator/sparkoperator --values="generated-spark-values.yaml" --version "0.6.7" --namespace cloudflow
 	kubectl apply -f spark-mutating-webhook.yaml --namespace cloudflow
 	@echo '****** Installing Flink Operator'


### PR DESCRIPTION
This PR makes the Makefile of the integration tests more idempotent.
The Spark operator doesn't allow version upgrades, so we try to remove it before installing a new one.