### PR TITLE
Fix failing GH Actions CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2.0.3
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.14.2
       id: go
@@ -86,7 +86,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2.0.3
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.14.2
       id: go


### PR DESCRIPTION
Just updating the `setup-go` action seems to do the job 😄 