### PR TITLE
Fix the generation of the scala/java docs for all the released version

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -6,9 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8' ]
-        # for now...
-        # , '11', '13' ]
+        java: [ '8', '11', '13' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -23,7 +21,7 @@ jobs:
       run: |
         sudo snap install yq
         cd docs
-        make all
+        make html-author-mode
     - name: Run integration tests of the sbt plugin
       run: |
         git config --global user.email "cloudflow@lightbend.com"

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -6,7 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '13' ]
+        java: [ '8' ]
+        # for now...
+        # , '11', '13' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -117,7 +117,7 @@ list-todos: html
 all_javascaladocs:
 	@echo "Building old java and scala docs"
 	# (yq r docs-source/site.yml 'content.sources[0].branches.*' | xargs -n1 ./build-javascaladocs.sh)
-	(echo "v2.0.12-docs" | xargs -n1 ./build-javascaladocs.sh)
+	(yq r docs-source/site.yml 'content.sources[0].branches.[-1]' | xargs -n1 ./build-javascaladocs.sh)
 
 print-site:
 	# The result directory with the contents of this build:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -116,7 +116,8 @@ list-todos: html
 # Generate the ScalaDoc and the JavaDoc, for the old versions
 all_javascaladocs:
 	@echo "Building old java and scala docs"
-	(yq r docs-source/site.yml 'content.sources[0].branches.*' | xargs -n1 ./build-javascaladocs.sh)
+	# (yq r docs-source/site.yml 'content.sources[0].branches.*' | xargs -n1 ./build-javascaladocs.sh)
+	./build-javascaladocs.sh master
 
 print-site:
 	# The result directory with the contents of this build:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -117,7 +117,7 @@ list-todos: html
 all_javascaladocs:
 	@echo "Building old java and scala docs"
 	# (yq r docs-source/site.yml 'content.sources[0].branches.*' | xargs -n1 ./build-javascaladocs.sh)
-	(echo "v2.0.12-docs" | ./build-javascaladocs.sh)
+	(echo "v2.0.12-docs" | xargs -n1 ./build-javascaladocs.sh)
 
 print-site:
 	# The result directory with the contents of this build:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,8 +12,6 @@ work_dir := ${ROOT_DIR}/docs/target
 
 staging_dir := ${work_dir}/staging
 
-javascaladoc_dir := ${staging_dir}/docs/current/api
-
 all: build
 
 local-preview: html-author-mode
@@ -28,7 +26,7 @@ show:
 clean:
 	rm -rf ${work_dir}
 
-build: clean html javascaladoc_staged print-site
+build: clean html all_javascaladocs print-site
 
 get-version:
 	# get latest tag
@@ -115,23 +113,10 @@ list-todos: html
 		--cache-dir=./.cache/antora \
 		-c 'find /antora/docs-source/build/site/cloudflow/${version} -name "*.html" -print0 | xargs -0 grep -iE "TODO|FIXME|REVIEWERS|adoc"'
 
-# Generate the ScalaDoc and the JavaDoc, and put it in ${output}/scaladoc and ${output}/javadoc
-javascaladoc: 
-	cd ${ROOT_DIR}/core && sbt clean unidoc
-
-javascaladoc_staged: ${javascaladoc_dir} javascaladoc
-	cp -r ${ROOT_DIR}/core/target/scala-2.12/unidoc ${javascaladoc_dir}/scaladoc
-	cp -r ${ROOT_DIR}/core/target/javaunidoc ${javascaladoc_dir}/javadoc
-
-${work_dir}: 
-	mkdir -p ${work_dir}
-
-${staging_dir}:
-	mkdir -p ${staging_dir}
-
-${javascaladoc_dir}: 	
-	mkdir -p ${javascaladoc_dir}/scaladoc
-	mkdir -p ${javascaladoc_dir}/javadoc
+# Generate the ScalaDoc and the JavaDoc, for the old versions
+all_javascaladocs:
+	@echo "Building old java and scala docs"
+	(yq r docs-source/site.yml 'content.sources[0].branches.*' | xargs -n1 ./build-javascaladocs.sh)
 
 print-site:
 	# The result directory with the contents of this build:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -117,7 +117,7 @@ list-todos: html
 all_javascaladocs:
 	@echo "Building old java and scala docs"
 	# (yq r docs-source/site.yml 'content.sources[0].branches.*' | xargs -n1 ./build-javascaladocs.sh)
-	./build-javascaladocs.sh v2.0.12-docs
+	(echo "v2.0.12-docs" | ./build-javascaladocs.sh)
 
 print-site:
 	# The result directory with the contents of this build:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -116,8 +116,7 @@ list-todos: html
 # Generate the ScalaDoc and the JavaDoc, for the old versions
 all_javascaladocs:
 	@echo "Building old java and scala docs"
-	# (yq r docs-source/site.yml 'content.sources[0].branches.*' | xargs -n1 ./build-javascaladocs.sh)
-	(yq r docs-source/site.yml 'content.sources[0].branches.[-1]' | xargs -n1 ./build-javascaladocs.sh)
+	(yq r docs-source/site.yml 'content.sources[0].branches.*' | xargs -n1 ./build-javascaladocs.sh)
 
 print-site:
 	# The result directory with the contents of this build:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -117,7 +117,7 @@ list-todos: html
 all_javascaladocs:
 	@echo "Building old java and scala docs"
 	# (yq r docs-source/site.yml 'content.sources[0].branches.*' | xargs -n1 ./build-javascaladocs.sh)
-	./build-javascaladocs.sh master
+	./build-javascaladocs.sh v2.0.12-docs
 
 print-site:
 	# The result directory with the contents of this build:

--- a/docs/build-javascaladocs.sh
+++ b/docs/build-javascaladocs.sh
@@ -2,16 +2,18 @@
 
 VERSION=$1
 
-(cd target && \
-	rm -rf cloudflow && \
-	git clone --depth=100 --branch "$VERSION" https://github.com/lightbend/cloudflow.git && \
-  cd cloudflow && \
-  export DIR=$(yq r docs/docs-source/docs/antora.yml 'version') && \
-  echo $DIR && \
-	cd core && \
-	(sbt -mem 2048 clean unidoc | true) && \
-  cd ../../../ && \
-	mkdir -p "./target/staging/docs/$DIR/api/scaladoc" && \
-	mkdir -p "./target/staging/docs/$DIR/api/javadoc" && \
-	cp -r "./target/cloudflow/core/target/scala-2.12/unidoc/" "./target/staging/docs/$DIR/api/scaladoc" && \
-	cp -r "./target/cloudflow/core/target/javaunidoc/" "./target/staging/docs/$DIR/api/javadoc")
+echo $VERSION
+
+# (cd target && \
+# 	rm -rf cloudflow && \
+# 	git clone --depth=100 --branch "$VERSION" https://github.com/lightbend/cloudflow.git && \
+#   cd cloudflow && \
+#   export DIR=$(yq r docs/docs-source/docs/antora.yml 'version') && \
+#   echo $DIR && \
+# 	cd core && \
+# 	(sbt -mem 2048 clean unidoc | true) && \
+#   cd ../../../ && \
+# 	mkdir -p "./target/staging/docs/$DIR/api/scaladoc" && \
+# 	mkdir -p "./target/staging/docs/$DIR/api/javadoc" && \
+# 	cp -r "./target/cloudflow/core/target/scala-2.12/unidoc/" "./target/staging/docs/$DIR/api/scaladoc" && \
+# 	cp -r "./target/cloudflow/core/target/javaunidoc/" "./target/staging/docs/$DIR/api/javadoc")

--- a/docs/build-javascaladocs.sh
+++ b/docs/build-javascaladocs.sh
@@ -4,16 +4,20 @@ VERSION=$1
 
 echo $VERSION
 
-(cd target && \
-	rm -rf cloudflow && \
-	git clone --depth=100 --branch "$VERSION" https://github.com/lightbend/cloudflow.git && \
-  cd cloudflow && \
-  export DIR=$(yq r docs/docs-source/docs/antora.yml 'version') && \
-  echo $DIR && \
-	cd core && \
-	(sbt -mem 2048 clean unidoc | true) && \
-  cd ../../../ && \
-	mkdir -p "./target/staging/docs/$DIR/api/scaladoc" && \
-	mkdir -p "./target/staging/docs/$DIR/api/javadoc" && \
-	cp -r "./target/cloudflow/core/target/scala-2.12/unidoc/" "./target/staging/docs/$DIR/api/scaladoc" && \
-	cp -r "./target/cloudflow/core/target/javaunidoc/" "./target/staging/docs/$DIR/api/javadoc")
+if [[ -z "${VERSION}" ]]; then
+  echo "Version not defined"
+else
+  (cd target && \
+    rm -rf cloudflow && \
+    git clone --depth=100 --branch "$VERSION" https://github.com/lightbend/cloudflow.git && \
+    cd cloudflow && \
+    export DIR=$(yq r docs/docs-source/docs/antora.yml 'version') && \
+    echo $DIR && \
+    cd core && \
+    (sbt -mem 2048 clean unidoc | true) && \
+    cd ../../../ && \
+    mkdir -p "./target/staging/docs/$DIR/api/scaladoc" && \
+    mkdir -p "./target/staging/docs/$DIR/api/javadoc" && \
+    cp -r "./target/cloudflow/core/target/scala-2.12/unidoc/" "./target/staging/docs/$DIR/api/scaladoc" && \
+    cp -r "./target/cloudflow/core/target/javaunidoc/" "./target/staging/docs/$DIR/api/javadoc")
+fi

--- a/docs/build-javascaladocs.sh
+++ b/docs/build-javascaladocs.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+
+VERSION=$1
+
+(cd target && \
+	rm -rf cloudflow && \
+	git clone --depth=100 --branch "$VERSION" https://github.com/lightbend/cloudflow.git && \
+  cd cloudflow && \
+  export DIR=$(yq r docs/docs-source/docs/antora.yml 'version') && \
+  echo $DIR && \
+	cd core && \
+	(sbt -mem 2048 clean unidoc | true) && \
+  cd ../../../ && \
+  echo "$PWD" && \
+  echo "./target/staging/docs/$DIR/api/scaladoc" && \
+	mkdir -p "./target/staging/docs/$DIR/api/scaladoc" && \
+	mkdir -p "./target/staging/docs/$DIR/api/javadoc" && \
+	cp -r "./target/cloudflow/core/target/scala-2.12/unidoc/" "./target/staging/docs/$DIR/api/scaladoc" && \
+	cp -r "./target/cloudflow/core/target/javaunidoc/" "./target/staging/docs/$DIR/api/javadoc")

--- a/docs/build-javascaladocs.sh
+++ b/docs/build-javascaladocs.sh
@@ -11,8 +11,6 @@ VERSION=$1
 	cd core && \
 	(sbt -mem 2048 clean unidoc | true) && \
   cd ../../../ && \
-  echo "$PWD" && \
-  echo "./target/staging/docs/$DIR/api/scaladoc" && \
 	mkdir -p "./target/staging/docs/$DIR/api/scaladoc" && \
 	mkdir -p "./target/staging/docs/$DIR/api/javadoc" && \
 	cp -r "./target/cloudflow/core/target/scala-2.12/unidoc/" "./target/staging/docs/$DIR/api/scaladoc" && \

--- a/docs/build-javascaladocs.sh
+++ b/docs/build-javascaladocs.sh
@@ -4,16 +4,16 @@ VERSION=$1
 
 echo $VERSION
 
-# (cd target && \
-# 	rm -rf cloudflow && \
-# 	git clone --depth=100 --branch "$VERSION" https://github.com/lightbend/cloudflow.git && \
-#   cd cloudflow && \
-#   export DIR=$(yq r docs/docs-source/docs/antora.yml 'version') && \
-#   echo $DIR && \
-# 	cd core && \
-# 	(sbt -mem 2048 clean unidoc | true) && \
-#   cd ../../../ && \
-# 	mkdir -p "./target/staging/docs/$DIR/api/scaladoc" && \
-# 	mkdir -p "./target/staging/docs/$DIR/api/javadoc" && \
-# 	cp -r "./target/cloudflow/core/target/scala-2.12/unidoc/" "./target/staging/docs/$DIR/api/scaladoc" && \
-# 	cp -r "./target/cloudflow/core/target/javaunidoc/" "./target/staging/docs/$DIR/api/javadoc")
+(cd target && \
+	rm -rf cloudflow && \
+	git clone --depth=100 --branch "$VERSION" https://github.com/lightbend/cloudflow.git && \
+  cd cloudflow && \
+  export DIR=$(yq r docs/docs-source/docs/antora.yml 'version') && \
+  echo $DIR && \
+	cd core && \
+	(sbt -mem 2048 clean unidoc | true) && \
+  cd ../../../ && \
+	mkdir -p "./target/staging/docs/$DIR/api/scaladoc" && \
+	mkdir -p "./target/staging/docs/$DIR/api/javadoc" && \
+	cp -r "./target/cloudflow/core/target/scala-2.12/unidoc/" "./target/staging/docs/$DIR/api/scaladoc" && \
+	cp -r "./target/cloudflow/core/target/javaunidoc/" "./target/staging/docs/$DIR/api/javadoc")

--- a/docs/build-javascaladocs.sh
+++ b/docs/build-javascaladocs.sh
@@ -14,8 +14,10 @@ else
     export DIR=$(yq r docs/docs-source/docs/antora.yml 'version') && \
     echo $DIR && \
     cd core && \
-    (sbt -mem 2048 clean unidoc | true) && \
+    (sbt -mem 2048 clean unidoc || true) && \
     cd ../../../ && \
+    ls -al "./target/cloudflow/core/target" && \
+    ls -al "./target/cloudflow/core/target/scala-2.12" && \
     mkdir -p "./target/staging/docs/$DIR/api/scaladoc" && \
     mkdir -p "./target/staging/docs/$DIR/api/javadoc" && \
     cp -r "./target/cloudflow/core/target/scala-2.12/unidoc/" "./target/staging/docs/$DIR/api/scaladoc" && \

--- a/docs/docs-source/site.yml
+++ b/docs/docs-source/site.yml
@@ -8,7 +8,9 @@ content:
         - docs/docs-source/docs
         - docs/shared-content-source/docs
         - examples/snippets
-      branches: [master, v1.3.3-docs, v2.0.0-docs, v2.0.5-docs, v2.0.7-docs, v2.0.8-docs, v2.0.10-docs, v2.0.11-docs, v2.0.12-docs] # versioned content - add branches here
+      branches: [master, v1.3.3-docs] # versioned content - add branches here
+      # RESTORE ME
+      # branches: [master, v1.3.3-docs, v2.0.0-docs, v2.0.5-docs, v2.0.7-docs, v2.0.8-docs, v2.0.10-docs, v2.0.11-docs, v2.0.12-docs] # versioned content - add branches here
     - url: git@github.com:lightbend/cloudflow.git
       start-path: docs/homepage-source/docs
       branches: [master] # should always remain as master

--- a/docs/docs-source/site.yml
+++ b/docs/docs-source/site.yml
@@ -8,9 +8,7 @@ content:
         - docs/docs-source/docs
         - docs/shared-content-source/docs
         - examples/snippets
-      branches: [master, v1.3.3-docs] # versioned content - add branches here
-      # RESTORE ME
-      # branches: [master, v1.3.3-docs, v2.0.0-docs, v2.0.5-docs, v2.0.7-docs, v2.0.8-docs, v2.0.10-docs, v2.0.11-docs, v2.0.12-docs] # versioned content - add branches here
+      branches: [master, v1.3.3-docs, v2.0.0-docs, v2.0.5-docs, v2.0.7-docs, v2.0.8-docs, v2.0.10-docs, v2.0.11-docs, v2.0.12-docs] # versioned content - add branches here
     - url: git@github.com:lightbend/cloudflow.git
       start-path: docs/homepage-source/docs
       branches: [master] # should always remain as master


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the generation of the scaladocs and javadocs for all the official releases.

### Why are the changes needed?
Fix those links:
https://cloudflow.io/docs/2.0.11/api/scaladoc/cloudflow/streamlets/index.html
for every release.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
```
cd docs
make all
```
Browse the generated links to scaladocs for all versions 