### PR TITLE
Restructure Akka Streamlet lifecycle signalling

### DIFF
--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/HttpServerLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/scaladsl/HttpServerLogic.scala
@@ -198,6 +198,6 @@ abstract class HttpServerLogic(
       .andThen {
         case Failure(cause) ⇒
           system.log.error(cause, s"Failed to bind to $port.")
-          context.stop()
+          context.stopOnException(cause)
       }
 }

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -22,6 +22,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 import scala.collection.immutable
 import akka.{ Done, NotUsed }
 import akka.actor.ActorSystem
+import akka.annotation.InternalApi
 import akka.cluster.sharding.typed.scaladsl.Entity
 import akka.kafka.ConsumerMessage.{ Committable, CommittableOffset }
 import akka.kafka.CommitterSettings
@@ -91,7 +92,9 @@ trait AkkaStreamletContext extends StreamletContext {
 
   private[akkastream] def streamletExecution: StreamletExecution
 
-  protected object Stoppers {
+  @InternalApi
+  private[akkastream] object Stoppers {
+
     private val stoppers = new AtomicReference(Vector.empty[() ⇒ Future[Dun]])
 
     def add(f: () => Future[Dun]): Unit = stoppers.getAndUpdate(old => old :+ f)

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContext.scala
@@ -16,14 +16,16 @@
 
 package cloudflow.akkastream
 
-import scala.concurrent.Future
-import scala.collection.immutable
+import java.util.concurrent.atomic.AtomicReference
 
-import akka.NotUsed
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.collection.immutable
+import akka.{ Done, NotUsed }
 import akka.actor.ActorSystem
 import akka.cluster.sharding.typed.scaladsl.Entity
 import akka.kafka.ConsumerMessage.{ Committable, CommittableOffset }
 import akka.kafka.CommitterSettings
+import akka.stream.KillSwitches
 import akka.stream.scaladsl._
 import cloudflow.streamlets._
 
@@ -85,8 +87,30 @@ trait AkkaStreamletContext extends StreamletContext {
    * The system in which the AkkaStreamlet will be run.
    */
   implicit def system: ActorSystem
+  protected val killSwitch = KillSwitches.shared(streamletRef)
 
   private[akkastream] def streamletExecution: StreamletExecution
+
+  protected object Stoppers {
+    private val stoppers = new AtomicReference(Vector.empty[() ⇒ Future[Dun]])
+
+    def add(f: () => Future[Dun]): Unit = stoppers.getAndUpdate(old => old :+ f)
+
+    def stop(): Future[Done] = {
+      implicit val ec: ExecutionContext = system.dispatcher
+      Future
+        .sequence(
+          stoppers.get.map { f =>
+            f().recover {
+              case cause =>
+                system.log.error(cause, "onStop callback failed.")
+                Dun
+            }
+          }
+        )
+        .map(_ => Done)
+    }
+  }
 
   /**
    * Signals that the streamlet is ready to process data.
@@ -101,6 +125,21 @@ trait AkkaStreamletContext extends StreamletContext {
   def signalReady(): Boolean
 
   /**
+   * Marks the streamlet pod "ready" for Kubernetes.
+   */
+  def ready(localMode: Boolean): Unit
+
+  /**
+   * Marks the streamlet pod "alive" for Kubernetes.
+   */
+  def alive(localMode: Boolean): Unit
+
+  /**
+   * Stops the streamlet knowing an exception occured.
+   */
+  def stopOnException(nonFatal: Throwable): Unit
+
+  /**
    * Stops the streamlet.
    */
   def stop(): Future[Dun]
@@ -109,7 +148,7 @@ trait AkkaStreamletContext extends StreamletContext {
    * Registers a callback, which is called when the streamlet is stopped.
    * It is usually used to close resources that have been created in the streamlet.
    */
-  def onStop(f: () ⇒ Future[Dun]): Unit
+  def onStop(f: () => Future[Dun]): Unit = Stoppers.add(f)
 
   private[akkastream] def metricTags(): Map[String, String]
 }

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/internal/HealthCheckFiles.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/internal/HealthCheckFiles.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.akkastream.internal
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Paths }
+
+object HealthCheckFiles {
+
+  def createReady(streamletRef: String): Unit = createTempFile(readyFilename(streamletRef), streamletRef)
+  def deleteReady(streamletRef: String): Unit = Files.deleteIfExists(Paths.get(readyFilename(streamletRef)))
+
+  def createAlive(streamletRef: String): Unit = createTempFile(aliveFilename(streamletRef), streamletRef)
+  def deleteAlive(streamletRef: String): Unit = Files.deleteIfExists(Paths.get(aliveFilename(streamletRef)))
+
+  private def readyFilename(streamletRef: String) =
+    s"${streamletRef}-ready.txt"
+
+  private def aliveFilename(streamletRef: String) =
+    s"${streamletRef}-live.txt"
+
+  private def createTempFile(relativePath: String, streamletRef: String): Unit = {
+    val tempDir = System.getProperty("java.io.tmpdir")
+    val path    = java.nio.file.Paths.get(tempDir, relativePath)
+
+    Files.write(Paths.get(path.toString), s"an akka streamlet $streamletRef".getBytes(StandardCharsets.UTF_8))
+  }
+
+}

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/internal/StreamletExecutionImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/internal/StreamletExecutionImpl.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.akkastream.internal
+
+import akka.Done
+import akka.annotation.InternalApi
+import cloudflow.akkastream.{ AkkaStreamletContext, AkkaStreamletContextImpl }
+import cloudflow.streamlets.{ Dun, StreamletExecution }
+
+import scala.concurrent.{ Future, Promise }
+import scala.util.Try
+
+@InternalApi
+final class StreamletExecutionImpl(owner: AkkaStreamletContext) extends StreamletExecution {
+  private val readyPromise                         = Promise[Dun]()
+  private[akkastream] val completionPromise        = Promise[Dun]()
+  private[akkastream] def signalReady()            = readyPromise.trySuccess(Dun)
+  private[akkastream] def complete(res: Try[Done]) = completionPromise.tryComplete(res.map(_ => Dun))
+  private[akkastream] def complete(): Future[Dun] = {
+    completionPromise.trySuccess(Dun)
+    completed
+  }
+
+  override val ready: Future[Dun]     = readyPromise.future
+  override def stop(): Future[Dun]    = owner.stop()
+  override val completed: Future[Dun] = completionPromise.future
+}

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/AkkaRunner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/AkkaRunner.scala
@@ -198,6 +198,7 @@ final class AkkaRunner(akkaRunnerDefaults: AkkaRunnerDefaults) extends Runner[De
       volumeMounts = List(secretMount) ++ pvcVolumeMounts ++ getVolumeMounts(podsConfig, PodsConfig.CloudflowPodName) :+ volumeMount :+ Runner.DownwardApiVolumeMount
     )
 
+    // See cloudflow.akkastream.internal.HealthCheckFiles
     val fileNameToCheckLiveness  = s"${deployment.streamletName}-live.txt"
     val fileNameToCheckReadiness = s"${deployment.streamletName}-ready.txt"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

* This prepares for a better shutdown of Akka Streamlets as initiated in #847 
* More life-cycle code is shared between `AkkaStreamletContextImpl` and `TestContext`


### Why are the changes needed?

* Akka Streamlets should shut down more carefully to lessen the amount of half-processed records. This can be achieved by using Akka's coordinated shutdown mechanism.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
