### PR TITLE
Downgrade Sbt version for users

### DIFF
--- a/docs/docs-source/docs/modules/get-started/pages/run-in-sandbox.adoc
+++ b/docs/docs-source/docs/modules/get-started/pages/run-in-sandbox.adoc
@@ -13,6 +13,8 @@ The `sbt runLocal` command allows you to run your application on your local mach
 NOTE: If you are trying to run the examples contained in the upstream cloudflow repository remember to run
 `export CLOUDFLOW_VERSION={cloudflow-version}` before invoking `sbt`.
 
+NOTE: Currently Cloudflow can run with sbt up to version 1.3.X.
+
 . From the `sbt` shell, invoke `runLocal`:
 +
 You should see output similar to the following:

--- a/docs/docs-source/docs/modules/get-started/pages/setup-example-project-configure-build.adoc
+++ b/docs/docs-source/docs/modules/get-started/pages/setup-example-project-configure-build.adoc
@@ -13,6 +13,8 @@ https://github.com/lightbend/cloudflow[`cloudflow` project on Github].
 To use the examples directly remember to run
 `export CLOUDFLOW_VERSION={cloudflow-version}` before invoking `sbt`.
 
+NOTE: Currently Cloudflow can run with sbt up to version 1.3.X.
+
 A typical Cloudflow application uses the organization shown below. 
 We will implement the example in Scala. 
 

--- a/docs/shared-content-source/docs/modules/get-started/pages/prepare-development-environment.adoc
+++ b/docs/shared-content-source/docs/modules/get-started/pages/prepare-development-environment.adoc
@@ -9,7 +9,7 @@ Please see xref:administration:installing-cloudflow.adoc[Installing Cloudflow] f
 First, make sure that you have the following installed:
 
 * Java(JDK) >= 8
-* https://www.scala-sbt.org/[sbt,window=_blank], version 1.2.8 or higher
+* https://www.scala-sbt.org/[sbt,window=_blank], version 1.2.8 or higher (currently Cloudflow supports sbt up to version 1.3.X)
 * https://www.docker.com/community-edition[Docker,window=_blank], version 18.09 or higher
 * https://helm.sh/docs/intro/install/[Helm,window=_blank], version 2 or higher. We recommend version 3 to avoid dealing with tiller.
 * https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl,window=_blank]

--- a/examples/call-record-aggregator/project/build.properties
+++ b/examples/call-record-aggregator/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/connected-car-cluster-sharding/project/build.properties
+++ b/examples/connected-car-cluster-sharding/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-grpc-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/akkastreams-grpc-scala/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-grpc-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/akkastreams-java/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/akkastreams-scala/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/akkastreams-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/build-akka-streamlets-java/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/build-akka-streamlets-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/build-akka-streamlets-scala/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/build-akka-streamlets-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/build-flink-streamlets-scala/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/build-flink-streamlets-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/build-spark-streamlets-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/sensor-data-scala/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/sensor-data-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/snippets/modules/ROOT/examples/spark-scala/project/build.properties
+++ b/examples/snippets/modules/ROOT/examples/spark-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/spark-sensors-proto/project/build.properties
+++ b/examples/spark-sensors-proto/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/spark-sensors/project/build.properties
+++ b/examples/spark-sensors/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/taxi-ride-proto/project/build.properties
+++ b/examples/taxi-ride-proto/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/taxi-ride/project/build.properties
+++ b/examples/taxi-ride/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/templates/single-backend-java/project/build.properties
+++ b/examples/templates/single-backend-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/templates/single-backend-scala/project/build.properties
+++ b/examples/templates/single-backend-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13

--- a/examples/tensorflow-akka/project/build.properties
+++ b/examples/tensorflow-akka/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.3.13


### PR DESCRIPTION
### What changes were proposed in this pull request?
Downgrade Sbt version for the users

### Why are the changes needed?
`runLocal` is broken with sbt 1.4

Long story short:
 - we run Embedded Kafka from sbt
 - Embedded Kafka inline the Scala version
 - The inlined version happens to be 2.12.11
 - Everything works with sbt 1.3 that uses 2.12.10 (that probably gets evicted in favor of 2.12.11 declared in our own plugin)
 - It doesn't work with sbt 1.4 since Scala becomes 2.12.12

### Does this PR introduce any user-facing change?
Yes and is documented accordingly in the docs

### How was this patch tested?
`runLocal` in taxi-ride