### PR TITLE
Fixes for Ubuntu 16

### DIFF
--- a/docs/shared-content-source/docs/modules/get-started/pages/prepare-development-environment.adoc
+++ b/docs/shared-content-source/docs/modules/get-started/pages/prepare-development-environment.adoc
@@ -22,18 +22,23 @@ First, make sure that you have the following installed:
 Install the Cloudflow CLI using the official installer:
 
 ....
-curl -sL http://cloudflow.io/docs/get.sh | sh
+curl -sL http://cloudflow.io/docs/get.sh | bash
 ....
 
 You can pass options to the installer script with `-s --` e.g.:
 
 ....
-curl -sL http://cloudflow.io/docs/get.sh | sh -s -- --prefix=$HOME --version=2.0.22 --verbose
-curl -sL http://cloudflow.io/docs/get.sh | sh -s -- -P $HOME -v 2.0.22 -V
+curl -sL http://cloudflow.io/docs/get.sh | bash -s -- --prefix=$HOME --version=2.0.22 --verbose
+curl -sL http://cloudflow.io/docs/get.sh | bash -s -- -P $HOME -v 2.0.22 -V
 ....
 
-If the installer script fails (e.g. there is no `curl` nor `wget` installed) downaload the binaries at the specific version from:
+If the installer script fails, please, report the failure and download the binaries at the specific version at the url:
 
-* https://bintray.com/lightbend/cloudflow-cli/kubectl-cloudflow
+* https://bintray.com/lightbend/cloudflow-cli/download_file?file_path=kubectl-cloudflow-<version>-<platform>-amd64.tar.gz
+
+where you have to substitute:
+
+  - <version> with the specific version (e.g. `2.0.23`)
+  - <platform> with one of `darwin`, `linux`, `windows` depending on the target OS
 
 ifdef::review[Reviewers:still need recommendations for Windows.]

--- a/tools/get.sh
+++ b/tools/get.sh
@@ -4,12 +4,12 @@
 # `get.sh` is a simple one-liner shell script to
 # Install the official Cloudflow kubectl plugin
 #
-#   $ curl -sL http://cloudflow.io/docs/get.sh | sh
+#   $ curl -sL http://cloudflow.io/docs/get.sh | bash
 #
 # Options may be passed to the shell script with `-s --`:
 #
-#   $ curl -sL http://cloudflow.io/docs/get.sh | sh -s -- --prefix=$HOME --version=2.0.22 --verbose
-#   $ curl -sL http://cloudflow.io/docs/get.sh | sh -s -- -P $HOME -v 2.0.22 -V
+#   $ curl -sL http://cloudflow.io/docs/get.sh | bash -s -- --prefix=$HOME --version=2.0.22 --verbose
+#   $ curl -sL http://cloudflow.io/docs/get.sh | bash -s -- -P $HOME -v 2.0.22 -V
 #
 set -euo pipefail
 

--- a/tools/get.sh
+++ b/tools/get.sh
@@ -256,7 +256,7 @@ confirm "Install Cloudflow CLI ${GREEN}${RESOLVED}${NO_COLOR} to ${BOLD}${GREEN}
 
 info "Installing Cloudflow CLI, please wait…"
 
-rm -f "${PREFIX}/kubectl-cloudflow"
+rm -f "${PREFIX}/kubectl-cloudflow" || true
 
 fetch "${URL}" \
   | tar xzf${VERBOSE} - \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Switch fully to `bash` for the installation script and improve the documentation.

### Why are the changes needed?
Fix the installer script for Ubuntu 16 ( fix #988 )

### Does this PR introduce any user-facing change?
Change the one-liner `get.sh` to default to `bash`.

### How was this patch tested?
On Ubuntu 16 and on Mac OsX

Thanks @michael-read for the report!