### PR TITLE
Fix Flink Docker image creation with upstream artifacts

### DIFF
--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowFlinkPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowFlinkPlugin.scala
@@ -68,7 +68,7 @@ object CloudflowFlinkPlugin extends AutoPlugin {
         copy(appJarsDir, OptAppDir, chown = userAsOwner(UserInImage))
         addInstructions(extraDockerInstructions.value)
         runRaw(
-          s"cp ${OptAppDir}cloudflow-runner_${(ThisProject / scalaBinaryVersion).value}.jar  /opt/flink/flink-web-upload/cloudflow-runner.jar"
+          s"cp ${OptAppDir}cloudflow-runner_${(ThisProject / scalaBinaryVersion).value}*.jar  /opt/flink/flink-web-upload/cloudflow-runner.jar"
         )
       }
     }

--- a/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/build.sbt
+++ b/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/build.sbt
@@ -1,0 +1,26 @@
+lazy val helloWorld =  (project in file("."))
+    .enablePlugins(CloudflowApplicationPlugin, CloudflowFlinkPlugin)
+    .settings(
+      scalaVersion := "2.12.11",
+      name := "hello-world",
+      version := "0.0.1",
+      cloudflowFlinkBaseImage := Some("lightbend/flink:2.0.10-cloudflow-flink-1.10.0-scala-2.12"),
+
+      libraryDependencies ++= Seq(
+        "ch.qos.logback"         %  "logback-classic"           % "1.2.3"
+      )
+    )
+
+val checkCRFile = taskKey[Unit]("Testing the CR file")
+checkCRFile := {
+  val data = ujson.read(file("target/hello-world.json"))
+
+  val appId = data("spec")("app_id").str
+  val appVersion = data("spec")("app_version").str
+  
+  val image = data("spec")("deployments")(0)("image").str
+
+  assert { appId == "hello-world" }
+  assert { !appVersion.contains("sha256") }
+  assert { image == "hello-world:0.0.1"}
+}

--- a/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/project/plugins.sbt
+++ b/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/project/plugins.sbt
@@ -1,0 +1,7 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.lightbend.cloudflow" % "sbt-cloudflow" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
+
+libraryDependencies += "com.lihaoyi" %% "ujson" % "0.9.5"

--- a/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/src/main/blueprint/blueprint.conf
+++ b/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/src/main/blueprint/blueprint.conf
@@ -1,0 +1,5 @@
+blueprint {
+  streamlets {
+    hello-world = helloworld.HelloWorldShape
+  }
+}

--- a/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/src/main/scala/helloworld/HelloWorld.scala
+++ b/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/src/main/scala/helloworld/HelloWorld.scala
@@ -15,24 +15,6 @@
  */
 package helloworld
 
-// import akka.stream.scaladsl._
-// import cloudflow.akkastream._
-// import cloudflow.akkastream.scaladsl._
-// import cloudflow.streamlets._
-
-// class HelloWorldShape extends AkkaStreamlet {
-//   val shape = StreamletShape.empty
-
-//   def createLogic = new RunnableGraphStreamletLogic() {
-//     def runnableGraph = 
-//       Source
-//         .single("Hello, world!")
-//         .map(println)
-//         .to(Sink.ignore)
-//   }
-// }
-
-
 import cloudflow.flink.FlinkStreamlet
 import org.apache.flink.streaming.api.scala._
 import cloudflow.streamlets.{StreamletShape, StringConfigParameter}
@@ -48,4 +30,3 @@ class HelloWorldShape extends FlinkStreamlet {
   }
 
 }
-

--- a/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/src/main/scala/helloworld/HelloWorld.scala
+++ b/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/src/main/scala/helloworld/HelloWorld.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package helloworld
+
+// import akka.stream.scaladsl._
+// import cloudflow.akkastream._
+// import cloudflow.akkastream.scaladsl._
+// import cloudflow.streamlets._
+
+// class HelloWorldShape extends AkkaStreamlet {
+//   val shape = StreamletShape.empty
+
+//   def createLogic = new RunnableGraphStreamletLogic() {
+//     def runnableGraph = 
+//       Source
+//         .single("Hello, world!")
+//         .map(println)
+//         .to(Sink.ignore)
+//   }
+// }
+
+
+import cloudflow.flink.FlinkStreamlet
+import org.apache.flink.streaming.api.scala._
+import cloudflow.streamlets.{StreamletShape, StringConfigParameter}
+import cloudflow.flink._
+
+class HelloWorldShape extends FlinkStreamlet {
+  val shape = StreamletShape.empty
+
+  def createLogic() = new FlinkStreamletLogic {
+    override def buildExecutionGraph: Unit = {
+      println("hello-world")
+    }
+  }
+
+}
+

--- a/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/test
+++ b/core/sbt-cloudflow/src/sbt-test/sbt-cloudflow/simple-flink/test
@@ -1,0 +1,2 @@
+> buildApp
+> checkCRFile


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the creation of Flink Streamlets Docker images

### Why are the changes needed?
`sbt-docker` names differently local/upstream binaries

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Rebuilding `swiss-knife` and adding an sbt test