### PR TITLE
Execute actions in sequence and not in parallel

### DIFF
--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/Action.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/Action.scala
@@ -413,7 +413,7 @@ final case class CompositeAction[T <: ObjectResource](
   override def execute(
       client: RequestContext
   )(implicit sys: ActorSystem, ec: ExecutionContext, lc: LoggingContext): Future[Action] =
-    Future.sequence(actions.map(_.execute(client))).map(_ => this)
+    Future.foldLeft(actions.map(_.execute(client)))(Seq[Action]())((prev, n) => prev :+ n).map(_ => this)
 }
 
 final class ProvidedAction[T <: ObjectResource](

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/ActionExecutor.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/ActionExecutor.scala
@@ -39,7 +39,7 @@ trait ActionExecutor {
    */
   def execute(actions: Seq[Action]): Future[Seq[Action]] = {
     implicit val ec = executionContext
-    Future.sequence(actions.map(execute))
+    Future.foldLeft(actions.map(execute))(Seq[Action]())((prev, n) => prev :+ n)
   }
 }
 


### PR DESCRIPTION
as discussed with @RayRoestenburg 
tested with the integration tests, and with manual deploy/undeploy, looks pretty stable.