### PR TITLE
Remove version mangling from the release process

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -586,7 +586,6 @@ lazy val commonSettings = bintraySettings ++ Seq(
         releaseProcess := Seq[ReleaseStep](
               // TODO: re-introduce this command
               // checkSnapshotDependencies,
-              inquireVersions,
               runClean,
               releaseStepCommand("+test"),
               releaseStepCommandAndRemaining("+publishSigned"),

--- a/core/project/InternalRelease.scala
+++ b/core/project/InternalRelease.scala
@@ -33,13 +33,9 @@ object InternalReleaseCommand {
        */
       releaseProcess := Seq[ReleaseStep](
         checkSnapshotDependencies,
-        inquireVersions,
         runClean,
         runTest,
-        setReleaseVersion,
-        tagReleaseWithChecks,
         publishArtifacts,
-        setNextVersion,
         pushChanges
       )), state)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove version mangling done by `sbt-release`

### Why are the changes needed?
To stop confusing `sbt-buildinfo`

### Does this PR introduce any user-facing change?
No
