### PR TITLE
Proposal to allow shorter K8S object names for pods, services, config-maps, etc.

### DIFF
--- a/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/RunnerConfigSpec.scala
+++ b/core/cloudflow-blueprint/src/test/scala/cloudflow/blueprint/deployment/RunnerConfigSpec.scala
@@ -96,7 +96,7 @@ class RunnerConfigSpec extends WordSpec with MustMatchers with OptionValues with
     .connect(Topic(id = "bars"), processorRef.out)
 
   val verifiedBlueprint = blueprint.verified.right.value
-  val descriptor        = ApplicationDescriptor(appId, appVersion, image, verifiedBlueprint, agentPaths, BuildInfo.version)
+  val descriptor        = ApplicationDescriptor(appId, appVersion, image, verifiedBlueprint, agentPaths, BuildInfo.version)(false)
 
   val allDeployments      = descriptor.deployments
   val ingressDeployment   = allDeployments.find(_.streamletName == ingressRef.name).value

--- a/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/Name.scala
+++ b/core/cloudflow-operator-actions/src/main/scala/cloudflow/operator/action/Name.scala
@@ -125,7 +125,7 @@ object Name {
     makeDNS1039Compatible(fixDots(streamletDeploymentName))
 
   def ofConfigMap(streamletDeploymentName: String) =
-    makeDNS1123CompatibleSubDomainName(s"configmap-${fixDots(streamletDeploymentName)}")
+    makeDNS1123CompatibleSubDomainName(s"configmap-${fixDots(streamletDeploymentName)}") // TODO - why append '-service' (line 145) but prepend 'configmap-'? - suffixes seem the more k8s-idiomatic choice
 
   def ofLabelValue(name: String) =
     truncateTo63Characters(name)
@@ -142,7 +142,7 @@ object Name {
   val ofContainerPrometheusExporterPort = max15Chars("prom-metrics")
 
   def ofService(streamletDeploymentName: String) =
-    truncateTo63CharactersWithSuffix(makeDNS1039Compatible(ofPod(streamletDeploymentName)), "-service")
+    truncateTo63CharactersWithSuffix(ofPod(streamletDeploymentName), "-service")
 
   def ofAdminService(streamletDeploymentName: String) =
     s"${ofPod(streamletDeploymentName)}-admin-service"

--- a/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/TestApplication.scala
+++ b/core/cloudflow-operator-actions/src/test/scala/cloudflow/operator/action/TestApplication.scala
@@ -32,7 +32,7 @@ object CloudflowApplicationSpecBuilder {
 
     val sanitizedApplicationId = Dns1123Formatter.transformToDNS1123Label(appId)
     val streamlets             = blueprint.streamlets.map(toStreamlet)
-    val deployments            = ApplicationDescriptor(appId, appVersion, image, blueprint, agentPaths, BuildInfo.version).deployments
+    val deployments            = ApplicationDescriptor(appId, appVersion, image, blueprint, agentPaths, BuildInfo.version)(false).deployments
     CloudflowApplication.Spec(sanitizedApplicationId, appVersion, streamlets, deployments, agentPaths)
   }
 

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/BlueprintVerificationPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/BlueprintVerificationPlugin.scala
@@ -88,6 +88,7 @@ object BlueprintVerificationPlugin extends AutoPlugin {
       }
     },
     applicationDescriptor := {
+      val shortK8sNames   = (ThisProject / useShortK8sObjectNames).value
       val appId           = (ThisProject / name).value
       val appVersion      = (ThisProject / version).value
       val agentPathsMap   = Map("prometheus" -> "/prometheus/jmx_prometheus_javaagent.jar")
@@ -97,7 +98,9 @@ object BlueprintVerificationPlugin extends AutoPlugin {
       for {
         BlueprintVerified(bp, _) <- verificationResult.value.toOption
         verifiedBlueprint        <- bp.verified.toOption
-      } yield ApplicationDescriptor(appId, appVersion, dockerImageName.get.name, verifiedBlueprint, agentPathsMap, libraryVersion)
+      } yield ApplicationDescriptor(appId, appVersion, dockerImageName.get.name, verifiedBlueprint, agentPathsMap, libraryVersion)(
+        shortK8sNames
+      )
     },
     fork in Compile := true
   )

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowKeys.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowKeys.scala
@@ -47,8 +47,11 @@ trait CloudflowSettingKeys {
   val cloudflowVersion           = settingKey[String]("The version of Cloudflow, for development purposes, change it at your own risk")
   val blueprint                  = settingKey[Option[String]]("The path to the blueprint file to use in this Cloudflow application.")
   val schemaCodeGenerator        = settingKey[SchemaCodeGenerator.Language]("The language to generate data model schemas into.")
-  val schemaPaths                = settingKey[Map[SchemaFormat.Format, String]]("A Map of paths to your data model schemas.")
-  val runLocalConfigFile         = settingKey[Option[String]]("the HOCON configuration file to use with the local runner Sandbox.")
+  val useShortK8sObjectNames = settingKey[Boolean](
+    "Define whether to generate short K8S object names in CRs consisting mainly of the streamlet-name, or remain with long names based on app-id and streamlet-name"
+  )
+  val schemaPaths        = settingKey[Map[SchemaFormat.Format, String]]("A Map of paths to your data model schemas.")
+  val runLocalConfigFile = settingKey[Option[String]]("the HOCON configuration file to use with the local runner Sandbox.")
   val runLocalLog4jConfigFile = settingKey[Option[String]](
     s"The path to the log4j configuration file to use with the local runner Sandbox, if omitted, ${CloudflowApplicationPlugin.DefaultLocalLog4jConfigFile} is read from plugin classpath."
   )

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CommonSettingsAndTasksPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CommonSettingsAndTasksPlugin.scala
@@ -56,6 +56,7 @@ object CommonSettingsAndTasksPlugin extends AutoPlugin {
             Some(DockerImageName((ThisProject / name).value.toLowerCase, (ThisProject / version).value))
           }.value,
       cloudflowWorkDir := (ThisBuild / baseDirectory).value / "target" / ".cloudflow",
+      useShortK8sObjectNames := false,
       imageNamesByProject := Def.taskDyn {
             val buildNumber = (ThisProject / version).value
             Def.task {


### PR DESCRIPTION
For the past year, we've continously run into various object name length limitations issued by K8S - mostly the 63character limit.
Unfortunately, the object names generated by Cloudflow are very long as the usually consist of `applid-streamletname`.

A quick test with a manually modified CR (containing a few streamlets and HTTP endpoints) showed that
- the actual magic for shorter object names can be handled by the sbt-cloudflow plugin (by creating shorter names in the CRs)
- the names for K8S services are still pretty long due to to way how service-names are computed (function `Names.ofSerivce` is misleading here because changing it would not impact the actual service name).

This PR proposes 2 changes:
1. Use the deployment-name from the CR instead of calculating the K8S service name from the endpoint configuration in the CR. With the current implementation of Cloudflow (2.0.21 and earlier) the computed Service name would always amount to `appid-streamletname` (-prefix) - same as the deployment name.
2. add setting key `useShortK8sObjectNames` to sbt-cloudflow in order to yield shorter deployment names (which boil down to K8S object names of pods, services, config-maps) during CR creation.

The existing tests are still running through.
I added another test to actually verify the creation of short K8S object names.
Aside from that long object names (as used until now) remain the default.
