### PR TITLE
Controlled shutdown of Kafka consumers

### DIFF
--- a/core/cloudflow-akka-tests/src/test/resources/logback-test.xml
+++ b/core/cloudflow-akka-tests/src/test/resources/logback-test.xml
@@ -1,12 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  <logger name="akka" level="${LOGLEVEL_AKKA:-OFF}" />
+  <logger name="akka" level="DEBUG"/>
+  <logger name="akka.actor.TimerScheduler" level="INFO"/>
+  <logger name="akka.kafka" level="DEBUG"/>
+
+  <logger name="org.apache.zookeeper" level="WARN"/>
+  <logger name="org.I0Itec.zkclient" level="WARN"/>
+
+  <logger name="kafka" level="WARN"/>
+  <logger name="org.apache.kafka" level="WARN"/>
+  <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
+  <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
+
+  <logger name="com.github.dockerjava" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
 
   <root level="${LOGLEVEL_ROOT:-OFF}">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
       <target>System.out</target>
       <encoder>
-        <pattern>%d{ISO8601} %-5level [%logger{0}] - %msg%n</pattern>
+        <pattern>%d{ISO8601} %-5level [%-20.20thread] [%-36.36logger{36}]  %msg%n%rEx</pattern>
       </encoder>
     </appender>
   </root>

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -41,6 +41,7 @@ object AkkaStreamletConsumerGroupSpec {
         stdout-loglevel = "OFF"
         loglevel = "OFF"
       }
+      akka.kafka.consumer.stop-timeout = 0s
       """)
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

This implements more controlled Consumer shutdown as described in https://doc.akka.io/docs/alpakka-kafka/current/consumer.html#controlled-shutdown


### Why are the changes needed?

This lowers the risk of messages being half processed during streamlet shutdown.
It improves chances that commits reach the Kafka consumer during shutdown.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

A new setting "consumer stop timeout" needs to be introduced.
The underlying `akka.kafka.consumer.stop-timeout` can be overwritten to 0s for streamlets.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
