### PR TITLE
Index only current and remove development documentation

### DIFF
--- a/docs/antora-docker/Dockerfile
+++ b/docs/antora-docker/Dockerfile
@@ -7,6 +7,7 @@ RUN yarn global add antora-site-generator-lunr
 ENV DOCSEARCH_ENABLED=true
 ENV DOCSEARCH_ENGINE=lunr
 ENV DOCSEARCH_LANGS=en
+ENV DOCSEARCH_INDEX_VERSION=latest
 
 LABEL description="antora/antora image with the additional 'asciidoc-link-check', 'antora-lunr' and 'antora-site-generator-lunr' tool"
 

--- a/docs/docs-source/site.yml
+++ b/docs/docs-source/site.yml
@@ -10,7 +10,7 @@ content:
         - examples/snippets
       # TODO: check if we can restore all the versions
       # branches: [master, v1.3.3-docs, v2.0.0-docs, v2.0.5-docs, v2.0.7-docs, v2.0.8-docs, v2.0.10-docs, v2.0.11-docs, v2.0.12-docs, v2.0.13-docs, v2.0.14-docs, v2.0.16-docs, v2.0.18-docs, v2.0.19-docs, v2.0.20-docs, v2.0.21-docs] # versioned content - add branches here
-      branches: [master, v1.3.3-docs, v2.0.0-docs, v2.0.18-docs, v2.0.19-docs, v2.0.20-docs, v2.0.21-docs] # versioned content - add branches here
+      branches: [v1.3.3-docs, v2.0.0-docs, v2.0.18-docs, v2.0.19-docs, v2.0.20-docs, v2.0.21-docs] # versioned content - add branches here
     - url: git@github.com:lightbend/cloudflow.git
       start-path: docs/homepage-source/docs
       branches: [master] # should always remain as master


### PR DESCRIPTION
This PR index only the `latest` branch, and we remove the `development` documentation as suggested by @rstento .

We have to note that `latest` is not forcefully matching `current` and this might cause quirks.

E.g.:
if we update an older version of the docs we probably need to push a commit to the `current` to re-index the correct version.
Fortunately, this doesn't happen very often and we can probably live with it.