### PR TITLE
Remove custom Flink operator image usage

### DIFF
--- a/docs/shared-content-source/docs/modules/administration/pages/installing-flink-operator.adoc
+++ b/docs/shared-content-source/docs/modules/administration/pages/installing-flink-operator.adoc
@@ -12,7 +12,6 @@ Install the Lyft Flink operator using the following Helm command:
 helm install flink-operator \
   https://github.com/lightbend/flink-operator/releases/download/v0.8.2/flink-operator-0.8.2.tgz \
   --namespace cloudflow \
-  --set operatorImageName="docker.io/lyft/flinkk8soperator" \
   --set operatorVersion="v0.5.0"
 ----
 

--- a/tools/cloudflow-it/Makefile
+++ b/tools/cloudflow-it/Makefile
@@ -49,7 +49,6 @@ prepare-cluster:
 	@echo '****** Installing Flink Operator'
 	(helm upgrade -i flink-operator \
 		https://github.com/lightbend/flink-operator/releases/download/v0.8.2/flink-operator-0.8.2.tgz \
-		--set operatorImageName="lightbend/flinkk8soperator" \
 		--set operatorVersion="v0.5.0" \
 		--namespace cloudflow)
 	@echo '****** Installing Cloudflow Operator'


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove references to "lightbend" republished flink operator image.

### Why are the changes needed?
Cleanup

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Integration tests
