### PR TITLE
Use testcontainers instead of EmbeddedKafka

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -204,7 +204,7 @@ lazy val akkastreamTests =
       libraryDependencies ++= Vector(
             AkkaHttpTestkit,
             AkkaHttpSprayJsonTest,
-            EmbeddedKafka % Test,
+            TestcontainersKafka % Test,
             Logback       % Test,
             ScalaTest,
             Junit

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -241,8 +241,8 @@ lazy val spark =
             SparkProto,
             ScalaTest
           ),
-      dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.11.2" ,
-      dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.2",
+      dependencyOverrides += "com.fasterxml.jackson.core"   % "jackson-core"              % "2.11.2",
+      dependencyOverrides += "com.fasterxml.jackson.core"   % "jackson-databind"          % "2.11.2",
       dependencyOverrides += "com.fasterxml.jackson.module" % "jackson-module-scala_2.12" % "2.11.2"
     )
     .settings(
@@ -260,8 +260,8 @@ lazy val sparkTestkit =
             ScalaTestUnscoped,
             Junit
           ),
-      dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.11.2" ,
-      dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.2",
+      dependencyOverrides += "com.fasterxml.jackson.core"   % "jackson-core"              % "2.11.2",
+      dependencyOverrides += "com.fasterxml.jackson.core"   % "jackson-databind"          % "2.11.2",
       dependencyOverrides += "com.fasterxml.jackson.module" % "jackson-module-scala_2.12" % "2.11.2"
     )
 
@@ -276,8 +276,8 @@ lazy val sparkTests =
             ScalaTest,
             Junit
           ),
-      dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.11.2" ,
-      dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.2",
+      dependencyOverrides += "com.fasterxml.jackson.core"   % "jackson-core"              % "2.11.2",
+      dependencyOverrides += "com.fasterxml.jackson.core"   % "jackson-databind"          % "2.11.2",
       dependencyOverrides += "com.fasterxml.jackson.module" % "jackson-module-scala_2.12" % "2.11.2"
     )
     .settings(
@@ -388,13 +388,15 @@ lazy val plugin =
       libraryDependencies ++= Vector(
             FastClasspathScanner,
             ScalaPbCompilerPlugin,
-            EmbeddedKafka,
             Logback               % Test,
             "com.github.mutcianm" %% "ascii-graphs" % "0.0.6",
-            ScalaTest
+            ScalaTest,
+            TestcontainersKafka,
+            KafkaClient
           ),
-      scriptedLaunchOpts := { scriptedLaunchOpts.value ++
-        Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+      scriptedLaunchOpts := {
+        scriptedLaunchOpts.value ++
+          Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
       },
       scriptedBufferLog := false
     )
@@ -439,7 +441,7 @@ lazy val localRunner =
     .settings(
       scalafmtOnCompile := true
     )
-lazy val operatorActions = 
+lazy val operatorActions =
   cloudflowModule("cloudflow-operator-actions")
     .enablePlugins(
       ScalafmtPlugin
@@ -532,7 +534,7 @@ lazy val operator =
             "-language:_",
             "-unchecked"
           ),
-      scalacOptions in (Compile, console) := (scalacOptions in (Global)).value.filter(_ == "-Ywarn-unused-import"),
+      scalacOptions in (Compile, console) := (scalacOptions in (Global)).value.filter(_ == "-Ywarn-unused-import")
     )
     .settings(
       buildInfoKeys := Seq[BuildInfoKey](

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -30,13 +30,10 @@ import cloudflow.akkastream.testdata._
 import cloudflow.streamlets._
 import cloudflow.streamlets.avro._
 
-import net.manub.embeddedkafka._
 import org.scalatest.time._
 
 object AkkaStreamletConsumerGroupSpec {
-  val kafkaPort = 1234
-  val zkPort    = 5678
-  val config    = ConfigFactory.parseString("""
+  val config = ConfigFactory.parseString("""
       akka {
         stdout-loglevel = "OFF"
         loglevel = "OFF"
@@ -47,19 +44,10 @@ object AkkaStreamletConsumerGroupSpec {
 
 import AkkaStreamletConsumerGroupSpec._
 
-class AkkaStreamletConsumerGroupSpec extends EmbeddedKafkaSpec(kafkaPort, zkPort, ActorSystem("test", config)) {
+class AkkaStreamletConsumerGroupSpec extends EmbeddedKafkaSpec(ActorSystem("test", config)) {
+  import system.dispatcher
 
   implicit override val patienceConfig = PatienceConfig(timeout = Span(10, Seconds), interval = Span(20, Millis))
-
-  override def createKafkaConfig: EmbeddedKafkaConfig =
-    EmbeddedKafkaConfig(kafkaPort,
-                        zooKeeperPort,
-                        Map(
-                          "broker.id"                        -> "1",
-                          "num.partitions"                   -> "53",
-                          "offsets.topic.replication.factor" -> "1",
-                          "offsets.topic.num.partitions"     -> "3"
-                        ))
 
   "Akka streamlet instances" should {
     "consume from an outlet as a group per streamlet reference" in {

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -44,7 +44,7 @@ object AkkaStreamletConsumerGroupSpec {
 
 import AkkaStreamletConsumerGroupSpec._
 
-class AkkaStreamletConsumerGroupSpec extends EmbeddedKafkaSpec(ActorSystem("test", config)) {
+class AkkaStreamletConsumerGroupSpec extends TestcontainersKafkaSpec(ActorSystem("test", config)) {
   import system.dispatcher
 
   implicit override val patienceConfig = PatienceConfig(timeout = Span(10, Seconds), interval = Span(20, Millis))

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/EmbeddedKafkaSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/EmbeddedKafkaSpec.scala
@@ -31,7 +31,7 @@ import org.testcontainers.{ utility => tcutility }
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.wait.strategy.Wait
 
-abstract class EmbeddedKafkaSpec(system: ActorSystem)
+abstract class TestcontainersKafkaSpec(system: ActorSystem)
     extends TestKit(system)
     with Suite
     with WordSpecLike

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/EmbeddedKafkaSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/EmbeddedKafkaSpec.scala
@@ -23,7 +23,6 @@ import scala.util.Try
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import akka.kafka.testkit.internal.TestFrameworkInterface
-// import akka.kafka.testkit.scaladsl._
 
 import org.scalatest._
 import org.scalatest.Suite

--- a/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
+++ b/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
@@ -56,7 +56,6 @@ object LocalRunner extends StreamletLoader {
     })
 
   val BootstrapServersKey = "bootstrap.servers"
-  val EmbeddedKafkaKey    = "embedded-kafka"
 
   /**
    * Starts the local runner using an Application Descriptor JSON file and

--- a/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
+++ b/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
@@ -64,15 +64,17 @@ object LocalRunner extends StreamletLoader {
    *
    * @param args: args(0) must be the JSON-encoded Application Descriptor
    *             args(1) must be the file to use for the output
+   *             args(2) must be the port where kafka is running on
    */
   def main(args: Array[String]): Unit = {
-    val usage = "Usage: localRunner <applicationFileJson> <outputFile> [localConfigFile]"
-    val (appDescriptorFilename, outputFilename, localConfig) = args.toList match {
-      case app :: out :: conf :: Nil => (app, out, ConfigFactory.parseFile(new File(conf)).resolve)
-      case app :: out :: Nil         => (app, out, ConfigFactory.empty())
-      case Nil                       => throw new RuntimeException(s"Missing application configuration file and output file for Local Runner\n$usage")
-      case _ :: Nil                  => throw new RuntimeException(s"Missing output file for Local Runner\n$usage")
-      case _                         => throw new RuntimeException(s"Missing parameters for Local Runner. \n$usage")
+    val usage = "Usage: localRunner <applicationFileJson> <outputFile> <kafka-port> [localConfigFile]"
+    val (appDescriptorFilename, outputFilename, kafkaPort, localConfig) = args.toList match {
+      case app :: out :: kafkaPort :: conf :: Nil => (app, out, kafkaPort, ConfigFactory.parseFile(new File(conf)).resolve)
+      case app :: out :: kafkaPort :: Nil         => (app, out, kafkaPort, ConfigFactory.empty())
+      case Nil                                    => throw new RuntimeException(s"Missing application configuration file and output file for Local Runner\n$usage")
+      case _ :: Nil                               => throw new RuntimeException(s"Missing output file for Local Runner\n$usage")
+      case _ :: _ :: Nil                          => throw new RuntimeException(s"Missing kafka port\n$usage")
+      case _                                      => throw new RuntimeException(s"Missing parameters for Local Runner. \n$usage")
     }
 
     val outputFile = new File(outputFilename)
@@ -87,7 +89,7 @@ object LocalRunner extends StreamletLoader {
         System.setErr(new PrintStream(fos))
         readDescriptorFile(appDescriptorFilename) match {
           case Success(applicationDescriptor) =>
-            run(applicationDescriptor, localConfig)
+            run(applicationDescriptor, localConfig, kafkaPort)
           case Failure(ex) =>
             log.error(s"Failed JSON unmarshalling of application descriptor file [${appDescriptorFilename}].", ex)
             System.exit(1)
@@ -96,9 +98,7 @@ object LocalRunner extends StreamletLoader {
     }
   }
 
-  private def run(appDescriptor: ApplicationDescriptor, localConfig: Config): Unit = {
-
-    val kafkaPort = 9093
+  private def run(appDescriptor: ApplicationDescriptor, localConfig: Config, kafkaPort: String): Unit = {
     val bootstrapServers =
       if (localConfig.hasPath(BootstrapServersKey)) localConfig.getString(BootstrapServersKey) else s"localhost:$kafkaPort"
     val topicConfig = ConfigFactory.parseString(s"""bootstrap.servers = "$bootstrapServers"""")

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -12,8 +12,9 @@ object Version {
   val ScalaOperator = "2.13.3"
   val Spark         = "2.4.5"
   val Flink         = "1.10.0"
-  val KafkaClients  = "2.5.0"
   val EmbeddedKafka = "2.5.0" 
+  val KafkaClients  = "2.5.0"
+  val TestcontainersKafka = "1.15.0" 
 }
 
 object Library {
@@ -41,8 +42,9 @@ object Library {
 
   val AkkaGrpcRuntime = "com.lightbend.akka.grpc" %% "akka-grpc-runtime" % Version.AkkaGrpc
 
-  val EmbeddedKafkaOrg      = "io.github.embeddedkafka"
-  val EmbeddedKafka         = EmbeddedKafkaOrg        %% "embedded-kafka"           % Version.EmbeddedKafka 
+  val EmbeddedKafka         = "io.github.embeddedkafka"        %% "embedded-kafka"           % Version.EmbeddedKafka 
+  val TestcontainersKafka   = "org.testcontainers"     % "kafka"                    % Version.TestcontainersKafka
+  val KafkaClient           = "org.apache.kafka"      %% "kafka"                    % "2.5.1"
   val Ficus                 = "com.iheart"            %% "ficus"                    % "1.4.7"
   val JodaTime              = "joda-time"              % "joda-time"                % "2.10.6"
   val Config                = "com.typesafe"           % "config"                   % "1.3.4"

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -12,7 +12,6 @@ object Version {
   val ScalaOperator = "2.13.3"
   val Spark         = "2.4.5"
   val Flink         = "1.10.0"
-  val EmbeddedKafka = "2.5.0" 
   val KafkaClients  = "2.5.0"
   val TestcontainersKafka = "1.15.0" 
 }
@@ -42,7 +41,6 @@ object Library {
 
   val AkkaGrpcRuntime = "com.lightbend.akka.grpc" %% "akka-grpc-runtime" % Version.AkkaGrpc
 
-  val EmbeddedKafka         = "io.github.embeddedkafka"        %% "embedded-kafka"           % Version.EmbeddedKafka 
   val TestcontainersKafka   = "org.testcontainers"     % "kafka"                    % Version.TestcontainersKafka
   val KafkaClient           = "org.apache.kafka"      %% "kafka"                    % "2.5.1"
   val Ficus                 = "com.iheart"            %% "ficus"                    % "1.4.7"

--- a/core/project/InternalRelease.scala
+++ b/core/project/InternalRelease.scala
@@ -1,23 +1,18 @@
 import sbt._
 
 import sbtrelease.ReleasePlugin.autoImport.ReleaseKeys.releaseCommand
-import sbtrelease.ReleasePlugin.autoImport.{
-  releaseProcess,
-  ReleaseStep,
-  releaseVersion,
-  releaseNextVersion
-}
-import sbtrelease.{versionFormatError, ReleaseStateTransformations, Version => RVersion}
+import sbtrelease.ReleasePlugin.autoImport.{ releaseNextVersion, releaseProcess, releaseVersion, ReleaseStep }
+import sbtrelease.{ versionFormatError, ReleaseStateTransformations, Version => RVersion }
 import sbtrelease.ReleaseStateTransformations._
 import scala.util.Try
 
 object InternalReleaseCommand {
+
   /**
    * Command to publish development builds.
    * Builds and publishs version <version>-<commit_count>-<commit_hash>, and push the tag v<version>-<commit_count>-<commit_hash>.
    */
-  val command: Command = Command.make("internalRelease"){ state =>
-
+  val command: Command = Command.make("internalRelease") { state =>
     // tweak the keys used by sbt-release, for develop build
     val extracted = Project.extract(state)
     val updatedState = extracted.appendWithSession(List(
@@ -48,7 +43,7 @@ object InternalReleaseCommand {
     if (Try("git --version".!!).isSuccess) {
       if (Try("git rev-parse --git-dir".!!).isSuccess) {
         val commits = "git rev-list --count HEAD".!!.trim()
-        val hash = "git rev-parse --short HEAD".!!.trim()
+        val hash    = "git rev-parse --short HEAD".!!.trim()
         s"-pre-${commits}-${hash}"
       } else {
         sys.error("The current project is not a valid Git project.")
@@ -60,13 +55,11 @@ object InternalReleaseCommand {
   }
 
   // extract the checks we want that are attached to other commands
-  lazy val checkUpstream = ReleaseStateTransformations.pushChanges.check
+  lazy val checkUpstream    = ReleaseStateTransformations.pushChanges.check
   lazy val initialVcsChecks = ReleaseStateTransformations.commitReleaseVersion.check
 
   // attach the checks to the tagRelease step
   lazy val tagReleaseWithChecks: ReleaseStep =
-    ReleaseStep(
-      ReleaseStateTransformations.tagRelease,
-      s => checkUpstream(initialVcsChecks(s)))
+    ReleaseStep(ReleaseStateTransformations.tagRelease, s => checkUpstream(initialVcsChecks(s)))
 
 }

--- a/core/project/WhitesourceLicensePlugin.scala
+++ b/core/project/WhitesourceLicensePlugin.scala
@@ -4,12 +4,12 @@ import sbtwhitesource.WhiteSourcePlugin.autoImport._
 
 object LicensePlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
-  override def trigger = allRequirements
+  override def trigger  = allRequirements
 
   override def buildSettings: Seq[Setting[_]] =
     List(
-      whitesourceProduct               := "cloudflow",
-      whitesourceAggregateProjectName  := "cloudflow-streamlets-1.0-stable",
+      whitesourceProduct := "cloudflow",
+      whitesourceAggregateProjectName := "cloudflow-streamlets-1.0-stable",
       // The project token is just a project UID, not a password.
       whitesourceAggregateProjectToken := "7a76fc644e2d4ffc8a1b8ca9a9406e78624994604c6f43fc8bdbbda4a188d62a"
     )

--- a/core/project/plugins.sbt
+++ b/core/project/plugins.sbt
@@ -1,25 +1,24 @@
+addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter"   % "0.5.0")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"         % "2.2.1")
+addSbtPlugin("com.dwijnand"      % "sbt-dynver"           % "4.1.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release"          % "1.0.11")
+addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"        % "0.9.0")
+addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.9.2")
+addSbtPlugin("com.julianpeeters" % "sbt-avrohugger"       % "2.0.0-RC18")
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent"        % "0.1.5")
+addSbtPlugin("com.lightbend"     % "sbt-whitesource"      % "0.1.16")
 
-addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.5.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
-addSbtPlugin("com.julianpeeters" % "sbt-avrohugger" % "2.0.0-RC18")
-addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.16")
-
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.8.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.24")
-addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker"          % "1.8.0")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager" % "1.3.24")
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent"       % "0.1.5")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"          % "5.2.0")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"             % "2.0.1")
 
 // to generate one complete scaladoc site and one complete javadoc site
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.8")
+addSbtPlugin("org.foundweekends" % "sbt-bintray"  % "0.5.6")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.2"

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
@@ -216,7 +216,7 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
         Thread.currentThread().setContextClassLoader(cl)
       }
 
-    log.debug(s"Setting up embedded Kafka broker on port: $kafkaPort")
+    log.debug(s"Setting up Kafka broker in Docker on port: $kafkaPort")
 
     topics.foreach { topic =>
       log.debug(s"Kafka Setup: creating topic: $topic")

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
@@ -18,6 +18,7 @@ package cloudflow.sbt
 
 import java.nio.file._
 import java.io._
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.sys.process.Process
 import scala.sys.SystemProperties
@@ -30,7 +31,8 @@ import sbt.Keys._
 import spray.json._
 import com.github.mdr.ascii.layout._
 import com.github.mdr.ascii.graph._
-import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
+import org.testcontainers.{ utility => tcutility }
+import org.testcontainers.containers.KafkaContainer
 import cloudflow.blueprint.deployment.{ ApplicationDescriptor, StreamletInstance }
 import cloudflow.blueprint.deployment.ApplicationDescriptorJsonFormat._
 import cloudflow.sbt.CloudflowKeys._
@@ -48,11 +50,6 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
   val Slf4jLog4jBridge = "org.slf4j" % "slf4j-log4j12" % "1.7.30"
   val Log4J            = "log4j" % "log4j" % "1.2.17"
 
-  // kafka config keys
-  val BootstrapServersKey = "bootstrap.servers"
-  val EmbeddedKafkaKey    = "embedded-kafka"
-
-  // kafka local values
   val KafkaPort = 9093
 
   // Banner decorators
@@ -133,7 +130,7 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
               }
               .distinct
               .sorted
-            setupKafka(KafkaPort, topics)
+            val kafkaPort = setupKafka(topics)
 
             printAppLayout(resolveConnections(appDescriptor))
             printInfo(runtimeDescriptorByProject, tempDir.toFile, topics, localConfig.message)
@@ -142,7 +139,7 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
               case (pid, rd) =>
                 val classpath               = cpByProject(pid)
                 val loggingPatchedClasspath = prepareLoggingInClasspath(classpath, logDependencies)
-                runPipelineJVM(rd.appDescriptorFile, loggingPatchedClasspath, rd.outputFile, rd.logConfig, rd.localConfPath)
+                runPipelineJVM(rd.appDescriptorFile, loggingPatchedClasspath, rd.outputFile, rd.logConfig, rd.localConfPath, kafkaPort)
             }
 
             println(s"Running ${appDescriptor.appId}  \nTo terminate, press [ENTER]\n")
@@ -199,25 +196,67 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
     s"$org/$name"
   }
 
+  val kafka = new AtomicReference[KafkaContainer]()
+
+  def setupKafka(topics: Seq[String])(implicit log: Logger) = {
+
+    val cl = Thread.currentThread().getContextClassLoader()
+    val kafkaPort =
+      try {
+        val c = getClass().getClassLoader()
+        Thread.currentThread().setContextClassLoader(c)
+
+        val k = new KafkaContainer(tcutility.DockerImageName.parse("confluentinc/cp-kafka:5.4.3"))
+          .withExposedPorts(KafkaPort)
+        k.start()
+        kafka.set(k)
+
+        k.getMappedPort(KafkaPort)
+      } finally {
+        Thread.currentThread().setContextClassLoader(cl)
+      }
+
+    log.debug(s"Setting up embedded Kafka broker on port: $kafkaPort")
+
+    topics.foreach { topic =>
+      log.debug(s"Kafka Setup: creating topic: $topic")
+
+      import org.apache.kafka.clients.admin.{ AdminClient, AdminClientConfig, NewTopic }
+      import scala.collection.JavaConverters._
+
+      val newTopic = new NewTopic(topic, 1, 1.toShort)
+
+      val adminClient = AdminClient.create(
+        Map[String, Object](
+          AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost.:${kafkaPort}",
+          AdminClientConfig.CLIENT_ID_CONFIG         -> "embedded-kafka-admin-client"
+        ).asJava
+      )
+
+      try {
+        adminClient
+          .createTopics(Seq(newTopic).asJava)
+          .all
+          .get()
+      } finally {
+        adminClient.close()
+      }
+    }
+
+    kafkaPort
+  }
+
+  def stopKafka() = Try {
+    kafka.get().stop()
+    kafka.set(null)
+  }
+
   case class RuntimeDescriptor(id: String,
                                appDescriptor: ApplicationDescriptor,
                                appDescriptorFile: Path,
                                outputFile: File,
                                logConfig: Path,
                                localConfPath: Option[String])
-
-  def setupKafka(port: Int, topics: Seq[String])(implicit log: Logger) = {
-    implicit val kafkaConfig = EmbeddedKafkaConfig(kafkaPort = port)
-    EmbeddedKafka.start()
-    log.debug(s"Setting up embedded Kafka broker on port: $port")
-
-    topics.foreach { topic =>
-      log.debug(s"Kafka Setup: creating topic: $topic")
-      EmbeddedKafka.createCustomTopic(topic)
-    }
-  }
-  def stopKafka() =
-    EmbeddedKafka.stop()
 
   def getDescriptorsOrFail(
       descriptors: Iterable[(String, Try[RuntimeDescriptor])]
@@ -365,7 +404,8 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
                      classpath: Array[URL],
                      outputFile: File,
                      log4JConfigFile: Path,
-                     localConfPath: Option[String])(
+                     localConfPath: Option[String],
+                     kafkaPort: Int)(
       implicit logger: Logger
   ): Process = {
     val cp = "-cp"
@@ -381,9 +421,11 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
       .withConnectInput(false)
       .withRunJVMOptions(Vector(s"-Dlog4j.configuration=file:///${log4JConfigFile.toFile.getAbsolutePath}"))
     val classpathStr = classpath.collect { case url if !url.toString.contains("logback") => new File(url.toURI) }.mkString(separator)
+
     val options: Seq[String] = Seq(
       Some(applicationDescriptorFile.toFile.getAbsolutePath),
       Some(outputFile.getAbsolutePath),
+      Some(kafkaPort.toString),
       localConfPath
     ).flatten
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use Testcontainers instead of Embedded Kafka for the `runLocal` command.

### Why are the changes needed?
To be able to support Sbt >= 1.4.X

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
`runLocal` in `taxi-ride`, since `runLocal` is pretty hard to mock and test as-it-is I ask the reviewers to test that everything works accordingly.
We don't have automated tests for this functionality yet.