### PR TITLE
Fix custom configuration reading in the LocalRunner

### DIFF
--- a/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
+++ b/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
@@ -198,15 +198,15 @@ object LocalRunner extends StreamletLoader {
 
   private def resolveLocalStreamletConf(streamletDescriptor: StreamletInstance, localConf: Config): Try[Config] = {
     // streamlet implementations read their parameter config from the path `cloudflow.streamlets.${streamletRef}`
-    val streamletParamConfig: Seq[(String, String, Option[String])] = streamletDescriptor.descriptor.configParameters.map {
+    val streamletParamConfig: Seq[(String, String, Option[Config])] = streamletDescriptor.descriptor.configParameters.map {
       configParamDescriptor =>
         val sourceKey      = s"cloudflow.streamlets.${streamletDescriptor.name}.config-parameters.${configParamDescriptor.key}"
         val targetKey      = s"cloudflow.streamlets.${streamletDescriptor.name}.${configParamDescriptor.key}"
         val validationType = configParamDescriptor.validationType
         val value = if (localConf.hasPath(sourceKey)) {
-          Some(localConf.getString(sourceKey))
+          Some(localConf.getConfig(sourceKey))
         } else {
-          configParamDescriptor.defaultValue
+          configParamDescriptor.defaultValue.map(ConfigFactory.parseString)
         }
         (targetKey, validationType, value)
     }
@@ -215,18 +215,7 @@ object LocalRunner extends StreamletLoader {
     if (missingValues.nonEmpty) {
       Failure(MissingConfigurationException(missingValues))
     } else {
-      Success {
-        // I'll let the consumer of this configuration to parse the values as they want.
-        // This quoting policy is here to preserve the type of the value in the resulting config obj
-        ConfigFactory.parseString {
-          streamletParamConfig
-            .collect {
-              case (key, validationType, Some(value)) =>
-                s"$key : ${quotePolicy(validationType)(value)}"
-            }
-            .mkString("\n")
-        }
-      }
+      Success(streamletParamConfig.map(_._3.get).fold(ConfigFactory.empty)((last, curr) => last.withFallback(curr)))
     }
   }
 

--- a/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
+++ b/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
@@ -30,7 +30,14 @@ import spray.json._
 import cloudflow.blueprint.deployment.{ ApplicationDescriptor, RunnerConfig, StreamletDeployment, StreamletInstance, Topic }
 import cloudflow.blueprint.deployment.ApplicationDescriptorJsonFormat._
 import cloudflow.blueprint.RunnerConfigUtils._
-import cloudflow.streamlets.{ BooleanValidationType, DoubleValidationType, IntegerValidationType, StreamletExecution, StreamletLoader }
+import cloudflow.streamlets.{
+  BooleanValidationType,
+  ConfigValidationType,
+  DoubleValidationType,
+  IntegerValidationType,
+  StreamletExecution,
+  StreamletLoader
+}
 import com.typesafe.config._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -219,12 +226,8 @@ object LocalRunner extends StreamletLoader {
     }
   }
 
-  private val isNonQuotedType = Set(BooleanValidationType.`type`, IntegerValidationType.`type`, DoubleValidationType.`type`)
-
-  private def quotePolicy(validationType: String): String => String = { x =>
-    if (isNonQuotedType(validationType)) x else s""""$x""""
-
-  }
+  private val isNonQuotedType =
+    Set(BooleanValidationType.`type`, IntegerValidationType.`type`, DoubleValidationType.`type`, ConfigValidationType.`type`)
 
   private def readDescriptorFile(appDescriptorFilename: String): Try[ApplicationDescriptor] =
     Try {

--- a/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
+++ b/core/cloudflow-localrunner/src/main/scala/cloudflow/localrunner/LocalRunner.scala
@@ -241,7 +241,7 @@ object LocalRunner extends StreamletLoader {
   }
 
   private val isNonQuotedType =
-    Set(BooleanValidationType.`type`, IntegerValidationType.`type`, DoubleValidationType.`type`)
+    Set(BooleanValidationType.`type`, IntegerValidationType.`type`, DoubleValidationType.`type`, ConfigValidationType.`type`)
 
   private def quotePolicy(validationType: String): String => String = { x =>
     if (isNonQuotedType(validationType)) x else s""""$x""""

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/ConfigParameters.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/ConfigParameters.scala
@@ -17,6 +17,7 @@
 package cloudflow.streamlets
 
 import cloudflow.streamlets.descriptors._
+import com.typesafe.config.Config
 
 sealed trait ValidationType {
   def pattern: Option[String] = None
@@ -27,6 +28,7 @@ final case object IntegerValidationType    extends ValidationType { val `type` =
 final case object DoubleValidationType     extends ValidationType { val `type` = "double"     }
 final case object DurationValidationType   extends ValidationType { val `type` = "duration"   }
 final case object MemorySizeValidationType extends ValidationType { val `type` = "memorysize" }
+final case object ConfigValidationType     extends ValidationType { val `type` = "config"     }
 final case class RegexpValidationType(regExpPattern: String) extends ValidationType {
   override val pattern = Some(regExpPattern)
   override val `type`  = "string"
@@ -343,6 +345,34 @@ final case class MemorySizeConfigParameter(key: String, description: String = ""
     context.streamletConfig.getMemorySize(key)
   def value(implicit context: StreamletContext) =
     context.streamletConfig.getMemorySize(key)
+  def withDefaultValue(value: String) =
+    this.copy(defaultValue = Some(value))
+}
+
+/**
+ * Describes a config configuration parameter.
+ *
+ * @param key name of the parameter
+ * @param description description of the parameter
+ * @param defaultValue the default value used if the parameter is not specified at application deployment time.
+ */
+object ConfigConfigParameter {
+  // Java API
+  def create(key: String, description: String) =
+    ConfigConfigParameter(key, description)
+}
+final case class ConfigConfigParameter(key: String, description: String = "", defaultValue: Option[String] = None) extends ConfigParameter {
+  def toDescriptor: ConfigParameterDescriptor =
+    ConfigParameterDescriptor(key, description, ConfigValidationType, defaultValue)
+
+  /**
+   * Java API
+   * Gets the value for this configuration parameter.
+   */
+  def getValue(context: StreamletContext): Config =
+    context.streamletConfig.getConfig(key)
+  def value(implicit context: StreamletContext): Config =
+    context.streamletConfig.getConfig(key)
   def withDefaultValue(value: String) =
     this.copy(defaultValue = Some(value))
 }

--- a/core/cloudflow-streamlets/src/test/scala/cloudflow/streamlets/ConfigParameterSpec.scala
+++ b/core/cloudflow-streamlets/src/test/scala/cloudflow/streamlets/ConfigParameterSpec.scala
@@ -114,5 +114,17 @@ class ConfigParameterSpec extends WordSpec with MustMatchers with OptionValues {
       descriptor.defaultValue.value mustBe "some string"
     }
 
+    "validate that ConfigConfigParameter produce a correct descriptor" in {
+      val aConfig = ConfigConfigParameter("test", "description", Some("{ foo = bar }"))
+
+      val descriptor = aConfig.toDescriptor
+
+      descriptor.key mustBe "test"
+      descriptor.description mustBe "description"
+      descriptor.validationType mustBe "config"
+      descriptor.validationPattern mustBe empty
+      ConfigFactory.parseString(descriptor.defaultValue.value).getString("foo") mustBe "bar"
+    }
+
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix #941 

### Why are the changes needed?
Be able to pass arbitrary config in `runLocal` mode.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
With the repro project provided in the Issue
