### PR TITLE
Flink taskmanager taskSlots, parallelism.default, jobmanager.replicas is now configurable.

### DIFF
--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/CloudflowApplication.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/CloudflowApplication.scala
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory
 import play.api.libs.json._
 import play.api.libs.json.JsonNaming.SnakeCase
 
-import skuber.{ Container, CustomResource, ObjectEditor, ObjectMeta, ObjectResource, OwnerReference, Pod, ResourceDefinition }
+import skuber.{ Container, CustomResource, ObjectEditor, ObjectMeta, OwnerReference, Pod, ResourceDefinition }
 import skuber.apiextensions.CustomResourceDefinition
 import skuber.ResourceSpecification.Subresources
 
@@ -125,7 +125,7 @@ object CloudflowApplication {
   }
 
   object Status {
-    val Unknown          = "Unknown"
+    //val Unknown          = "Unknown"
     val Running          = "Running"
     val Pending          = "Pending"
     val CrashLoopBackOff = "CrashLoopBackOff"
@@ -140,7 +140,7 @@ object CloudflowApplication {
         spec.appId,
         spec.appVersion,
         streamletStatuses,
-        Some(Unknown)
+        Some(Pending)
       )
     }
 
@@ -191,7 +191,7 @@ object CloudflowApplication {
                     streamletStatuses: Vector[StreamletStatus],
                     appStatus: Option[String],
                     appMessage: Option[String] = None) {
-    def aggregatedStatus = appStatus.getOrElse(Status.Unknown)
+    def aggregatedStatus = appStatus.getOrElse(Status.Pending)
     def updateApp(newApp: CloudflowApplication.CR) = {
       val newStreamletStatuses = Status.createStreamletStatuses(newApp.spec).map { newStreamletStatus =>
         streamletStatuses

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/CloudflowApplication.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/CloudflowApplication.scala
@@ -126,7 +126,6 @@ object CloudflowApplication {
   }
 
   object Status {
-    //val Unknown          = "Unknown"
     val Running          = "Running"
     val Pending          = "Pending"
     val CrashLoopBackOff = "CrashLoopBackOff"
@@ -161,7 +160,7 @@ object CloudflowApplication {
         runners: Map[String, Runner[_]]
     ) =
       spec.deployments.map { deployment =>
-        val expectedPodCount = runners.get(deployment.runtime).map(_.expectedPodCount(deployment)).getOrElse(0)
+        val expectedPodCount = runners.get(deployment.runtime).map(_.expectedPodCount(deployment)).getOrElse(1)
         StreamletStatus(
           deployment.streamletName,
           expectedPodCount

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/FlinkRunner.scala
@@ -183,7 +183,6 @@ final class FlinkRunner(flinkRunnerDefaults: FlinkRunnerDefaults) extends Runner
     val scale = deployment.replicas
 
     val taskManagerConfig = TaskManagerConfig(
-      // TODO support taskmanager.numberOfTaskSlots from flink config.
       Some(
         flinkConfig
           .get("taskmanager.numberOfTaskSlots")
@@ -197,7 +196,6 @@ final class FlinkRunner(flinkRunnerDefaults: FlinkRunnerDefaults) extends Runner
     val _spec = Spec(
       image = image,
       jarName = RunnerJarName,
-      // TODO support parallelism.default from flink config.
       parallelism = scale
         .map(_ * taskManagerDefaults.taskSlots)
         .getOrElse(

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/FlinkRunner.scala
@@ -35,7 +35,7 @@ import cloudflow.operator.action.Action
 object FlinkRunner {
   final val Runtime         = "flink"
   final val PVCMountPath    = "/mnt/flink/storage"
-  final val DefaultReplicas = 2
+  final val DefaultReplicas = 1
 
   final val JobManagerPod  = "job-manager"
   final val TaskManagerPod = "task-manager"

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/event/StreamletChangeEvent.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/event/StreamletChangeEvent.scala
@@ -23,11 +23,9 @@ import org.slf4j.LoggerFactory
 
 import skuber.{ ObjectResource, Secret }
 import skuber.api.client.{ EventType, WatchEvent }
-import skuber.json.format._
 
 import cloudflow.operator.action._
 import cloudflow.operator.action.runner._
-import cloudflow.operator.action.runner.SparkResource.SpecPatch
 
 /**
  * Indicates that a streamlet has changed.
@@ -108,8 +106,7 @@ object StreamletChangeEvent extends Event {
       .find(_.streamletName == streamletName)
       .map { streamletDeployment ⇒
         log.info(s"[app: ${app.spec.appId} configuration changed for streamlet $streamletName]")
-        val updateLabels = Map(CloudflowLabels.ConfigUpdateLabel -> System.currentTimeMillis.toString)
-        val updateAction = runners.get(streamletDeployment.runtime).map(_.streamletChangeAction(app, streamletDeployment)).toList
+        val updateAction = runners.get(streamletDeployment.runtime).map(_.streamletChangeAction(app, runners, streamletDeployment)).toList
         val streamletChangeEventAction =
           EventActions.streamletChangeEvent(app, streamletDeployment, namespace, podName, watchEvent._object)
 

--- a/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/CloudflowApplicationSpec.scala
+++ b/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/CloudflowApplicationSpec.scala
@@ -64,9 +64,9 @@ class CloudflowApplicationSpec
       customResource.spec mustBe cr.spec
     }
 
-    "report its status as Unknown when there are no pod statuses yet" in {
+    "report its status as Pending when there are no pod statuses yet" in {
       val status = mkTestStatus()
-      status.aggregatedStatus mustBe CloudflowApplication.Status.Unknown
+      status.aggregatedStatus mustBe CloudflowApplication.Status.Pending
     }
 
     "report its status as Pending when one pod is not ready" in {
@@ -243,7 +243,7 @@ class CloudflowApplicationSpec
       .value
 
     val newApp = mkApp(verifiedBlueprint)
-    CloudflowApplication.Status(newApp)
+    CloudflowApplication.Status(newApp, runners)
   }
 
   def mkTestStatusMixedApp() = {
@@ -267,7 +267,7 @@ class CloudflowApplicationSpec
       .value
 
     val newApp = mkApp(verifiedBlueprint)
-    CloudflowApplication.Status(newApp)
+    CloudflowApplication.Status(newApp, runners)
   }
 
   def mkApp(verifiedBlueprint: VerifiedBlueprint) =

--- a/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/CloudflowApplicationSpec.scala
+++ b/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/CloudflowApplicationSpec.scala
@@ -178,7 +178,7 @@ class CloudflowApplicationSpec
         status.aggregatedStatus mustBe CloudflowApplication.Status.Pending
       }
 
-      (1 to FlinkRunner.DefaultReplicas + 1).foreach { _ =>
+      (1 to FlinkRunner.DefaultTaskManagerReplicas + 1).foreach { _ =>
         status = status.updatePod(
           "flink-egress",
           mkRunningReadyPod("flink-egress")

--- a/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/TestDeploymentContext.scala
+++ b/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/TestDeploymentContext.scala
@@ -17,6 +17,7 @@
 package cloudflow.operator
 
 import skuber.Resource.Quantity
+import cloudflow.operator.action.runner._
 
 trait TestDeploymentContext {
   implicit val ctx: DeploymentContext =
@@ -69,4 +70,9 @@ trait TestDeploymentContext {
       podName = "cloudflow-operator",
       podNamespace = "cloudflow"
     )
+  val runners = Map(
+    AkkaRunner.Runtime  -> new AkkaRunner(ctx.akkaRunnerDefaults),
+    SparkRunner.Runtime -> new SparkRunner(ctx.sparkRunnerDefaults),
+    FlinkRunner.Runtime -> new FlinkRunner(ctx.flinkRunnerDefaults)
+  )
 }

--- a/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/EventActionsSpec.scala
+++ b/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/EventActionsSpec.scala
@@ -27,7 +27,6 @@ class EventActionsSpec extends WordSpec with MustMatchers with GivenWhenThen wit
   case class Foo(name: String)
   case class Bar(name: String)
   val runner     = new AkkaRunner(ctx.akkaRunnerDefaults)
-  val runners    = Map(AkkaRunner.Runtime -> runner)
   val namespace  = "ns"
   val agentPaths = Map("prometheus" -> "/app/prometheus/prometheus.jar")
 

--- a/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/TopicActionsSpec.scala
+++ b/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/TopicActionsSpec.scala
@@ -58,7 +58,7 @@ class TopicActionsSpec
       val newApp = createApp()
 
       When("savepoint actions are created from a new app")
-      val actions = TopicActions(newApp, ctx.podNamespace)
+      val actions = TopicActions(newApp, runners, ctx.podNamespace)
 
       Then("only create topic actions must be created between the streamlets")
       val createActions =
@@ -124,7 +124,7 @@ class TopicActionsSpec
       val savepoint = newApp.spec.deployments.find(_.streamletName == "processor").value.portMappings(processor.out.name)
 
       Then("create actions for both topics should be created for the new savepoint between processor and egress")
-      val Seq(foosAction, barsAction) = TopicActions(newApp, ctx.podNamespace)
+      val Seq(foosAction, barsAction) = TopicActions(newApp, runners, ctx.podNamespace)
 
       val configMap0 = foosAction
         .asInstanceOf[ProvidedAction[Secret, TopicActions.TopicResource]]
@@ -186,7 +186,7 @@ class TopicActionsSpec
       val newApp = createApp(Option(clusterName))
 
       When("savepoint actions are created from a new app")
-      val actions = TopicActions(newApp, ctx.podNamespace)
+      val actions = TopicActions(newApp, runners, ctx.podNamespace)
 
       Then("only create topic actions must be created between the streamlets")
       val createActions =

--- a/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/runner/RunnerActionsSpec.scala
+++ b/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/runner/RunnerActionsSpec.scala
@@ -63,7 +63,7 @@ class RunnerActionsSpec extends WordSpec with MustMatchers with GivenWhenThen wi
       val newApp     = CloudflowApplication(CloudflowApplicationSpecBuilder.create(appId, appVersion, image, verifiedBlueprint, agentPaths))
 
       When("runner actions are created from a new app")
-      val actions = akkaRunner.actions(newApp, currentApp, namespace)
+      val actions = akkaRunner.actions(newApp, currentApp, namespace, runners)
 
       Then("only 'create actions' must be created for every runner")
       val createActions = actions.collect {
@@ -118,7 +118,7 @@ class RunnerActionsSpec extends WordSpec with MustMatchers with GivenWhenThen wi
       val currentApp = Some(newApp)
 
       When("nothing changes in the new app")
-      val actions = akkaRunner.actions(newApp, currentApp, namespace)
+      val actions = akkaRunner.actions(newApp, currentApp, namespace, runners)
 
       Then("update actions should be created")
       val updateActions = actions.collect { case a: CreateOrUpdateAction[_] ⇒ a }
@@ -156,7 +156,7 @@ class RunnerActionsSpec extends WordSpec with MustMatchers with GivenWhenThen wi
         bp.disconnect(egressRef.in).remove(egressRef.name)
       val newApp =
         CloudflowApplication(CloudflowApplicationSpecBuilder.create(appId, newAppVersion, image, newBp.verified.right.value, agentPaths))
-      val actions = akkaRunner.actions(newApp, Some(currentApp), namespace)
+      val actions = akkaRunner.actions(newApp, Some(currentApp), namespace, runners)
 
       Then("delete actions should be created")
       val deleteActions = actions.collect { case d: DeleteAction[_] ⇒ d }
@@ -190,7 +190,7 @@ class RunnerActionsSpec extends WordSpec with MustMatchers with GivenWhenThen wi
         CloudflowApplication(CloudflowApplicationSpecBuilder.create(appId, newAppVersion, image, newBp.verified.right.value, agentPaths))
 
       Then("create actions for runner resources should be created for the new endpoint")
-      val actions       = akkaRunner.actions(newApp, Some(currentApp), namespace)
+      val actions       = akkaRunner.actions(newApp, Some(currentApp), namespace, runners)
       val createActions = actions.collect { case a: CreateOrUpdateAction[_] ⇒ a }
 
       val createDeploymentActions = actions.collect {

--- a/core/cloudflow-operator/src/main/resources/application.conf
+++ b/core/cloudflow-operator/src/main/resources/application.conf
@@ -103,7 +103,7 @@ cloudflow {
 
       flink-runner {
         # no of Task Managers = ceil(parallelism / no of task slots)
-        parallelism = 4
+        parallelism = 1
         jobmanager {
           replicas = 1
 

--- a/core/cloudflow-operator/src/main/resources/application.conf
+++ b/core/cloudflow-operator/src/main/resources/application.conf
@@ -129,7 +129,7 @@ cloudflow {
           # https://ci.apache.org/projects/flink/flink-docs-stable/internals/job_scheduling.html
 
           # per task manager pod
-          task-slots = 2
+          task-slots = 1
 
           # total across all task manager pods
           requests-memory = "1024Mi"

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
@@ -60,7 +60,7 @@ object Main extends {
       Operator.handleAppEvents(client, runners, ctx.podName, ctx.podNamespace)
       Operator.handleConfigurationUpdates(client, runners, ctx.podName)
       Operator.handleConfigurationInput(client, ctx.podNamespace)
-      Operator.handleStatusUpdates(client)
+      Operator.handleStatusUpdates(client, runners)
     } catch {
       case t: Throwable ⇒
         system.log.error(t, "Unexpected error starting cloudflow operator, terminating.")

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/flow/StatusChangeEventFlow.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/flow/StatusChangeEventFlow.scala
@@ -25,6 +25,7 @@ import skuber._
 import skuber.api.client._
 
 import cloudflow.operator.action._
+import cloudflow.operator.action.runner.Runner
 import cloudflow.operator.event._
 
 object StatusChangeEventFlow extends {
@@ -47,14 +48,14 @@ object StatusChangeEventFlow extends {
         }
       }
 
-  def toStatusUpdateAction: Flow[(Option[CloudflowApplication.CR], StatusChangeEvent), Action, NotUsed] =
+  def toStatusUpdateAction(runners: Map[String, Runner[_]]): Flow[(Option[CloudflowApplication.CR], StatusChangeEvent), Action, NotUsed] =
     Flow[(Option[CloudflowApplication.CR], StatusChangeEvent)]
       .statefulMapConcat { () ⇒
         var currentStatuses = Map[String, CloudflowApplication.Status]()
 
         {
           case (mappedApp, event) =>
-            val (updatedStatuses, actionList) = toActionList(currentStatuses, mappedApp, event)
+            val (updatedStatuses, actionList) = toActionList(currentStatuses, mappedApp, runners, event)
             currentStatuses = updatedStatuses
             actionList
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
- Flink.DefaultTaskManagerReplicas set to 1. More consistent with default for Spark. Can be scaled by the user with deploy or scale, so no need to set to 2 initially, if not provided.
- Flink job manager replicas, parallelism, task manager task slots are now configurable. expected pods in status works accordingly.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
More consistent. Less resources needed initially.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Default 1 taskmanager will run.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- [x] GKE.