### PR TITLE
Controlled shutdown of Kafka consumers

### DIFF
--- a/core/cloudflow-akka-tests/src/test/resources/logback-test.xml
+++ b/core/cloudflow-akka-tests/src/test/resources/logback-test.xml
@@ -1,12 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <logger name="akka" level="${LOGLEVEL_AKKA:-OFF}" />
+  <logger name="akka.actor.TimerScheduler" level="INFO"/>
+  <logger name="akka.kafka" level="DEBUG"/>
+
+  <logger name="org.apache.zookeeper" level="WARN"/>
+  <logger name="org.I0Itec.zkclient" level="WARN"/>
+
+  <logger name="kafka" level="WARN"/>
+  <logger name="org.apache.kafka" level="WARN"/>
+  <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
+  <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
+
+  <logger name="com.github.dockerjava" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
 
   <root level="${LOGLEVEL_ROOT:-OFF}">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
       <target>System.out</target>
       <encoder>
-        <pattern>%d{ISO8601} %-5level [%logger{0}] - %msg%n</pattern>
+        <pattern>%d{ISO8601} %-5level [%-20.20thread] [%-36.36logger{36}]  %msg%n%rEx</pattern>
       </encoder>
     </appender>
   </root>

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -41,6 +41,7 @@ object AkkaStreamletConsumerGroupSpec {
         stdout-loglevel = "OFF"
         loglevel = "OFF"
       }
+      cloudflow.akka.consumer-stop-timeout = 5 s
       """)
 }
 

--- a/core/cloudflow-akka/src/main/resources/reference.conf
+++ b/core/cloudflow-akka/src/main/resources/reference.conf
@@ -1,7 +1,12 @@
-akka.kafka.consumer.stop-timeout = 0s
-
 # Tuning parameter of how many sends that can run in parallel.
 akka.kafka.producer.parallelism = 10000
 
 # Delay commits until a next offset is observed for batch operators like mapConcat
 akka.kafka.committer.when = NextOffsetObserved
+
+# switch off the Alpakka Kafka's consumer stop delay
+akka.kafka.consumer.stop-timeout = 0s
+
+# Configure the time to wait after stopping the inflow before shutting down the Kafka consumer
+# This helps to process in-flight messages (and commits).
+cloudflow.streamlet.akka.consumer-stop-timeout = 10 s

--- a/core/cloudflow-akka/src/main/resources/reference.conf
+++ b/core/cloudflow-akka/src/main/resources/reference.conf
@@ -9,4 +9,4 @@ akka.kafka.consumer.stop-timeout = 0s
 
 # Configure the time to wait after stopping the inflow before shutting down the Kafka consumer
 # This helps to process in-flight messages (and commits).
-cloudflow.streamlet.akka.consumer-stop-timeout = 10 s
+cloudflow.akka.consumer-stop-timeout = 10 s

--- a/core/cloudflow-akka/src/main/resources/reference.conf
+++ b/core/cloudflow-akka/src/main/resources/reference.conf
@@ -1,5 +1,4 @@
-# Turn off stack dumps produced by Alpakka kafka
-akka.kafka.consumer.wakeup-debug = false
+akka.kafka.consumer.stop-timeout = 0s
 
 # Tuning parameter of how many sends that can run in parallel.
 akka.kafka.producer.parallelism = 10000

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -59,9 +59,7 @@ final class AkkaStreamletContextImpl(
   override def config: Config = streamletDefinition.config
 
   private val consumerStopTimeout: FiniteDuration =
-    if (config.hasPath("consumer-stop-timeout"))
-      FiniteDuration(config.getDuration("consumer-stop-timeout").toMillis, TimeUnit.MILLISECONDS).toCoarsest
-    else 5.seconds
+    FiniteDuration(sys.settings.config.getDuration("cloudflow.streamlet.akka.consumer-stop-timeout").toMillis, TimeUnit.MILLISECONDS).toCoarsest
 
   private val execution                               = new StreamletExecutionImpl(this)
   override val streamletExecution: StreamletExecution = execution

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -58,8 +58,9 @@ final class AkkaStreamletContextImpl(
 
   override def config: Config = streamletDefinition.config
 
+  private val StopTimeoutSetting = "cloudflow.akka.consumer-stop-timeout"
   private val consumerStopTimeout: FiniteDuration =
-    FiniteDuration(sys.settings.config.getDuration("cloudflow.streamlet.akka.consumer-stop-timeout").toMillis, TimeUnit.MILLISECONDS).toCoarsest
+    FiniteDuration(sys.settings.config.getDuration(StopTimeoutSetting).toMillis, TimeUnit.MILLISECONDS).toCoarsest
 
   private val execution                               = new StreamletExecutionImpl(this)
   override val streamletExecution: StreamletExecution = execution
@@ -445,7 +446,7 @@ final class AkkaStreamletContextImpl(
     KafkaControls
       .stopInflow()
       .flatMap { _ =>
-        log.debug("Waiting {} (consumer-stop-timeout) until {} consumers are shut down",
+        log.debug(s"Waiting {} ($StopTimeoutSetting) until {} consumers are shut down",
                   consumerStopTimeout: Any,
                   streamletDefinitionMsg: Any)
         akka.pattern.after(consumerStopTimeout)(Future.successful(Done))

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextImpl.scala
@@ -17,12 +17,15 @@
 package cloudflow.akkastream
 
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.immutable
 import scala.concurrent._
 import scala.util._
 import akka._
 import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import akka.annotation.InternalApi
 import akka.cluster.sharding.external.ExternalShardAllocationStrategy
 import akka.cluster.sharding.typed.scaladsl.{ ClusterSharding, Entity }
 import akka.kafka._
@@ -36,23 +39,85 @@ import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization._
 import cloudflow.streamlets._
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.{ DurationInt, FiniteDuration }
 
 /**
  * Implementation of the StreamletContext trait.
  */
+@InternalApi
 final class AkkaStreamletContextImpl(
     private[cloudflow] override val streamletDefinition: StreamletDefinition,
     sys: ActorSystem
 ) extends AkkaStreamletContext {
+  private val log                            = LoggerFactory.getLogger(classOf[AkkaStreamletContextImpl])
+  private val streamletDefinitionMsg: String = s"${streamletDefinition.streamletRef} (${streamletDefinition.streamletClass})"
 
   implicit val system: ActorSystem = sys
 
   override def config: Config = streamletDefinition.config
 
+  private val consumerStopTimeout: FiniteDuration =
+    if (config.hasPath("consumer-stop-timeout"))
+      FiniteDuration(config.getDuration("consumer-stop-timeout").toMillis, TimeUnit.MILLISECONDS).toCoarsest
+    else 5.seconds
+
   private val execution                               = new StreamletExecutionImpl(this)
   override val streamletExecution: StreamletExecution = execution
+
+  /**
+   * See https://doc.akka.io/docs/alpakka-kafka/current/consumer.html#controlled-shutdown
+   */
+  @InternalApi
+  object KafkaControls {
+    import akka.kafka.scaladsl.Consumer.Control
+    private val controls = new AtomicReference(Set[Control]())
+
+    def add(c: Control): Control = {
+      controls.updateAndGet(set => set + c)
+      c
+    }
+
+    def get: Set[Control] = controls.get()
+
+    /**
+     * Stop producing messages from all inlets and complete the streams.
+     *
+     * The underlying Kafka consumer stays alive so that it can handle commits for the
+     * already enqueued messages. It does not unsubscribe from any topics/partitions
+     * as that could trigger a consumer group rebalance.
+     */
+    def stopInflow()(implicit ec: ExecutionContext) = {
+      log.debug("Stopping inflow from {}", streamletDefinitionMsg)
+      Future
+        .sequence(controls.get.map(_.stop().recover {
+          case cause =>
+            log.error("stopping the consumer source failed.", cause)
+            Done
+        }))
+        .map(_ => Done)
+    }
+
+    /**
+     * Shut down the consumer `Source`.
+     *
+     * After this no more commits from enqueued messages can be handled.
+     * The actor will wait for acknowledgements of the already sent offset commits from the Kafka broker before shutting down.
+     */
+    def shutdownConsumers()(implicit ec: ExecutionContext) = {
+      log.debug("Shutting down consumers of {}", streamletDefinitionMsg)
+      Future
+        .sequence(
+          controls.get.map(_.shutdown().recover {
+            case cause =>
+              log.error("shutting down the consumer source failed.", cause)
+              Done
+          })
+        )
+        .map(_ => Done)
+    }
+  }
 
   // internal implementation that uses the CommittableOffset implementation to provide access to the underlying offsets
   private[akkastream] def sourceWithContext[T](inlet: CodecInlet[T]): SourceWithContext[T, CommittableOffset, _] = {
@@ -69,15 +134,12 @@ final class AkkaStreamletContextImpl(
 
     Consumer
       .sourceWithOffsetContext(consumerSettings, Subscriptions.topics(topic.name))
-      // TODO clean this up, once SourceWithContext has mapError and mapMaterializedValue
-      .asSource
-      .mapMaterializedValue(_ ⇒ NotUsed) // TODO we should likely use control to gracefully stop.
-      .via(handleTermination)
-      .map {
-        case (record, committableOffset) ⇒ inlet.codec.decode(record.value) -> committableOffset
+      .mapMaterializedValue { c =>
+        KafkaControls.add(c)
+        NotUsed
       }
-      .asSourceWithContext { case (_, committableOffset) ⇒ committableOffset }
-      .map { case (record, _) ⇒ record }
+      .map(record => inlet.codec.decode(record.value))
+      .via(handleTermination)
   }
 
   override def sourceWithCommittableContext[T](inlet: CodecInlet[T]): cloudflow.akkastream.scaladsl.SourceWithCommittableContext[T] =
@@ -128,13 +190,13 @@ final class AkkaStreamletContextImpl(
 
           Consumer
             .sourceWithOffsetContext(consumerSettings, subscription)
-            // TODO clean this up, once SourceWithContext has mapError and mapMaterializedValue
-            .asSource
-            .mapMaterializedValue(_ ⇒ NotUsed) // TODO we should likely use control to gracefully stop.
-            .via(handleTermination)
-            .map {
-              case (record, committableOffset) ⇒ inlet.codec.decode(record.value) -> committableOffset
+            .mapMaterializedValue { c =>
+              KafkaControls.add(c)
+              NotUsed
             }
+            .map(record => inlet.codec.decode(record.value))
+            .via(handleTermination)
+            .asSource
         }(system.dispatcher)
       }
       .asSourceWithContext { case (_, committableOffset) ⇒ committableOffset }
@@ -231,7 +293,10 @@ final class AkkaStreamletContextImpl(
 
     Consumer
       .plainSource(consumerSettings, Subscriptions.topics(topic.name))
-      .mapMaterializedValue(_ ⇒ NotUsed) // TODO we should likely use control to gracefully stop.
+      .mapMaterializedValue { c =>
+        KafkaControls.add(c)
+        NotUsed
+      }
       .via(handleTermination)
       .map { record ⇒
         inlet.codec.decode(record.value)
@@ -281,7 +346,10 @@ final class AkkaStreamletContextImpl(
 
           Consumer
             .plainSource(consumerSettings, subscription)
-            .mapMaterializedValue(_ ⇒ NotUsed) // TODO we should likely use control to gracefully stop.
+            .mapMaterializedValue { c =>
+              KafkaControls.add(c)
+              NotUsed
+            }
             .via(handleTermination)
             .map { record ⇒
               inlet.codec.decode(record.value)
@@ -329,14 +397,11 @@ final class AkkaStreamletContextImpl(
       .alsoTo(
         Sink.onComplete { res =>
           execution.complete(res)
-          val streamletDefinitionMsg: String = s"${streamletDefinition.streamletRef} (${streamletDefinition.streamletClass})"
           res match {
             case Success(_) ⇒
-              system.log.info(
-                s"Stream has completed. Shutting down streamlet $streamletDefinitionMsg."
-              )
+              log.info("Stream has completed. Shutting down streamlet {}.", streamletDefinitionMsg)
             case Failure(e) ⇒
-              system.log.error(e, s"Stream has failed. Shutting down streamlet $streamletDefinitionMsg.")
+              log.error(s"Stream has failed. Shutting down streamlet $streamletDefinitionMsg.", e)
           }
         }
       )
@@ -348,11 +413,19 @@ final class AkkaStreamletContextImpl(
     // the streamlet context has been created and the streamlet is ready to take requests
     // needs to be done only in cluster mode - not in local running
     if (!localMode) HealthCheckFiles.createReady(streamletRef)
+
+    import system.dispatcher
     CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, s"akka-streamlet-${streamletRef}-unbind") { () =>
       serviceUnbind()
     }
     CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseBeforeClusterShutdown, s"akka-streamlet-${streamletRef}-stop") { () =>
-      stop().map(_ => Done)(system.dispatcher)
+      stop().map(_ => Done)
+    }
+    CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseActorSystemTerminate, s"akka-streamlet-${streamletRef}-terminate") { () =>
+      Future {
+        HealthCheckFiles.deleteAlive(streamletRef)
+        Done
+      }
     }
   }
 
@@ -362,19 +435,33 @@ final class AkkaStreamletContextImpl(
     // needs to be done only in cluster mode - not in local running
     if (!localMode) HealthCheckFiles.createAlive(streamletRef)
 
-  private def serviceUnbind(): Future[Done] =
-    Future {
-      HealthCheckFiles.deleteReady(streamletRef)
-      Done
-    }(system.dispatcher)
+  private def serviceUnbind(): Future[Done] = {
+    HealthCheckFiles.deleteReady(streamletRef)
+    KafkaControls.stopInflow()(system.dispatcher)
+  }
 
   override def stop(): Future[Dun] = {
     HealthCheckFiles.deleteReady(streamletRef)
 
-    killSwitch.shutdown()
     import system.dispatcher
-    Stoppers
-      .stop()
+    KafkaControls
+      .stopInflow()
+      .flatMap { _ =>
+        log.debug("Waiting {} (consumer-stop-timeout) until {} consumers are shut down",
+                  consumerStopTimeout: Any,
+                  streamletDefinitionMsg: Any)
+        akka.pattern.after(consumerStopTimeout)(Future.successful(Done))
+      }
+      .flatMap { _ =>
+        KafkaControls.shutdownConsumers()
+      }
+      .map { _ =>
+        // The kill switch wouldn't do anything in most cases
+        // as `stopInflow` completes the sources and the stream should be completed by now
+        log.debug("Triggering kill switch of {}", streamletDefinitionMsg)
+        killSwitch.shutdown()
+      }
+      .flatMap(_ => Stoppers.stop())
       .flatMap(_ => execution.complete())
   }
 

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/internal/HealthCheckFiles.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/internal/HealthCheckFiles.scala
@@ -37,7 +37,8 @@ object HealthCheckFiles {
     val tempDir = System.getProperty("java.io.tmpdir")
     val path    = java.nio.file.Paths.get(tempDir, relativePath)
 
-    Files.write(Paths.get(path.toString), s"an akka streamlet $streamletRef".getBytes(StandardCharsets.UTF_8))
+    Files.write(path, s"an akka streamlet $streamletRef".getBytes(StandardCharsets.UTF_8))
+    path.toFile.deleteOnExit()
   }
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This implements a more controlled Consumer shutdown as described in https://doc.akka.io/docs/alpakka-kafka/current/consumer.html#controlled-shutdown

References #848 

### Why are the changes needed?

This lowers the risk of messages being half processed during streamlet shutdown.
It improves chances that commits reach the Kafka consumer during shutdown.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

A new streamlet setting `consumer-stop-timeout` is introduced.
The underlying `akka.kafka.consumer.stop-timeout` can be overwritten to 0s for streamlets.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
