### PR TITLE
Expose the Kafka Consumer Control and improve shutdown behaviour

### DIFF
--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
@@ -96,8 +96,13 @@ final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
   /**
    *
    */
-  def makeInletFromSource[T](inlet: CodecInlet[T], source: Source[T, NotUsed]): SourceInletTap[T] =
-    SourceInletTap[T](inlet, source.map(t ⇒ (t, TestCommittableOffset())))
+  def makeInletFromSource[T](inlet: CodecInlet[T], source: Source[T, NotUsed]): SourceInletTap[T] = {
+    val control: akka.kafka.scaladsl.Consumer.Control = akka.kafka.scaladsl.Consumer.NoopControl
+    SourceInletTap[T](inlet,
+                      source
+                        .mapMaterializedValue(_ => control)
+                        .map(t ⇒ (t, TestCommittableOffset())))
+  }
 
   /**
    * Creates an outlet tap. An outlet tap provides a probe that can be used to assert elements produced to the specified outlet.

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/package.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/package.scala
@@ -18,7 +18,7 @@ package cloudflow.akkastream
 
 package testkit {
   import scala.concurrent.Future
-  import akka.{ Done, NotUsed }
+  import akka.Done
   import akka.stream.scaladsl._
   import cloudflow.streamlets.CodecOutlet
   import akka.kafka.ConsumerMessage._
@@ -27,7 +27,7 @@ package testkit {
     def portName: String
 
     // This is for internal usage so using a scaladsl Source and a Tuple is no problem
-    private[testkit] def source: Source[(T, Committable), NotUsed]
+    private[testkit] def source: Source[(T, Committable), akka.kafka.scaladsl.Consumer.Control]
   }
 
   trait OutletTap[T] {

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/AkkaStreamletTestKit.scala
@@ -88,8 +88,13 @@ final case class AkkaStreamletTestKit private[testkit] (system: ActorSystem,
   /**
    *
    */
-  def inletFromSource[T](inlet: CodecInlet[T], source: Source[T, NotUsed]): SourceInletTap[T] =
-    SourceInletTap[T](inlet, source.map(t ⇒ (t, TestCommittableOffset())))
+  def inletFromSource[T](inlet: CodecInlet[T], source: Source[T, NotUsed]): SourceInletTap[T] = {
+    val control: akka.kafka.scaladsl.Consumer.Control = akka.kafka.scaladsl.Consumer.NoopControl
+    SourceInletTap[T](inlet,
+                      source
+                        .mapMaterializedValue(_ => control)
+                        .map(t ⇒ (t, TestCommittableOffset())))
+  }
 
   /**
    * Creates an outlet tap. An outlet tap provides a probe that can be used to assert elements produced to the specified outlet.

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -46,19 +46,20 @@ trait AkkaStreamletContext extends StreamletContext {
       inlet: CodecInlet[T],
       shardEntity: Entity[M, E],
       kafkaTimeout: FiniteDuration = 10.seconds
-  ): SourceWithContext[T, CommittableOffset, Future[NotUsed]]
+  ): SourceWithContext[T, CommittableOffset, Future[akka.kafka.scaladsl.Consumer.Control]]
 
   @deprecated("Use `sourceWithCommittableContext` instead.", "1.3.4")
   private[akkastream] def sourceWithOffsetContext[T](inlet: CodecInlet[T]): cloudflow.akkastream.scaladsl.SourceWithOffsetContext[T]
 
-  private[akkastream] def plainSource[T](inlet: CodecInlet[T], resetPosition: ResetPosition): Source[T, NotUsed]
+  private[akkastream] def plainSource[T](inlet: CodecInlet[T],
+                                         resetPosition: ResetPosition): Source[T, akka.kafka.scaladsl.Consumer.Control]
   private[akkastream] def plainSink[T](outlet: CodecOutlet[T]): Sink[T, NotUsed]
   private[akkastream] def shardedPlainSource[T, M, E](
       inlet: CodecInlet[T],
       shardEntity: Entity[M, E],
       resetPosition: ResetPosition = Latest,
       kafkaTimeout: FiniteDuration = 10.seconds
-  ): Source[T, Future[NotUsed]]
+  ): Source[T, Future[akka.kafka.scaladsl.Consumer.Control]]
 
   private[akkastream] def committableSink[T](outlet: CodecOutlet[T], committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed]
   private[akkastream] def committableSink[T](committerSettings: CommitterSettings): Sink[(T, Committable), NotUsed]

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletLogic.scala
@@ -157,7 +157,7 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
       inlet: CodecInlet[T],
       shardEntity: Entity[M, E],
       kafkaTimeout: FiniteDuration = 10.seconds
-  ): SourceWithContext[T, CommittableOffset, Future[NotUsed]] =
+  ): SourceWithContext[T, CommittableOffset, Future[akka.kafka.scaladsl.Consumer.Control]] =
     context.shardedSourceWithCommittableContext(inlet, shardEntity, kafkaTimeout)
 
   /**
@@ -169,7 +169,7 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
       inlet: CodecInlet[T],
       shardEntity: Entity[M, E],
       kafkaTimeout: FiniteDuration = 10.seconds
-  ): akka.stream.javadsl.SourceWithContext[T, Committable, Future[NotUsed]] =
+  ): akka.stream.javadsl.SourceWithContext[T, Committable, Future[akka.kafka.scaladsl.Consumer.Control]] =
     context.shardedSourceWithCommittableContext(inlet, shardEntity, kafkaTimeout).asJava
 
   /**
@@ -178,18 +178,21 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
    * It has no support for committing offsets to Kafka.
    * The `inlet` specifies a [[cloudflow.streamlets.Codec]] that will be used to deserialize the records read from Kafka.
    */
-  def plainSource[T](inlet: CodecInlet[T], resetPosition: ResetPosition = Latest): akka.stream.scaladsl.Source[T, NotUsed] =
+  def plainSource[T](inlet: CodecInlet[T],
+                     resetPosition: ResetPosition = Latest): akka.stream.scaladsl.Source[T, akka.kafka.scaladsl.Consumer.Control] =
     context.plainSource(inlet, resetPosition)
 
   /**
    * Java API
    */
-  def getPlainSource[T](inlet: CodecInlet[T]): akka.stream.javadsl.Source[T, NotUsed] = plainSource(inlet).asJava
+  def getPlainSource[T](inlet: CodecInlet[T]): akka.stream.javadsl.Source[T, akka.kafka.scaladsl.Consumer.Control] =
+    plainSource(inlet).asJava
 
   /**
    * Java API
    */
-  def getPlainSource[T](inlet: CodecInlet[T], resetPosition: ResetPosition): akka.stream.javadsl.Source[T, NotUsed] =
+  def getPlainSource[T](inlet: CodecInlet[T],
+                        resetPosition: ResetPosition): akka.stream.javadsl.Source[T, akka.kafka.scaladsl.Consumer.Control] =
     plainSource(inlet, resetPosition).asJava
 
   /**
@@ -212,26 +215,30 @@ abstract class AkkaStreamletLogic(implicit val context: AkkaStreamletContext) ex
   def shardedPlainSource[T, M, E](inlet: CodecInlet[T],
                                   shardEntity: Entity[M, E],
                                   resetPosition: ResetPosition = Latest,
-                                  kafkaTimeout: FiniteDuration = 10.seconds): Source[T, Future[NotUsed]] =
+                                  kafkaTimeout: FiniteDuration = 10.seconds): Source[T, Future[akka.kafka.scaladsl.Consumer.Control]] =
     context.shardedPlainSource(inlet, shardEntity, resetPosition, kafkaTimeout)
 
   /**
    * Java API
    */
   @ApiMayChange
-  def getShardedPlainSource[T, M, E](inlet: CodecInlet[T],
-                                     shardEntity: Entity[M, E],
-                                     kafkaTimeout: FiniteDuration): akka.stream.javadsl.Source[T, Future[NotUsed]] =
+  def getShardedPlainSource[T, M, E](
+      inlet: CodecInlet[T],
+      shardEntity: Entity[M, E],
+      kafkaTimeout: FiniteDuration
+  ): akka.stream.javadsl.Source[T, Future[akka.kafka.scaladsl.Consumer.Control]] =
     shardedPlainSource(inlet, shardEntity, Latest, kafkaTimeout).asJava
 
   /**
    * Java API
    */
   @ApiMayChange
-  def getShardedPlainSource[T, M, E](inlet: CodecInlet[T],
-                                     shardEntity: Entity[M, E],
-                                     resetPosition: ResetPosition = Latest,
-                                     kafkaTimeout: FiniteDuration = 10.seconds): akka.stream.javadsl.Source[T, Future[NotUsed]] =
+  def getShardedPlainSource[T, M, E](
+      inlet: CodecInlet[T],
+      shardEntity: Entity[M, E],
+      resetPosition: ResetPosition = Latest,
+      kafkaTimeout: FiniteDuration = 10.seconds
+  ): akka.stream.javadsl.Source[T, Future[akka.kafka.scaladsl.Consumer.Control]] =
     shardedPlainSource(inlet, shardEntity, resetPosition, kafkaTimeout).asJava
 
   /**

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/scaladsl/package.scala
@@ -24,7 +24,7 @@ package object scaladsl {
 
   type FlowWithCommittableContext[-In, +Out] = FlowWithContext[In, Committable, Out, Committable, NotUsed]
 
-  type SourceWithCommittableContext[+T] = SourceWithContext[T, Committable, _]
+  type SourceWithCommittableContext[+T] = SourceWithContext[T, Committable, akka.kafka.scaladsl.Consumer.Control]
 
   object FlowWithCommittableContext {
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

References #638 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->


### Why are the changes needed?

This improves the shutdown behaviour of Akka Streamlets as a first step to a controlled shutdown as descirbed in https://doc.akka.io/docs/alpakka-kafka/current/consumer.html#controlled-shutdown


### Does this PR introduce any user-facing change?

The APIs change as they now expose the materialized value of the Alpakka Kafka sources. This is not binary-compatible.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
