### PR TITLE
Remove storage class, not needed anymore in the operator.

### DIFF
--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/ConfigurationScopeLayering.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/ConfigurationScopeLayering.scala
@@ -158,7 +158,6 @@ object ConfigurationScopeLayering {
           portMappingWithFallbackConfig
             .atPath(s"cloudflow.runner.streamlet.context.port_mappings.$port.config")
             // Need to retain the topic.id
-            // Adding bootstrap-servers key for backwards compatibility
             .withFallback(ConfigFactory.parseString(s"""
                 cloudflow.runner.streamlet.context.port_mappings.$port.id = ${topic.id}
               """))

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/FlinkRunner.scala
@@ -437,6 +437,7 @@ object FlinkResource {
     ImagePullPolicy               apiv1.PullPolicy             `json:"imagePullPolicy,omitempty" protobuf:"bytes,14,opt,name=imagePullPolicy,casttype=PullPolicy"`
     ImagePullSecrets              []apiv1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
     ServiceAccountName            string                       `json:"serviceAccountName,omitempty"`
+    SecurityContext               *apiv1.PodSecurityContext    `json:"securityContext,omitempty"`
     FlinkConfig                   FlinkConfig                  `json:"flinkConfig"`
     FlinkVersion                  string                       `json:"flinkVersion"`
     TaskManagerConfig             TaskManagerConfig            `json:"taskManagerConfig,omitempty"`
@@ -448,6 +449,7 @@ object FlinkResource {
     // Deprecated: use SavepointPath instead
     SavepointInfo                  SavepointInfo               `json:"savepointInfo,omitempty"`
     SavepointPath                  string                      `json:"savepointPath,omitempty"`
+    SavepointDisabled              bool                        `json:"savepointDisabled"`
     DeploymentMode                 DeploymentMode              `json:"deploymentMode,omitempty"`
     RPCPort                        *int32                      `json:"rpcPort,omitempty"`
     BlobPort                       *int32                      `json:"blobPort,omitempty"`
@@ -461,7 +463,9 @@ object FlinkResource {
     AllowNonRestoredState          bool                        `json:"allowNonRestoredState,omitempty"`
     ForceRollback                  bool                        `json:"forceRollback"`
     MaxCheckpointRestoreAgeSeconds *int32                      `json:"maxCheckpointRestoreAgeSeconds,omitempty"`
-  } */
+    TearDownVersionHash            string                      `json:"tearDownVersionHash,omitempty"`
+  }
+   */
 
   final case class Spec(
       image: String = "", // required parameter
@@ -497,7 +501,9 @@ object FlinkResource {
       submissionTime: Option[String] // may need to parse it as a date later on
   )
 
-  implicit val hostPathFmt: Format[HostPath]               = Json.format[HostPath]
+  implicit val hostPathFmt: Format[HostPath] = Json.format[HostPath]
+
+  // TODO figure out why this is not used for fsGroup.
   implicit val securityContextFmt: Format[SecurityContext] = Json.format[SecurityContext]
 
   implicit val namePathFmt: Format[NamePath]                     = Json.format[NamePath]

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/FlinkRunner.scala
@@ -345,7 +345,7 @@ final class FlinkRunner(flinkRunnerDefaults: FlinkRunnerDefaults) extends Runner
     // secret
     val secretVolume = Volume("secret-vol", Volume.Secret(deployment.secretName))
 
-    // Streamlet volume mounting
+    // Streamlet volume mounting (Defined by Streamlet.volumeMounts API)
     val streamletPvcVolume = streamletToDeploy.toVector.flatMap(_.descriptor.volumeMounts.map { mount ⇒
       Volume(mount.name, Volume.PersistentVolumeClaimRef(mount.pvcName))
     })
@@ -356,10 +356,6 @@ final class FlinkRunner(flinkRunnerDefaults: FlinkRunnerDefaults) extends Runner
   /**
    * For every volume we need a volume mount spec
    * // "volumeMounts": [
-   * //   {
-   * //     "name": "persistent-storage",
-   * //     "mountPath": "/mnt/flink/storage"
-   * //   },
    * //   {
    * //     "name": "config-vol",
    * //     "mountPath": "/etc/cloudflow-runner"

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/FlinkRunner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/FlinkRunner.scala
@@ -381,7 +381,6 @@ final class FlinkRunner(flinkRunnerDefaults: FlinkRunnerDefaults) extends Runner
 
 object FlinkResource {
 
-  final case class SecurityContext(fsGroup: Option[Int])
   final case class HostPath(path: String, `type`: String)
   final case class NamePath(name: String, path: String)
   final case class NamePathSecretType(name: String, path: String, secretType: String = "Generic")
@@ -472,6 +471,7 @@ object FlinkResource {
       imagePullPolicy: String = "Always",
       flinkVersion: String = "1.10",
       serviceAccountName: String = Name.ofServiceAccount,
+      securityContext: Option[PodSecurityContext] = None,
       jarName: String,
       parallelism: Int,
       entryClass: String = "",
@@ -502,9 +502,6 @@ object FlinkResource {
   )
 
   implicit val hostPathFmt: Format[HostPath] = Json.format[HostPath]
-
-  // TODO figure out why this is not used for fsGroup.
-  implicit val securityContextFmt: Format[SecurityContext] = Json.format[SecurityContext]
 
   implicit val namePathFmt: Format[NamePath]                     = Json.format[NamePath]
   implicit val namePathSecretTypeFmt: Format[NamePathSecretType] = Json.format[NamePathSecretType]

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/Runner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/Runner.scala
@@ -411,9 +411,6 @@ object PodsConfig {
     }.toList
   }
 
-  /**
-   * TODO How to make this optional?
-   */
   implicit val sourceConfReader: ValueReader[Volume.Source] = ValueReader.relative { config =>
     val res: Option[Volume.Source] = config.root().keySet().toArray().headOption.map {
       case "secret" =>

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/SparkRunner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/SparkRunner.scala
@@ -68,8 +68,6 @@ final class SparkRunner(sparkRunnerDefaults: SparkRunnerDefaults) extends Runner
   def resourceDefinition = implicitly[ResourceDefinition[CR]]
   def prometheusConfig   = PrometheusConfig(prometheusRules)
 
-  val requiresPersistentVolume = true
-
   val DriverPod   = "driver"
   val ExecutorPod = "executor"
 
@@ -204,9 +202,7 @@ final class SparkRunner(sparkRunnerDefaults: SparkRunnerDefaults) extends Runner
 
     val streamletToDeploy = app.spec.streamlets.find(streamlet ⇒ streamlet.name == deployment.streamletName)
 
-    // Streamlet volume mounting
-    // Volume mounting
-
+    // Streamlet volume mounting (Defined by Streamlet.volumeMounts API)
     val streamletPvcVolume = streamletToDeploy.toSeq.flatMap(_.descriptor.volumeMounts.map { mount ⇒
       Volume(mount.name, Volume.PersistentVolumeClaimRef(mount.pvcName))
     })
@@ -240,8 +236,6 @@ final class SparkRunner(sparkRunnerDefaults: SparkRunnerDefaults) extends Runner
           updateLabels ++
           Map(CloudflowLabels.StreamletNameLabel -> deployment.streamletName, CloudflowLabels.AppIdLabel -> appId)
             .mapValues(Name.ofLabelValue)
-
-    //import ctx.sparkRunnerDefaults._
 
     val driver = addDriverResourceRequirements(
       Driver(

--- a/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/ConfigurationScopeLayeringSpec.scala
+++ b/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/ConfigurationScopeLayeringSpec.scala
@@ -186,7 +186,7 @@ class ConfigurationScopeLayeringSpec
       maybeValidConfig.getConfig("connection-config").getString("connection.foo.bar") mustBe "default-baz"
       maybeValidConfig.getConfig("producer-config").getString("producer.foo.bar") mustBe "default-baz"
       maybeValidConfig.getConfig("consumer-config").getString("consumer.foo.bar") mustBe "default-baz"
-
+      configs.streamlet.getString("cloudflow.kafka.bootstrap-servers") mustBe "default-named-cluster:9092"
       // 'sometimes' port uses global topic configuration from app config, and falls back 'default' named config for bootstrap.servers and other config
       val sometimesPort   = "sometimes"
       val sometimesConfig = configs.streamlet.getConfig(s"cloudflow.runner.streamlet.context.port_mappings.$sometimesPort.config")

--- a/docs/docs-source/docs/modules/administration/pages/installation-prerequisites.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installation-prerequisites.adoc
@@ -38,7 +38,7 @@ See xref:how-to-install-and-use-strimzi.adoc[Installing Kafka with Strimzi] as a
 
 === Storage requirements (for use with Spark or Flink)
 
-**If you plan to write Cloudflow applications using Spark or Flink**, the Kubernetes cluster will need to have a storage class of the `ReadWriteMany` type installed. The name of the `ReadWriteMany` storage class name is required when installing Cloudflow.
+**If you plan to write Cloudflow applications using Spark or Flink**, the Kubernetes cluster will need to have a storage class of the `ReadWriteMany` type installed.
 
 For testing purposes, we suggest using the NFS Server Provisioner, which can be found here: https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner[NFS Server Provisioner Helm chart]
 
@@ -72,8 +72,6 @@ NAME                 PROVISIONER            AGE
 nfs                  cloudflow-nfs          29s
 standard (default)   kubernetes.io/gce-pd   2m57s
 ----
-
-NOTE: When installing Cloudflow, we will use the name `nfs` to indicate that Cloudflow should use the NFS storage class.
 
 NOTE:: The documented NFS storage class is very portable and has been verified to work on GKE, EKS, AKS and Openshift.
 

--- a/docs/docs-source/docs/modules/administration/pages/installing-cloudflow.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/installing-cloudflow.adoc
@@ -24,29 +24,8 @@ First, we add the Cloudflow Helm repository and update the local index:
   helm repo add cloudflow-helm-charts https://lightbend.github.io/cloudflow-helm-charts/
   helm repo update
 
-=== Installing (with persistent storage support for Spark or Flink)
+=== Installing
 
-Spark and Flink require persistent storage to keep state.
-Cloudflow creates persistent volume claims for this purpose, using a storage class.  The `persistentStorageClass` parameter sets the storage class to `nfs`. This storage class, as mentioned in xref:installation-prerequisites.adoc[], has to be of the type `ReadWriteMany`. In our example, we are using the `nfs` storage class.
-
-  cloudflow_operator.persistentStorageClass=nfs
-
-The `kafkaClusters.default.bootstrapServers` parameter sets the address and port of the Kafka cluster that Cloudflow will use. In this example, we have used the address of a Strimzi created Kafka cluster located in the `cloudflow` namespace.
-
-  kafkaClusters.default.bootstrapServers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
-
-The following command installs Cloudflow using the Helm chart:
-
-[subs="attributes+"]
-  helm install cloudflow cloudflow-helm-charts/cloudflow --namespace cloudflow \
-    --version "{cloudflow-version}" \
-    --set cloudflow_operator.persistentStorageClass=nfs \
-    --set kafkaClusters.default.bootstrapServers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
-
-
-=== Installing (without persistent storage support)
-
-If you do not intend to use Spark or Flink, you can omit the `persistentStorageClass` parameter.
 The `kafkaClusters.default.bootstrapServers` parameter sets the address and port of the default Kafka cluster that Cloudflow will use. In this example, we have used the address of a Strimzi created Kafka cluster located in the `cloudflow` namespace.
 
   kafkaClusters.default.bootstrapServers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092

--- a/docs/docs-source/docs/modules/administration/pages/upgrading-cloudflow.adoc
+++ b/docs/docs-source/docs/modules/administration/pages/upgrading-cloudflow.adoc
@@ -15,7 +15,6 @@ To upgrade Cloudflow in your cluster to the latest version run
 ----
   helm upgrade cloudflow cloudflow-helm-charts/cloudflow \
     --namespace cloudflow \
-    --set cloudflow_operator.persistentStorageClass=nfs \
     --set kafkaClusters.default.bootstrapServers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
 ----
 
@@ -30,7 +29,6 @@ To upgrade Cloudflow to a specific version, add the _--version_ flag. For exampl
 ----
   helm upgrade cloudflow cloudflow-helm-charts/cloudflow \
     --namespace cloudflow \
-    --set cloudflow_operator.persistentStorageClass=nfs \
     --version="{cloudflow-version}" \
     --set kafkaClusters.default.bootstrapServers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092
 ----

--- a/docs/docs-source/docs/modules/cli/pages/cloudflow_deploy.adoc
+++ b/docs/docs-source/docs/modules/cli/pages/cloudflow_deploy.adoc
@@ -8,7 +8,7 @@ Deploys a Cloudflow application to the cluster.
 == Prerequisites
 
 To deploy a Flink or Spark application it is necessary that a PVC named `cloudflow-flink' or `cloudflow-spark` already exists in a namespace that is equal 
-to the application name. This name is the exactly the same as the json file you'll use to deploy, excluding the extension. e.g. For a file `swiss-knife.json` the namespace would be `swiss-knife`. Cloudflow will automatically mount this PVCs in the streamlets themselves to allow any job, Flink or Spark, to store its state.
+to the application name. This name is exactly the same as the json file you'll use to deploy, excluding the extension. e.g. For a file `swiss-knife.json` the namespace would be `swiss-knife`. Cloudflow will automatically mount this PVCs in the streamlets themselves to allow any job, Flink or Spark, to store its state.
 
 == Synopsis
 

--- a/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -30,7 +30,7 @@ Each outlet also allows the user to define a partitioning function that will be 
 
 == `StreamletShape`
 
-The `StreamletShape` captures the connectivity and compatibility details of a Spark-based streamlet.
+The `StreamletShape` captures the connectivity and compatibility details of a Flink-based streamlet.
 It captures which—and how many—inlets and outlets the streamlet has.
 
 The `sbt-cloudflow` plugin extracts—amongst other things—the _shape_ from the streamlet that it finds on the classpath.
@@ -111,8 +111,7 @@ In Cloudflow, streamlets communicate with each other through Kafka - hence the s
 
 A Pipeline application can be stateful and use the full capabilities of _keyed state_ and _operator state_ in Flink. Stateful operators are fully supported within a Flink streamlet. All states are stored in state stores deployed on Kubernetes using _Persistent Volume Claims_ (PVCs) backed by a storage class that allows for _access mode_ `ReadWriteMany`.
 
-PVCs are automatically provisioned for each Cloudflow application.
-The volumes are claimed for as long as the Pipeline application is deployed, allowing for seamless re-deployment, upgrades, and recovery in case of failure.
+To deploy a Flink application it is necessary that a PVC already exists in the namespace for the application. Cloudflow will automatically mount this PVC in the streamlets themselves to allow state storage, as long as it has a `/mnt/flink/storage` mount path. Cloudflow will look for a PVC named `cloudflow-flink` by default that mounts this path. It is also possible to create a differently named PVC, that mounts `/mnt/flink/storage` and mount it using a configuration file, as described in xref:develop:cloudflow-configuration.adoc[The Configuration Model]. The access mode for the PVC has to be `ReadWriteMany`.
 
 Flink's runtime encodes all state and writes them into checkpoints. And since checkpoints in Flink offer an exactly-once guarantee of semantics, all application state are preserved safely throughout the lifetime of the streamlet. In case of failures, recovery will be done from checkpoints, and there will be no data loss.
 

--- a/docs/shared-content-source/docs/modules/develop/pages/use-spark-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-spark-streamlets.adoc
@@ -189,8 +189,7 @@ This includes stateful processing, from time-based aggregations to arbitrary sta
 All stateful processing relies on snapshots and a state store for the bookkeeping of the offsets processed and the  computed state at any time.
 In Cloudflow, this state store is deployed on Kubernetes using _Persistent Volume Claims_ (PVCs) backed by a storage class that allows for _access mode_ `ReadWriteMany`.
 
-PVCs are automatically provisioned for each Cloudflow application.
-The volumes are claimed for as long as the Pipeline application is deployed, allowing for seamless re-deployment, upgrades, and recovery in case of failure.
+To deploy a Spark application it is necessary that a PVC already exists in the namespace for the application. Cloudflow will automatically mount this PVC in the streamlets themselves to allow state storage, as long as it has a `/mnt/spark/storage` mount path. Cloudflow will look for a PVC named `cloudflow-spark` by default that mounts this path. It is also possible to create a differently named PVC, that mounts `/mnt/spark/storage` and mount it using a configuration file, as described in xref:develop:cloudflow-configuration.adoc[The Configuration Model]. The access mode for the PVC has to be `ReadWriteMany`.
 
 We can use the managed storage to safely store checkpoint data. 
 Checkpoint information is managed by Cloudflow for all streamlets that use the `context.writeStream` method.

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -62,7 +62,6 @@ prepare-cluster:
 	(helm upgrade -i cloudflow cloudflow-helm-charts/cloudflow \
 		--atomic \
 		--version "${version}" \
-		--set cloudflow_operator.persistentStorageClass=nfs \
 		--set kafkaClusters.default.bootstrapServers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092 \
 		--namespace cloudflow)
 	@echo '****** The cluster is ready for integration tests!'

--- a/release-notes/cloudflow-2.0.13.md
+++ b/release-notes/cloudflow-2.0.13.md
@@ -1,0 +1,26 @@
+# Cloudflow 2.0.13 Release Notes (November 9th, 2020)
+
+Today we are happy to announce the availability of Cloudflow 2.0.13. 
+
+This patch release fixes a number of issues that have been reported since 2.0.12.
+
+From version 2.0.13, Flink and Spark applications require a Persistent Volume Claim (PVC) to already exist, which will be used to store state.
+This change allows users to manage that data. It is safe to undeploy an application, Cloudflow will not delete the PVC since it did not create it.
+It also means that you do not have to specify a `storageClass` when installing Cloudflow.
+If you have existing applications that run on auto-created PVCs and you want to move to your own PVCs:
+- create a PVC named `cloudflow-flink` for Flink streamlets and `cloudflow-spark` for Spark streamlets in the namespace of the application and re-deploy the application.
+- it is also possible to configure a PVC mount in a configuration file, as long as it mounts a `/mnt/spark/storage` or `/mnt/flink/storage` path respectively for Spark or Flink, which will be used if Cloudflow cannot find a `cloudflow-flink` or `cloudflow-spark` PVC.
+
+It is now also possible to configure `taskmanager.taskSlots`, `parallelism.default` and `jobmanager.replicas` in a Flink config section, please see https://cloudflow.io/docs/current/develop/cloudflow-configuration.html#_configuring_a_runtime_using_the_runtime_scope.
+
+For existing users of previous 2.0.x versions of Cloudflow 2.0.10 it is important to note that Cloudflow must be upgraded with the helm charts, as described in the documentation. The Cloudflow kubectl plugin must also be upgraded to 2.0.13 (links below) and existing applications must be rebuilt with the 2.0.13 sbt-cloudflow plugin. Stricter verification has been put in place that all of these have been upgraded to 2.0.13 to prevent incompatibility issues.
+
+We have moved from Gitter to [Zulip](https://cloudflow.zulipchat.com/), please sign up and continue to chat with us there. 
+
+Details of the fixes in this release can be found [here](https://github.com/lightbend/cloudflow/releases/tag/v2.0.13). 
+
+**The Cloudflow 2.0.13 `kubectl` plugin can be downloaded using one of the following links:**
+
+* [Linux](https://bintray.com/lightbend/cloudflow-cli/download_file?file_path=kubectl-cloudflow-TODO-linux-amd64.tar.gz)
+* [MacOS](https://bintray.com/lightbend/cloudflow-cli/download_file?file_path=kubectl-cloudflow-TODO-darwin-amd64.tar.gz)
+* [Windows](https://bintray.com/lightbend/cloudflow-cli/download_file?file_path=kubectl-cloudflow-TODO-windows-amd64.tar.gz)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
The cloudflow operator does not create a default persistent volume claim anymore for Flink and Spark applications. Instead, users must provide an already existing PVC, when they deploy Flink / Spark applications.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Parameter not needed anymore, cleanup.
Also noticed that the securityContext was not set on Flink CR. added this as well.
### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
The user facing changes was already committed. This is just more cleanup.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
GKE [x]