### PR TITLE
WIP, migrate Actions from Skuber to Fabric8

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -210,7 +210,7 @@ lazy val akkastreamTests =
             AkkaHttpTestkit,
             AkkaHttpSprayJsonTest,
             TestcontainersKafka % Test,
-            Logback       % Test,
+            Logback             % Test,
             ScalaTest,
             Junit
           )
@@ -461,6 +461,8 @@ lazy val operatorActions =
             Ficus,
             Logback,
             Skuber,
+            Fabric8KubernetesClient,
+            JacksonScala,
             ScalaTest,
             "org.apache.kafka" % "kafka-clients" % Version.KafkaClients,
             ScalaCheck         % "test"

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/Action.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/Action.scala
@@ -293,7 +293,6 @@ class CreateOrPatchAction[T <: HasMetadata](
         .map(_ =>
           recoverFromError(
             Future {
-              client.secrets().inNamespace().withName()
               client
                 .resource(resource)
                 .inNamespace(resource.getMetadata.getNamespace)

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/CloudflowApplication.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/CloudflowApplication.scala
@@ -33,7 +33,6 @@ import skuber.ResourceSpecification.Subresources
 import cloudflow.blueprint._
 import cloudflow.blueprint.deployment.{ Topic => AppDescriptorTopic, _ }
 
-import cloudflow.operator.action.{ Action, ResourceAction }
 import cloudflow.operator.action.runner.Runner
 
 /**

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/ConfigurationScopeLayering.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/ConfigurationScopeLayering.scala
@@ -20,7 +20,6 @@ import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 import cloudflow.blueprint.deployment.StreamletDeployment
-import cloudflow.operator.action.TopicActions
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/EndpointActions.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/EndpointActions.scala
@@ -21,13 +21,10 @@ import scala.concurrent._
 import scala.collection.immutable._
 import akka.actor.ActorSystem
 import play.api.libs.json._
-import skuber._
-import skuber.api.client._
-import skuber.json.format._
 import cloudflow.blueprint.deployment._
 
-import io.fabric8.kubernetes.api.model.{ Service => Fabric8Service }
-import io.fabric8.kubernetes.client.{ KubernetesClient => Fabric8KubernetesClient }
+import io.fabric8.kubernetes.api.model._
+import io.fabric8.kubernetes.client.KubernetesClient
 
 /**
  * Creates a sequence of resource actions for the endpoint changes
@@ -46,8 +43,7 @@ object EndpointActions {
 
     val deleteActions = (currentEndpoints -- newEndpoints).flatMap { endpoint =>
       Seq(
-        Action.delete[Service, Fabric8Service](Name.ofService(StreamletDeployment.name(newApp.spec.appId, endpoint.streamlet)),
-                                               newApp.namespace)
+        Action.delete[Service](Name.ofService(StreamletDeployment.name(newApp.spec.appId, endpoint.streamlet)), newApp.namespace)
       )
     }.toList
     val createActions = (newEndpoints -- currentEndpoints).flatMap { endpoint =>
@@ -107,10 +103,8 @@ object EndpointActions {
    * If the service already exists, it will be updated. A service has an immutable clusterIP field which is retained in the update.
    */
   class CreateServiceAction(
-      override val resource: Service,
-      format: Format[Service],
-      resourceDefinition: ResourceDefinition[Service]
-  ) extends CreateOrUpdateAction[Service](resource, format, resourceDefinition, serviceEditor) {
+      override val resource: io.fabric8.kubernetes.api.model.Service
+  ) extends CreateOrUpdateAction[Service, io.fabric8.kubernetes.api.model.Service](resource) {
     override def execute(
         client: KubernetesClient,
         fabric8Client: Fabric8KubernetesClient

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/SkuberActionExecutor.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/SkuberActionExecutor.scala
@@ -19,9 +19,8 @@ package cloudflow.operator.action
 import scala.concurrent._
 import scala.util.control.NonFatal
 import scala.util.Try
-
 import akka.actor.ActorSystem
-
+import io.fabric8.kubernetes.client.DefaultKubernetesClient
 import org.slf4j.LoggerFactory
 import skuber._
 import skuber.api.Configuration
@@ -40,6 +39,9 @@ final class SkuberActionExecutor(
   import SkuberActionExecutor._
   val executionContext = ec
   implicit val lc      = skuber.api.client.RequestLoggingContext()
+
+  val fabric8Client = new DefaultKubernetesClient()
+
   def execute(action: Action): Future[Action] =
     action match {
       case skAction: ResourceAction[_] =>
@@ -51,7 +53,7 @@ final class SkuberActionExecutor(
           }
           .getOrElse(k8sInit(k8sConfig))
         skAction
-          .execute(kubernetesClient)
+          .execute(kubernetesClient, fabric8Client)
           .map { executedAction =>
             Try(kubernetesClient.close)
             executedAction

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/Runner.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/runner/Runner.scala
@@ -96,8 +96,8 @@ trait Runner[T <: ObjectResource] {
       .filterNot(deployment => newDeploymentNames.contains(deployment.name))
       .flatMap { deployment =>
         Seq(
-          Action.delete[T](resourceName(deployment), newApp.namespace),
-          Action.delete[T](configResourceName(deployment), newApp.namespace)
+          Action.delete[T, io.fabric8.kubernetes.api.model.apps.Deployment](resourceName(deployment), newApp.namespace),
+          Action.delete[T, io.fabric8.kubernetes.api.model.ConfigMap](configResourceName(deployment), newApp.namespace)
         )
       }
 
@@ -130,7 +130,7 @@ trait Runner[T <: ObjectResource] {
       }
       .toSeq
 
-    deleteActions ++ createActions ++ _updateActions
+    (deleteActions ++ createActions ++ _updateActions).toSeq
   }
 
   def prepareNamespaceActions(app: CloudflowApplication.CR, labels: CloudflowLabels, ownerReferences: List[OwnerReference]) =

--- a/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/EndpointActionsSpec.scala
+++ b/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/EndpointActionsSpec.scala
@@ -142,7 +142,7 @@ class EndpointActionsSpec
 
       Then("delete actions should be created")
       actions.size mustBe 1
-      val deleteActions = actions.collect { case d: DeleteAction[_] => d }
+      val deleteActions = actions.collect { case d: DeleteAction[_, _] => d }
 
       val serviceNames = deleteActions.map(_.resourceName)
 

--- a/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/runner/RunnerActionsSpec.scala
+++ b/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/runner/RunnerActionsSpec.scala
@@ -157,7 +157,7 @@ class RunnerActionsSpec extends WordSpec with MustMatchers with GivenWhenThen wi
       val actions = akkaRunner.actions(newApp, Some(currentApp), runners)
 
       Then("delete actions should be created")
-      val deleteActions = actions.collect { case d: DeleteAction[_] => d }
+      val deleteActions = actions.collect { case d: DeleteAction[_, _] => d }
       deleteActions.size mustBe 2
     }
 

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
@@ -45,7 +45,7 @@ object Main extends {
 
       HealthChecks.serve(settings)
 
-      val client          = connectToKubernetes()
+      val client = connectToKubernetes()
       val ownerReferences = getDeploymentOwnerReferences(settings, client.usingNamespace(settings.podNamespace))
       installProtocolVersion(client.usingNamespace(settings.podNamespace), ownerReferences)
       installCRD(client)

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -13,7 +13,10 @@ object Version {
   val Spark         = "2.4.5"
   val Flink         = "1.10.0"
   val KafkaClients  = "2.5.0"
-  val TestcontainersKafka = "1.15.0" 
+  val TestcontainersKafka = "1.15.0"
+
+  val Fabric8 = "4.12.0"
+  val Jackson = "2.11.3" // same as used in fabric8
 }
 
 object Library {
@@ -55,6 +58,9 @@ object Library {
   val JacksonScalaModule    = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.4"
 
   val Skuber                = "io.skuber"                  %% "skuber"               % "2.6.0"
+
+  val Fabric8KubernetesClient = "io.fabric8" % "kubernetes-client" % Version.Fabric8
+  val JacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % Version.Jackson
   
   val Spark                 = "org.apache.spark"           %% "spark-core"           % Version.Spark
   val SparkMllib            = "org.apache.spark"           %% "spark-mllib"          % Version.Spark

--- a/core/project/InternalRelease.scala
+++ b/core/project/InternalRelease.scala
@@ -15,24 +15,32 @@ object InternalReleaseCommand {
   val command: Command = Command.make("internalRelease") { state =>
     // tweak the keys used by sbt-release, for develop build
     val extracted = Project.extract(state)
-    val updatedState = extracted.appendWithSession(List(
-      releaseVersion := {ver => RVersion(ver).map(_.copy(qualifier = Some(gitQualifier())).string).getOrElse(versionFormatError(ver))},
-      releaseNextVersion := {ver => RVersion(ver).map(_.asSnapshot.string).getOrElse(versionFormatError(ver))},
-      /* The logical steps which are executed are:
-       * - checking that the project is in a valid state
-       *   - clean and synced git (checks from tagReleaseWithChecks)
-       *   - project compiles and tests passes (checkSnapshotDependencies, inquireVersions, runClean, runTest)
-       * - tag the existing commit (tagReleaseWithChecks)
-       * - publish using the build number (setReleaseVersion, publishArtifacts, setNextVersion)
-       * - push the tag to the remote repo (pushChanges)
-       */
-      releaseProcess := Seq[ReleaseStep](
-        checkSnapshotDependencies,
-        runClean,
-        runTest,
-        publishArtifacts,
-        pushChanges
-      )), state)
+    val updatedState = extracted.appendWithSession(
+      List(
+        releaseVersion := { ver =>
+          RVersion(ver).map(_.copy(qualifier = Some(gitQualifier())).string).getOrElse(versionFormatError(ver))
+        },
+        releaseNextVersion := { ver =>
+          RVersion(ver).map(_.asSnapshot.string).getOrElse(versionFormatError(ver))
+        },
+        /* The logical steps which are executed are:
+         * - checking that the project is in a valid state
+         *   - clean and synced git (checks from tagReleaseWithChecks)
+         *   - project compiles and tests passes (checkSnapshotDependencies, inquireVersions, runClean, runTest)
+         * - tag the existing commit (tagReleaseWithChecks)
+         * - publish using the build number (setReleaseVersion, publishArtifacts, setNextVersion)
+         * - push the tag to the remote repo (pushChanges)
+         */
+        releaseProcess := Seq[ReleaseStep](
+              checkSnapshotDependencies,
+              runClean,
+              runTest,
+              publishArtifacts,
+              pushChanges
+            )
+      ),
+      state
+    )
 
     releaseCommand.parser(updatedState)
   }


### PR DESCRIPTION
Sharing for early comments and feedback (don't even know if it works ...)

Quick recap:
 - having separate Fabric8Actions breaks way too many signatures
 - I'm currently relying on some reflection magic, and don't know if I can get rid of it ...
 - having both the skuber and fabric8 clients around is not nice, but is a temporary solution