### PR TITLE
Fix cross-namespace cli operations when a context is set

### DIFF
--- a/tools/cloudflow-cli/src/test/scala/akka/cli/cloudflow/kubeclient/Fabric8KubeClientSpec.scala
+++ b/tools/cloudflow-cli/src/test/scala/akka/cli/cloudflow/kubeclient/Fabric8KubeClientSpec.scala
@@ -32,7 +32,7 @@ class Fabric8KubeClientSpec extends AnyFlatSpec with Matchers with BeforeAndAfte
       .once
 
     server.expect.get
-      .withPath("/apis/cloudflow.lightbend.com/v1alpha1/namespaces/test/cloudflowapplications")
+      .withPath("/apis/cloudflow.lightbend.com/v1alpha1/cloudflowapplications")
       .andReturn(
         HttpURLConnection.HTTP_OK,
         Source


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix  #961 
Setting a default namespace in the current context will break the _kubectl-cloudflow_ functionalities.

E.g.:
```
$ kubectl config set-context --current --namespace="non-existing"
$ kubectl cloudflow list
Error: No Cloudflow operators detected in the cluster. Exiting
```
Current workaround:
```
$ kubectl config set-context --current --namespace=""
```

### Why are the changes needed?
Enable the usage of _kubectl-cloudflow_ even when a namespace is defined in the current context.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Running the integration tests on GKE after setting a namespace in the context.
Running most of the operations (e.g. deploy/undeploy/configure/configuration/list/status) on a simple application on an OpenShift cluster.

cc. @thomasschoeftner @OBenner @michael-read 