### PR TITLE
Fix docs generation for cross-build

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -74,14 +74,15 @@ lazy val root =
       unidocAllSources in (JavaUnidoc, unidoc) ~= { v =>
         v.map(_.filterNot(f => javadocDisabledFor.exists(f.getAbsolutePath.endsWith(_))))
       },
-      unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(
+      ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(
             streamlets,
             akkastream,
             akkastreamUtil,
             akkastreamTestkit,
             spark,
             sparkTestkit
-          )
+          ),
+      JavaUnidoc / unidoc / unidocProjectFilter := (ScalaUnidoc / unidoc / unidocProjectFilter).value
     )
     .withId("root")
     .settings(commonSettings)
@@ -482,7 +483,6 @@ lazy val operator =
     )
     .settings(
       scalaVersion := Version.ScalaOperator,
-      crossScalaVersions := Vector(scalaVersion.value),
       organization := "com.lightbend.cloudflow",
       skip in publish := true,
       mainClass in Compile := Some("cloudflow.operator.Main"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
We need to fix the `unidoc` failing task on master

### Why are the changes needed?
The `unidoc` filter on package was not correctly applied to the `JavaDoc` generation, causing a recompilation of un-needed sub-projects.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
```
cd core
sbt clean unidoc
```