### PR TITLE
Creating streamlet secrets if missing in cli

### DIFF
--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/Action.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/Action.scala
@@ -453,18 +453,18 @@ final class ProvidedAction[T <: ObjectResource](
           maybe match {
             case Some(_) => getAction(maybe).execute(client)
             case None if retriesGet > 0 =>
-              sys.log.info(
+              Action.log.info(
                 s"Scheduling retry to get resource $namespace/$resourceName, retries left: ${retriesGet - 1}"
               )
               after(delay, sys.scheduler)(getAndProvide(retriesGet - 1))
             case None =>
-              sys.log.info(s"Did not find resource $namespace/$resourceName")
+              Action.log.info(s"Did not find resource $namespace/$resourceName")
               getAction(maybe).execute(client)
           }
         }
     getAndProvide(retriesGet).recoverWith {
       case e: K8SException if retries > 0 =>
-        sys.log.info(
+        Action.log.info(
           s"Scheduling retry to get resource $namespace/$resourceName, cause: ${e.getClass.getSimpleName} message: ${e.getMessage}"
         )
         after(delay, sys.scheduler)(executeWithRetry(client, delay, retries - 1, retriesGet))

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/AkkaRunner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/AkkaRunner.scala
@@ -63,7 +63,7 @@ final class AkkaRunner(akkaRunnerDefaults: AkkaRunnerDefaults) extends Runner[De
       Action.createOrUpdate(akkaRoleBinding(app.namespace, roleAkka, labels, ownerReferences), roleBindingEditor)
     )
   }
-  
+
   def streamletChangeAction(app: CloudflowApplication.CR,
                             runners: Map[String, Runner[_]],
                             streamletDeployment: StreamletDeployment,

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/AkkaRunner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/AkkaRunner.scala
@@ -63,6 +63,7 @@ final class AkkaRunner(akkaRunnerDefaults: AkkaRunnerDefaults) extends Runner[De
       Action.createOrUpdate(akkaRoleBinding(app.namespace, roleAkka, labels, ownerReferences), roleBindingEditor)
     )
   }
+  
   def streamletChangeAction(app: CloudflowApplication.CR,
                             runners: Map[String, Runner[_]],
                             streamletDeployment: StreamletDeployment,

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/Runner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/Runner.scala
@@ -107,7 +107,7 @@ trait Runner[T <: ObjectResource] {
       .flatMap { deployment =>
         Seq(
           Action.createOrUpdate(configResource(deployment, newApp), configEditor),
-          Action.providedRetry[Secret](deployment.secretName, newApp.namespace) {
+          Action.provided[Secret](deployment.secretName, newApp.namespace) {
             case Some(secret) => Action.createOrUpdate(resource(deployment, newApp, secret), editor)
             case None =>
               val msg =

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
@@ -22,11 +22,10 @@ import akka.actor._
 import skuber._
 import skuber.api.Configuration
 import scala.concurrent.Await
-import scala.concurrent.duration._
 import skuber.apiextensions._
 import skuber.json.format._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent._
 import scala.concurrent.duration._
 import skuber.apps.v1.Deployment
@@ -64,7 +63,7 @@ object Main extends {
     } catch {
       case t: Throwable =>
         system.log.error(t, "Unexpected error starting cloudflow operator, terminating.")
-        system.registerOnTermination(exitWithFailure)
+        system.registerOnTermination(exitWithFailure())
         system.terminate()
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Create empty secrets before creating input secret.
cc @andreaTP need to do this as well in the new cli.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This solves an ordering issue with the operator needing to get the secret before creating runner resource (deployment, flinkapp, sparkapp)

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- [x] GKE