### PR TITLE
Up testcontainers version to 1.15.2

### DIFF
--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Version {
   val Spark         = "2.4.5"
   val Flink         = "1.10.3"
   val KafkaClients  = "2.5.1"
-  val TestcontainersKafka = "1.15.1" 
+  val TestcontainersKafka = "1.15.2"
 }
 
 object Library {


### PR DESCRIPTION
### What changes were proposed in this pull request?
After switching to testcontainers instead of the embedded kafka in runLocal mode, kafka transactions stopped working, because until the latest version of testcontainers 1.15.2, the properties required for kafka transactions working in single-node mode were not set in the base container:
`KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1`
`KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1`

these changes were added recently in the latest release.

more details about the issue: https://github.com/testcontainers/testcontainers-java/issues/1816

changes in testcontainers in question:
https://github.com/testcontainers/testcontainers-java/blob/master/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java#L67

### Why are the changes needed?
Fixes runLocal mode when using kafka transactions.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
1. run locally one of example pipelines
2. find runing testcontainrs kafka container through `docker ps`
3. see logs of that container `docker logs -f :container_name`

with testcontainers version 1.15.1 logs contains:
`[2021-02-21 16:13:36,788] ERROR [KafkaApi-1] Number of alive brokers '1' does not meet the required replication factor '3' for the transactions state topic (configured via 'transaction.state.log.replication.factor'). This error can be ignored if the cluster is starting up and not all brokers are up yet. (kafka.server.KafkaApis)`

with version 1.15.2 all's ok:
`[2021-02-21 16:12:32,538] INFO [Transaction State Manager 1]: Completed loading transaction metadata from __transaction_state-18 for coordinator epoch 0 (kafka.coordinator.transaction.TransactionStateManager)`
