### PR TITLE
Fix pod config stacking with empty lists

### DIFF
--- a/tools/cloudflow-config/src/main/scala/akka/cloudflow/config/CloudflowConfig.scala
+++ b/tools/cloudflow-config/src/main/scala/akka/cloudflow/config/CloudflowConfig.scala
@@ -621,8 +621,8 @@ object CloudflowConfig {
 
     ConfigFactory
       .empty()
-      .withFallback(streamletConfig)
       .withFallback(runtimeConfig)
+      .withFallback(streamletConfig)
       .withOnlyPath("kubernetes")
   }
 

--- a/tools/cloudflow-config/src/main/scala/akka/cloudflow/config/CloudflowConfig.scala
+++ b/tools/cloudflow-config/src/main/scala/akka/cloudflow/config/CloudflowConfig.scala
@@ -190,8 +190,8 @@ object CloudflowConfig {
 
   // Container
   final case class Container(
-      env: List[EnvVar] = List(),
-      ports: List[ContainerPort] = List(),
+      env: Option[List[EnvVar]] = None,
+      ports: Option[List[ContainerPort]] = None,
       resources: Requirements = Requirements(),
       volumeMounts: Map[String, VolumeMount] = Map())
 
@@ -621,8 +621,8 @@ object CloudflowConfig {
 
     ConfigFactory
       .empty()
-      .withFallback(runtimeConfig)
       .withFallback(streamletConfig)
+      .withFallback(runtimeConfig)
       .withOnlyPath("kubernetes")
   }
 

--- a/tools/cloudflow-config/src/test/scala/akka/cloudflow/config/CloudflowConfigSpec.scala
+++ b/tools/cloudflow-config/src/test/scala/akka/cloudflow/config/CloudflowConfigSpec.scala
@@ -459,8 +459,8 @@ class CloudflowConfigSpec extends AnyFlatSpec with Matchers with OptionValues wi
     executor.annotations(AnnotationKey("akey3")) shouldBe AnnotationValue("avalue3")
     executor.annotations(AnnotationKey("akey4")) shouldBe AnnotationValue("avalue4")
 
-    val driverContainerEnv = driver.containers("container").env.head
-    val executorContainerEnv = executor.containers("container").env.head
+    val driverContainerEnv = driver.containers("container").env.head.head
+    val executorContainerEnv = executor.containers("container").env.head.head
 
     driverContainerEnv.name shouldBe "FOO"
     driverContainerEnv.value shouldBe "BAR"
@@ -615,6 +615,7 @@ class CloudflowConfigSpec extends AnyFlatSpec with Matchers with OptionValues wi
       .pods("pod")
       .containers("container")
       .ports
+      .get
 
     ports(0).containerPort shouldBe 9001
     ports(0).protocol shouldBe "TCP"

--- a/tools/cloudflow-config/src/test/scala/akka/cloudflow/config/CloudflowConfigSpec.scala
+++ b/tools/cloudflow-config/src/test/scala/akka/cloudflow/config/CloudflowConfigSpec.scala
@@ -1007,4 +1007,60 @@ class CloudflowConfigSpec extends AnyFlatSpec with Matchers with OptionValues wi
     res.isFailure shouldBe true
     res.failure.exception.getMessage.contains("cloudflow.topics.my-topic.topic.replicas") shouldBe true
   }
+
+  it should "stack pod config in the correct order" in {
+    // Arrange
+    val appConfig = ConfigFactory.parseString("""
+      cloudflow {
+        # if u remove the streamlet specific config then it works again
+        streamlets.logger {
+          kubernetes.pods.pod.containers {
+            cloudflow {
+              resources {
+                requests {
+                  memory = "1G"
+                }
+              }
+            }
+          }
+        }
+        runtimes.akka {
+          kubernetes.pods.pod.containers {
+            cloudflow {
+              resources {
+                limits {
+                  memory = "3G"
+                }
+              }
+              env = [
+                { name = "JAVA_OPTS"
+                  value = "-XX:MaxRAMPercentage=40.0"
+                }
+              ]
+            }
+          }
+        }
+      }
+      """)
+
+    // Act
+    val cloudflowConfig = CloudflowConfig.loadAndValidate(appConfig).get
+
+    val podConfig = CloudflowConfig.podsConfig("logger", "akka", cloudflowConfig)
+
+    // Assert
+    podConfig
+      .getConfigList("kubernetes.pods.pod.containers.cloudflow.env")
+      .get(0)
+      .getString("name") shouldBe "JAVA_OPTS"
+    podConfig
+      .getConfigList("kubernetes.pods.pod.containers.cloudflow.env")
+      .get(0)
+      .getString("value") shouldBe "-XX:MaxRAMPercentage=40.0"
+    podConfig
+      .getString("kubernetes.pods.pod.containers.cloudflow.resources.requests.memory") shouldBe "1G"
+    podConfig
+      .getString("kubernetes.pods.pod.containers.cloudflow.resources.limits.memory") shouldBe "3G"
+  }
+
 }

--- a/tools/tooling/src/main/scala/cli/SamplesGenerator.scala
+++ b/tools/tooling/src/main/scala/cli/SamplesGenerator.scala
@@ -27,7 +27,7 @@ object SamplesGenerator extends App {
                 "my-pvc" -> PvcVolume(name = "cloudflow-pvc", readOnly = false),
                 "my-secret" -> SecretVolume(name = "secret.conf")),
               containers = Map("my-container" -> Container(
-                env = List(EnvVar("ENV_VAR_KEY", "ENV_VAR_VALUE")),
+                env = Some(List(EnvVar("ENV_VAR_KEY", "ENV_VAR_VALUE"))),
                 resources = Requirements(
                   requests = Requirement(cpu = Some(Quantity("1")), memory = Some(Quantity("1Gb"))),
                   limits = Requirement(cpu = Some(Quantity("2")), memory = Some(Quantity("2Gb")))),
@@ -44,7 +44,7 @@ object SamplesGenerator extends App {
                 "my-pvc" -> PvcVolume(name = "cloudflow-pvc", readOnly = false),
                 "my-secret" -> SecretVolume(name = "secret.conf")),
               containers = Map("my-container" -> Container(
-                env = List(EnvVar("ENV_VAR_KEY", "ENV_VAR_VALUE")),
+                env = Some(List(EnvVar("ENV_VAR_KEY", "ENV_VAR_VALUE"))),
                 resources = Requirements(
                   requests = Requirement(cpu = Some(Quantity("1")), memory = Some(Quantity("1Gb"))),
                   limits = Requirement(cpu = Some(Quantity("2")), memory = Some(Quantity("2Gb")))),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the order for stacking Configuration of `pod-config`

### Why are the changes needed?
The specific streamlet config should override the generic runtime

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Unit test
