### PR TITLE
Use alpine moving tag for base images

### DIFF
--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowBasePlugin.scala
@@ -52,7 +52,7 @@ object CloudflowBasePlugin extends AutoPlugin {
     StreamletDescriptorsPlugin && JavaAppPackaging && sbtdocker.DockerPlugin
 
   override def projectSettings = Seq(
-    cloudflowDockerBaseImage := "adoptopenjdk/openjdk8:jdk8u265-b01-alpine",
+    cloudflowDockerBaseImage := "adoptopenjdk/openjdk8:alpine",
     libraryDependencies ++= Vector(
           "com.lightbend.cloudflow" % s"cloudflow-runner_${(ThisProject / scalaBinaryVersion).value}"      % (ThisProject / cloudflowVersion).value,
           "com.lightbend.cloudflow" % s"cloudflow-localrunner_${(ThisProject / scalaBinaryVersion).value}" % (ThisProject / cloudflowVersion).value


### PR DESCRIPTION
Alpine is already the latest in the operator versions:

```
docker run --rm -it --entrypoint=/bin/sh lightbend/cloudflow-operator:2.0.21
/ # cat /etc/os-release
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.12.3
PRETTY_NAME="Alpine Linux v3.12"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
```

Here we set the moving tag for base images as well.