### PR TITLE
added fix to avoid confusion when /mnt/[runtime]/storage is already present in the conf but is not in mount-path

### DIFF
--- a/kubectl-cloudflow/config/config.go
+++ b/kubectl-cloudflow/config/config.go
@@ -148,7 +148,11 @@ func MountExistingPVCs(applicationSpec cfapp.CloudflowApplicationSpec, config *C
 // If the config has already that volume mount will not proceed
 // otherwise will add default PVC configuration.
 func mountExistingPVC(applicationSpec cfapp.CloudflowApplicationSpec, runtime string, config *Config) (string, error) {
-	if strings.Contains(config.String(), fmt.Sprintf("/mnt/%s/storage", runtime)) {
+	trimmedConfig := strings.Replace(config.String(), "\t", "", -1)
+	trimmedConfig = strings.Replace(trimmedConfig, " ", "", -1)
+	trimmedConfig = strings.Replace(trimmedConfig, "=", ":", -1)
+
+	if strings.Contains(trimmedConfig, fmt.Sprintf("mount-path:\"/mnt/%s/storage\"", runtime)) {
 		fmt.Printf(`the configuration provided is already mounting a PVC on '/mnt/%s/storage'.
 Skipping adding default configuration for mounting PVC cloudflow-%s on '/mnt/%s/storage'
 `, runtime, runtime, runtime)


### PR DESCRIPTION

### What changes were proposed in this pull request?
allow mounting PVC in presence on /mnt/[runtime]/storage in the config that has nothing to do with mount-path


### Why are the changes needed?
fix. Otherwise PVC weren't mounted as expected. 


### Does this PR introduce any user-facing change?
no


### How was this patch tested?
unit tests