### PR TITLE
Bump Flink to 1.10.3

### DIFF
--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Version {
   val Scala212      = "2.12.12"
   val Scala213      = "2.13.3"
   val Spark         = "2.4.5"
-  val Flink         = "1.10.0"
+  val Flink         = "1.10.3"
   val KafkaClients  = "2.5.0"
   val TestcontainersKafka = "1.15.1" 
 }

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowFlinkPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowFlinkPlugin.scala
@@ -71,11 +71,11 @@ object CloudflowFlinkPlugin extends AutoPlugin {
       IO.write(flinkEntrypoint, flinkEntrypointContent)
 
       val scalaVersion = (ThisProject / scalaBinaryVersion).value
-      val flinkVersion = "1.10.0"
+      val flinkVersion = "1.10.3"
       val flinkHome    = "/opt/flink"
 
-      val flinkTgz    = s"lightbend-flink-${flinkVersion}.tgz"
-      val flinkTgzUrl = s"https://github.com/lightbend/flink/releases/download/v$flinkVersion-lightbend/$flinkTgz"
+      val flinkTgz    = s"flink-${flinkVersion}-bin-scala_2.12.tgz"
+      val flinkTgzUrl = s"https://downloads.apache.org/flink/flink-1.10.3/$flinkTgz"
 
       Seq(
         Instructions.Env("FLINK_VERSION", flinkVersion),
@@ -95,10 +95,6 @@ object CloudflowFlinkPlugin extends AutoPlugin {
             Seq("rm", flinkTgz),
             Seq("cp", "/tmp/config.sh", s"${flinkHome}/bin/config.sh"),
             Seq("cp", "/tmp/flink-console.sh", s"${flinkHome}/bin/flink-console.sh"),
-            // logback configuration:
-            // https://ci.apache.org/projects/flink/flink-docs-stable/deployment/advanced/logging.html#configuring-logback
-            // logback must be provided by the streamlet itself
-            Seq("rm", s"${flinkHome}/lib/log4j-slf4j-impl-2.12.1.jar"),
             Seq("addgroup", "-S", "-g", "9999", "flink"),
             Seq("adduser", "-S", "-h", flinkHome, "-u", "9999", "flink", "flink"),
             Seq("addgroup", "-S", "-g", "185", "cloudflow"),

--- a/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowFlinkPlugin.scala
+++ b/core/sbt-cloudflow/src/main/scala/cloudflow/sbt/CloudflowFlinkPlugin.scala
@@ -75,7 +75,7 @@ object CloudflowFlinkPlugin extends AutoPlugin {
       val flinkHome    = "/opt/flink"
 
       val flinkTgz    = s"flink-${flinkVersion}-bin-scala_2.12.tgz"
-      val flinkTgzUrl = s"https://downloads.apache.org/flink/flink-1.10.3/$flinkTgz"
+      val flinkTgzUrl = s"https://downloads.apache.org/flink/flink-${flinkVersion}/$flinkTgz"
 
       Seq(
         Instructions.Env("FLINK_VERSION", flinkVersion),

--- a/docs/shared-content-source/docs/modules/ROOT/partials/include.adoc
+++ b/docs/shared-content-source/docs/modules/ROOT/partials/include.adoc
@@ -27,7 +27,7 @@
 :supported-gcp-spark-v: v1beta2-1.1.2-2.4.5
 :supported-helm-spark-v: 0.6.7
 
-:supported-apache-flink-v: 1.10.0
+:supported-apache-flink-v: 1.10.3
 :supported-flink-8-v: 0.5.0
 :supported-helm-flink-8-v: 0.8.2
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Bump Flink to upstream version `1.10.3`

### Why are the changes needed?
Include community bug fixes and improvements

### Does this PR introduce any user-facing change?
Yes, Flink code will be compiled against `1.10.3` instead of `1.10.0`.
We are also depending on the upstream Flink version and the classpath for logging is slightly different.

### How was this patch tested?
`scripted` tests for the `sbt-plugin`, `taxi-ride` (`runLocal` and in the cluster), `integration-tests` against the cluster.