### PR TITLE
Fix tests instability

### DIFF
--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkScalaTestSupport.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkScalaTestSupport.scala
@@ -21,7 +21,12 @@ import org.scalatest._
 
 trait SparkScalaTestSupport extends WordSpec with MustMatchers with BeforeAndAfterAll {
 
-  val session: SparkSession = SparkSession.builder().master("local[2]").appName("test").getOrCreate()
+  val session: SparkSession = SparkSession
+    .builder()
+    .master("local[*]")
+    .config("spark.driver.bindAddress", "127.0.0.1")
+    .appName("test")
+    .getOrCreate()
   session.sparkContext.setLogLevel("WARN")
 
   implicit lazy val sqlCtx = session.sqlContext


### PR DESCRIPTION
This "should" make the Spark tests more stable (they started to fail quite frequently in CI only)