### PR TITLE
Remove component selector below TOC and Edit this page

### DIFF
--- a/docs/docs-source/supplemental_ui/layouts/default-dev.hbs
+++ b/docs/docs-source/supplemental_ui/layouts/default-dev.hbs
@@ -3,7 +3,7 @@
   <head>
 {{> head-dev defaultPageTitle='Untitled'}}
   </head>
-  <body class="blue-theme oss-banner article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
+  <body class="blue-theme oss-banner article hide-versions hide-edit-this-page {{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
 {{> oss-banner}}
 {{> header}}
 {{> body}}

--- a/docs/docs-source/supplemental_ui/layouts/default.hbs
+++ b/docs/docs-source/supplemental_ui/layouts/default.hbs
@@ -3,7 +3,7 @@
   <head>
 {{> head defaultPageTitle='Untitled'}}
   </head>
-  <body class="blue-theme oss-banner article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
+  <body class="blue-theme oss-banner article hide-versions hide-edit-this-page {{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
 {{> oss-banner}}
 {{> header}}
 {{> body}}


### PR DESCRIPTION
@andreaTP, this fixes the TOC and Edit this page problem, but does not fix the search problem. 

The command to build antora with search has DOCSEARCH_INDEX_VERSION=latest in it, which is kind of explained on this page: https://github.com/Mogztter/antora-lunr/issues/25

I think part of the problem is that antora determines the latest by looking at the last branch mentioned in the branches statement:
branches: [master, v1.3.3-docs, v2.0.0-docs, v2.0.18-docs, v2.0.19-docs, v2.0.20-docs, v2.0.21-docs], so in this case, master should be at the far right. I tested this and it made the search return the v2.0.21 docs, but the version selector contains both dev and current. I believe also that the branches listed here must have something incorrect in the antora.yml that defines the version. But, I can't figure out how to fix it because I don't know how the two files antora.yml and antora-base.yml are being used. 


Tangential, but this might be related:
I believe that we should not be publishing a dev version publicly. When readers go to cloudstate.io/docs, they should always be presented with the current version, which it looks like is 2.0.21? Therefore, master shouldn't be included in the branches. Those working on the docs can easily build locally to get the latest that includes master and their HEAD.   