### PR TITLE
Fix the it Makefile to provision the PVCs

### DIFF
--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -65,6 +65,10 @@ prepare-cluster:
 		--set cloudflow_operator.persistentStorageClass=nfs \
 		--set kafkaClusters.default.bootstrapServers=cloudflow-strimzi-kafka-bootstrap.cloudflow:9092 \
 		--namespace cloudflow)
+	@echo '****** Creating namspace and PVCs for Swiss-knife'
+	kubectl create namespace swiss-knife
+	kubectl create -f itest/resources/spark-pvc.yaml -n swiss-knife
+	kubectl create -f itest/resources/flink-pvc.yaml -n swiss-knife
 	@echo '****** The cluster is ready for integration tests!'
 
 .PHONY: spawn-gke-cluster


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the provisioning of PVCs as a followup from #841 

### Why are the changes needed?
To run integration tests on a newly crated cluster at version >= `2.0.13`

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Running deployments using the `Makefile` to prepare the cluster.