### PR TITLE
Add a flag to disable debug in runLocal

### DIFF
--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowApplicationPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowApplicationPlugin.scala
@@ -30,19 +30,21 @@ object CloudflowApplicationPlugin extends AutoPlugin {
   /** This plugin depends on these other plugins: */
   override def requires: Plugins = StreamletDescriptorsPlugin && BlueprintVerificationPlugin && BuildAppPlugin
 
+  val InitialDebugPort = 5004
+
   override def buildSettings = Seq(
     cloudflowDockerRegistry := None,
     cloudflowDockerRepository := None,
-    runLocalKafka := None
+    runLocalKafka := None,
+    initialDebugPort := InitialDebugPort,
+    remoteDebugRunLocal := true
   )
 
   val DefaultLocalLog4jConfigFile = "local-run-log4j.properties"
-  val InitialDebugPort            = 5004
 
   /** Set default values for keys. */
   override def projectSettings = Seq(
     blueprint := None,
-    initialDebugPort := InitialDebugPort,
     runLocalConfigFile := None,
     runLocalLog4jConfigFile := None,
     runLocalJavaOptions := None,

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowKeys.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowKeys.scala
@@ -63,7 +63,8 @@ trait CloudflowSettingKeys {
 
   val ownerInDockerImage =
     settingKey[String]("The user as owner in the resulting docker image, which can be used as chown in docker copy instructions.")
-  val initialDebugPort = settingKey[Int]("Initial port number for debugging. It will be increased by one for each Streamlet")
+  val initialDebugPort    = settingKey[Int]("Initial port number for debugging in runLocal. It will be increased by one for each Streamlet")
+  val remoteDebugRunLocal = settingKey[Boolean]("Enable/Disable remote debugging for streamlets in runLocal")
 }
 
 trait CloudflowTaskKeys {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a flag to let users disable the debugging java options in `runLocal`

### Does this PR introduce any user-facing change?
Yes an additional sbt `settingKey`

### How was this patch tested?
Locally running `runLocal`