### PR TITLE
Add missing sbt-dynver plugin

### DIFF
--- a/examples/connected-car-cluster-sharding/project/project/plugins.sbt
+++ b/examples/connected-car-cluster-sharding/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add required `sbt-dynver` plugin to `connected-car-cluster-sharding` example.

### Why are the changes needed?

The `connected-car-cluster-sharding` example fails to load:
```
$ sbt
[info] welcome to sbt 1.4.4 (AdoptOpenJDK Java 11.0.9.1)
[info] loading settings for project global-plugins from sbt-dependency-graph.sbt,sbt-updates.sbt ...
[info] loading global plugins from /home/vkorenev/.sbt/1.0/plugins
[info] loading project definition from /home/vkorenev/Projects/Cloudflow/cloudflow/examples/connected-car-cluster-sharding/project/project
/home/vkorenev/Projects/Cloudflow/cloudflow/examples/connected-car-cluster-sharding/project/cloudflow-plugins.sbt:3: error: not found: value sbtdynver
    sbtdynver.DynVer(None, "-", "v")
    ^
/home/vkorenev/Projects/Cloudflow/cloudflow/examples/connected-car-cluster-sharding/project/cloudflow-plugins.sbt:6: error: missing argument list for method identity in object Predef
Unapplied methods are only converted to functions when a function type is expected.
You can make this conversion explicit by writing `identity _` or `identity(_)` instead of `identity`.
  )(identity)
    ^
sbt.compiler.EvalException: Type error in expression
[error] sbt.compiler.EvalException: Type error in expression
[error] Use 'last' for the full log.
[warn] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)
```

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Ran `sbt` in `examples/connected-car-cluster-sharding`.