### PR TITLE
Remove a bunch of intermediate releases from docs to avoid Antora OOM

### DIFF
--- a/docs/docs-source/site.yml
+++ b/docs/docs-source/site.yml
@@ -8,7 +8,9 @@ content:
         - docs/docs-source/docs
         - docs/shared-content-source/docs
         - examples/snippets
-      branches: [master, v1.3.3-docs, v2.0.0-docs, v2.0.5-docs, v2.0.7-docs, v2.0.8-docs, v2.0.10-docs, v2.0.11-docs, v2.0.12-docs, v2.0.13-docs, v2.0.14-docs, v2.0.16-docs, v2.0.18-docs, v2.0.19-docs, v2.0.20-docs, v2.0.21-docs] # versioned content - add branches here
+      # TODO: check if we can restore all the versions
+      # branches: [master, v1.3.3-docs, v2.0.0-docs, v2.0.5-docs, v2.0.7-docs, v2.0.8-docs, v2.0.10-docs, v2.0.11-docs, v2.0.12-docs, v2.0.13-docs, v2.0.14-docs, v2.0.16-docs, v2.0.18-docs, v2.0.19-docs, v2.0.20-docs, v2.0.21-docs] # versioned content - add branches here
+      branches: [master, v1.3.3-docs, v2.0.0-docs, v2.0.18-docs, v2.0.19-docs, v2.0.20-docs, v2.0.21-docs] # versioned content - add branches here
     - url: git@github.com:lightbend/cloudflow.git
       start-path: docs/homepage-source/docs
       branches: [master] # should always remain as master


### PR DESCRIPTION
The CI is failing with OOM while building the documentation, and I can reproduce locally.

This is a workaround to make the CI green again, any tip @rasummer @rstento ?