### PR TITLE
no need for it and also it was throwing an error

### DIFF
--- a/core/cloudflow-sbt-plugin/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
+++ b/core/cloudflow-sbt-plugin/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
@@ -208,12 +208,15 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
     val localClasspath = classpath.files.map(_.toURI.toURL).toArray
     val logLibs = Seq(toURLSegment(Log4J), toURLSegment(Slf4jLog4jBridge))
     // forced `get` b/c these libraries are added to the classpath.
-    logLibs.map(lib => lib -> localClasspath.find(_.toString.contains(lib)).get)
+    logLibs.map(lib => lib -> localClasspath.find(path => dotToSlash(path.toString).contains(lib)).get)
   }
+
+  def dotToSlash(name: String): String =
+    name.replaceAll("\\.", "/")
 
   // transforms the organization and name of a module into the URL format used by the classpath resolution
   def toURLSegment(dep: ModuleID): String = {
-    val org = dep.organization
+    val org = dotToSlash(dep.organization)
     val name = dep.name
     s"$org/$name"
   }

--- a/core/cloudflow-sbt-plugin/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
+++ b/core/cloudflow-sbt-plugin/src/main/scala/cloudflow/sbt/CloudflowLocalRunnerPlugin.scala
@@ -213,7 +213,7 @@ object CloudflowLocalRunnerPlugin extends AutoPlugin {
 
   // transforms the organization and name of a module into the URL format used by the classpath resolution
   def toURLSegment(dep: ModuleID): String = {
-    val org = dep.organization.replaceAll("\\.", "/")
+    val org = dep.organization
     val name = dep.name
     s"$org/$name"
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
not substitute dot per forward slash


### Why are the changes needed?
We were getting this error when `runLocal`
```
[error] java.util.NoSuchElementException: None.get
[error] 	at scala.None$.get(Option.scala:529)
[error] 	at scala.None$.get(Option.scala:527)
[error] 	at cloudflow.sbt.CloudflowLocalRunnerPlugin$.$anonfun$findLogLibsInPluginClasspath$3(CloudflowLocalRunnerPlugin.scala:214)
[error] 	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238)
[error] 	at scala.collection.immutable.List.foreach(List.scala:392)
[error] 	at scala.collection.TraversableLike.map(TraversableLike.scala:238)
[error] 	at scala.collection.TraversableLike.map$(TraversableLike.scala:231)
[error] 	at scala.collection.immutable.List.map(List.scala:298)
[error] 	at cloudflow.sbt.CloudflowLocalRunnerPlugin$.findLogLibsInPluginClasspath(CloudflowLocalRunnerPlugin.scala:214)
[error] 	at cloudflow.sbt.CloudflowLocalRunnerPlugin$.$anonfun$projectSettings$11(CloudflowLocalRunnerPlugin.scala:106)
[error] 	at cloudflow.sbt.CloudflowLocalRunnerPlugin$.$anonfun$projectSettings$11$adapted(CloudflowLocalRunnerPlugin.scala:92)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:281)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error] 	at sbt.Execute.work(Execute.scala:290)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:281)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
```

with these entries (check the last 4):
```
####### logLibs List(log4j/log4j, org.slf4j/slf4j-log4j12)
####### localClasspath
....private information...
file:/Users/Francisco.Lopez-Sancho@ey.com/.sbt/boot/scala-2.12.10/lib/scala-library.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.sbt/boot/scala-2.12.10/lib/scala-compiler.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.sbt/boot/scala-2.12.10/lib/scala-reflect.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.thesamet.scalapb/scalapb-runtime_2.12/jars/scalapb-runtime_2.12-0.10.8.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.thesamet.scalapb/lenses_2.12/jars/lenses_2.12-0.10.8.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.scala-lang.modules/scala-collection-compat_2.12/jars/scala-collection-compat_2.12-2.1.6.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.google.protobuf/protobuf-java/bundles/protobuf-java-3.11.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.lihaoyi/fastparse_2.12/jars/fastparse_2.12-2.3.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.lihaoyi/sourcecode_2.12/jars/sourcecode_2.12-0.2.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.lihaoyi/geny_2.12/jars/geny_2.12-0.6.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.lightbend.akka.grpc/akka-grpc-runtime_2.12/jars/akka-grpc-runtime_2.12-1.0.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.grpc/grpc-core/jars/grpc-core-1.32.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.grpc/grpc-api/jars/grpc-api-1.32.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.grpc/grpc-context/jars/grpc-context-1.32.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.google.code.findbugs/jsr305/jars/jsr305-3.0.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.grpc/grpc-netty-shaded/jars/grpc-netty-shaded-1.32.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.akka/akka-stream_2.12/jars/akka-stream_2.12-2.5.31.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.akka/akka-actor_2.12/jars/akka-actor_2.12-2.5.31.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.akka/akka-protobuf_2.12/jars/akka-protobuf_2.12-2.5.31.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe/ssl-config-core_2.12/bundles/ssl-config-core_2.12-0.3.8.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.1.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.akka/akka-http-core_2.12/jars/akka-http-core_2.12-10.1.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.akka/akka-parsing_2.12/jars/akka-parsing_2.12-10.1.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.akka/akka-http_2.12/jars/akka-http_2.12-10.1.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.akka/akka-http2-support_2.12/jars/akka-http2-support_2.12-10.1.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.twitter/hpack/jars/hpack-1.0.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.eclipse.jetty.alpn/alpn-api/jars/alpn-api-1.1.3.v20160715.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.akka/akka-discovery_2.12/jars/akka-discovery_2.12-2.5.31.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.google.guava/guava/bundles/guava-29.0-android.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.google.guava/failureaccess/bundles/failureaccess-1.0.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.google.guava/listenablefuture/jars/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.checkerframework/checker-compat-qual/jars/checker-compat-qual-2.5.5.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.google.j2objc/j2objc-annotations/jars/j2objc-annotations-1.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.codehaus.mojo/animal-sniffer-annotations/jars/animal-sniffer-annotations-1.18.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.google.code.gson/gson/jars/gson-2.8.6.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.google.android/annotations/jars/annotations-4.1.1.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.perfmark/perfmark-api/jars/perfmark-api-0.19.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.grpc/grpc-stub/jars/grpc-stub-1.32.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.twitter/bijection-avro_2.12/jars/bijection-avro_2.12-0.9.7.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.twitter/bijection-core_2.12/jars/bijection-core_2.12-0.9.7.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/local/com.lightbend.cloudflow/cloudflow-streamlets_2.12/2.0.24-NIGHTLY20210302-27-efe3bc45/jars/cloudflow-streamlets_2.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.spray/spray-json_2.12/jars/spray-json_2.12-1.3.5.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe/config/bundles/config-1.4.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.iheart/ficus_2.12/jars/ficus_2.12-1.4.7.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.typelevel/macro-compat_2.12/jars/macro-compat_2.12-1.1.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.scala-logging/scala-logging_2.12/bundles/scala-logging_2.12-3.9.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.scalactic/scalactic_2.12/bundles/scalactic_2.12-3.1.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.krzemin/octopus_2.12/jars/octopus_2.12-0.4.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.chuusai/shapeless_2.12/bundles/shapeless_2.12-2.3.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.datastax.cassandra/cassandra-driver-core/jars/cassandra-driver-core-3.9.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.jnr/jnr-ffi/jars/jnr-ffi-2.1.7.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.jnr/jffi/jars/jffi-1.2.16.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.jnr/jffi/jars/jffi-1.2.16-native.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.ow2.asm/asm/jars/asm-5.0.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.ow2.asm/asm-commons/jars/asm-commons-5.0.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.ow2.asm/asm-tree/jars/asm-tree-5.0.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.ow2.asm/asm-analysis/jars/asm-analysis-5.0.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.ow2.asm/asm-util/jars/asm-util-5.0.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.jnr/jnr-x86asm/jars/jnr-x86asm-1.0.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.jnr/jnr-posix/jars/jnr-posix-3.0.44.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.jnr/jnr-constants/jars/jnr-constants-0.9.9.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.mockito/mockito-scala_2.12/jars/mockito-scala_2.12-1.14.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.mockito/mockito-core/jars/mockito-core-3.3.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/net.bytebuddy/byte-buddy/jars/byte-buddy-1.10.5.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/net.bytebuddy/byte-buddy-agent/jars/byte-buddy-agent-1.10.5.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.objenesis/objenesis/jars/objenesis-2.6.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/ru.vyarus/generics-resolver/jars/generics-resolver-3.0.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/local/au.com.westpac/itm-datapipeline-commons_2.12/20210508/jars/itm-datapipeline-commons_2.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.postgresql/postgresql/jars/postgresql-42.2.18.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.checkerframework/checker-qual/jars/checker-qual-3.5.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.commons/commons-dbcp2/jars/commons-dbcp2-2.8.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.commons/commons-pool2/jars/commons-pool2-2.8.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/commons-logging/commons-logging/jars/commons-logging-1.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.springframework/spring-expression/jars/spring-expression-5.3.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.springframework/spring-core/jars/spring-core-5.3.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.springframework/spring-jcl/jars/spring-jcl-5.3.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.commons/commons-lang3/jars/commons-lang3-3.11.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.sksamuel.avro4s/avro4s-core_2.12/jars/avro4s-core_2.12-3.0.0-RC2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.avro/avro/bundles/avro-1.9.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.commons/commons-compress/jars/commons-compress-1.18.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.softwaremill/magnolia_2.12/jars/magnolia_2.12-0.11.0-sml.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.propensive/mercator_2.12/jars/mercator_2.12-0.1.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-2.1.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.typelevel/cats-macros_2.12/jars/cats-macros_2.12-2.1.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.typelevel/cats-kernel_2.12/jars/cats-kernel_2.12-2.1.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.typelevel/cats-effect_2.12/jars/cats-effect_2.12-2.1.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.scalaz/scalaz-core_2.12/jars/scalaz-core_2.12-7.3.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.slamdata/matryoshka-core_2.12/jars/matryoshka-core_2.12-0.21.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.typelevel/scala-library/jars/scala-library-2.12.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.slamdata/slamdata-predef_2.12/jars/slamdata-predef_2.12-0.0.6.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.mpilquist/simulacrum_2.12/jars/simulacrum_2.12-0.11.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.typelevel/cats-free_2.12/jars/cats-free_2.12-2.1.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.microsoft.azure/azure-keyvault/jars/azure-keyvault-1.2.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.microsoft.azure/azure-keyvault-cryptography/jars/azure-keyvault-cryptography-1.2.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.microsoft.azure/azure-keyvault-webkey/jars/azure-keyvault-webkey-1.2.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.13.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.microsoft.azure/azure-keyvault-core/jars/azure-keyvault-core-1.2.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.microsoft.azure/azure-client-runtime/jars/azure-client-runtime-1.7.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.microsoft.rest/client-runtime/jars/client-runtime-1.7.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.squareup.retrofit2/retrofit/jars/retrofit-2.7.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.squareup.okhttp3/okhttp/jars/okhttp-3.14.7.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.squareup.okio/okio/jars/okio-1.17.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.squareup.okhttp3/logging-interceptor/jars/logging-interceptor-3.12.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.squareup.okhttp3/okhttp-urlconnection/jars/okhttp-urlconnection-3.12.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.squareup.retrofit2/converter-jackson/jars/converter-jackson-2.7.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.fasterxml.jackson.datatype/jackson-datatype-joda/bundles/jackson-datatype-joda-2.10.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/joda-time/joda-time/jars/joda-time-2.9.9.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.reactivex/rxjava/jars/rxjava-1.3.8.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.squareup.retrofit2/adapter-rxjava/jars/adapter-rxjava-2.7.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.microsoft.azure/azure-annotations/jars/azure-annotations-1.10.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.azure/azure-security-keyvault-secrets/jars/azure-security-keyvault-secrets-4.2.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.azure/azure-core/jars/azure-core-1.7.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.10.1/jackson-dataformat-xml-2.10.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.10.1/jackson-module-jaxb-annotations-2.10.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/jakarta/xml/bind/jakarta.xml.bind-api/2.3.2/jakarta.xml.bind-api-2.3.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/jakarta/activation/jakarta.activation-api/1.2.1/jakarta.activation-api-1.2.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/org/codehaus/woodstox/stax2-api/4.2/stax2-api-4.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/com/fasterxml/woodstox/woodstox-core/6.0.2/woodstox-core-6.0.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.slf4j/slf4j-api/jars/slf4j-api-1.7.30.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.projectreactor/reactor-core/jars/reactor-core-3.3.8.RELEASE.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-tcnative-boringssl-static/jars/netty-tcnative-boringssl-static-2.0.31.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.azure/azure-core-http-netty/jars/azure-core-http-netty-1.5.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-handler/jars/netty-handler-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-common/jars/netty-common-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-resolver/jars/netty-resolver-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-buffer/jars/netty-buffer-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-transport/jars/netty-transport-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-codec/jars/netty-codec-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-handler-proxy/jars/netty-handler-proxy-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-codec-socks/jars/netty-codec-socks-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-codec-http/jars/netty-codec-http-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-codec-http2/jars/netty-codec-http2-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-transport-native-unix-common/jars/netty-transport-native-unix-common-4.1.51.Final.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-transport-native-epoll/jars/netty-transport-native-epoll-4.1.51.Final-linux-x86_64.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.netty/netty-transport-native-kqueue/jars/netty-transport-native-kqueue-4.1.51.Final-osx-x86_64.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.projectreactor.netty/reactor-netty/jars/reactor-netty-0.9.10.RELEASE.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.azure/azure-identity/jars/azure-identity-1.1.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.microsoft.azure/msal4j/jars/msal4j-1.6.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.nimbusds/oauth2-oidc-sdk/jars/oauth2-oidc-sdk-7.1.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.stephenc.jcip/jcip-annotations/jars/jcip-annotations-1.0-1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.nimbusds/content-type/jars/content-type-2.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/net.minidev/json-smart/bundles/json-smart-1.3.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.nimbusds/lang-tag/jars/lang-tag-1.4.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.nimbusds/nimbus-jose-jwt/jars/nimbus-jose-jwt-8.8.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.sun.mail/javax.mail/jars/javax.mail-1.6.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/javax.activation/activation/jars/activation-1.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.microsoft.azure/msal4j-persistence-extension/jars/msal4j-persistence-extension-1.0.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/net.java.dev.jna/jna/jars/jna-5.5.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/net.java.dev.jna/jna-platform/jars/jna-platform-5.4.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.nanohttpd/nanohttpd/jars/nanohttpd-2.3.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.linguafranca.pwdb/KeePassJava2/jars/KeePassJava2-2.1.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.linguafranca.pwdb/KeePassJava2-kdb/jars/KeePassJava2-kdb-2.1.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.linguafranca.pwdb/database/jars/database-2.1.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.jetbrains/annotations/jars/annotations-15.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.madgag.spongycastle/core/jars/core-1.54.0.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.linguafranca.pwdb/KeePassJava2-dom/jars/KeePassJava2-dom-2.1.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.linguafranca.pwdb/KeePassJava2-kdbx/jars/KeePassJava2-kdbx-2.1.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.linguafranca.pwdb/KeePassJava2-jaxb/jars/KeePassJava2-jaxb-2.1.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.linguafranca.pwdb/KeePassJava2-simple/jars/KeePassJava2-simple-2.1.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.simpleframework/simple-xml/jars/simple-xml-2.7.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/stax/stax-api/jars/stax-api-1.0.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/stax/stax/jars/stax-1.2.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/xpp3/xpp3/jars/xpp3-1.1.3.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.httpcomponents/httpcore/jars/httpcore-4.4.5.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.fasterxml/aalto-xml/bundles/aalto-xml-1.0.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.azure/azure-security-keyvault-keys/jars/azure-security-keyvault-keys-4.0.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.play/play-json_2.12/jars/play-json_2.12-2.9.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.play/play-functional_2.12/jars/play-functional_2.12-2.9.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/bundles/jackson-datatype-jdk8-2.10.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/bundles/jackson-datatype-jsr310-2.10.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/tech.allegro.schema.json2avro/converter/jars/converter-0.2.9.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/au.com.westpac.itm.core.finite-state-machine.fsm-event-publisher/develop-fsm-event-publisher/jars/develop-fsm-event-publisher-25.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.itm.common.utility/itmTrackerUtility/jars/itmTrackerUtility-17.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.circe/circe-parser_2.12/jars/circe-parser_2.12-0.13.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.circe/circe-jawn_2.12/jars/circe-jawn_2.12-0.13.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.circe/circe-core_2.12/jars/circe-core_2.12-0.13.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.circe/circe-numbers_2.12/jars/circe-numbers_2.12-0.13.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.typelevel/jawn-parser_2.12/jars/jawn-parser_2.12-1.0.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.circe/circe-optics_2.12/jars/circe-optics_2.12-0.13.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.julien-truffaut/monocle-core_2.12/jars/monocle-core_2.12-2.0.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.blemale/scaffeine_2.12/jars/scaffeine_2.12-4.0.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.ben-manes.caffeine/caffeine/jars/caffeine-2.8.5.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.google.errorprone/error_prone_annotations/jars/error_prone_annotations-2.4.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.scala-lang.modules/scala-java8-compat_2.12/bundles/scala-java8-compat_2.12-0.9.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/io.dropwizard.metrics/metrics-core/bundles/metrics-core-3.2.6.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.cb372/scalacache-cats-effect_2.12/jars/scalacache-cats-effect_2.12-0.28.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.cb372/scalacache-core_2.12/jars/scalacache-core_2.12-0.28.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.itm.common.utility/itm-common-udf/jars/itm-common-udf-8.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.itm.common.utility/itmEEkeyvaultUtility/jars/itmEEkeyvaultUtility-5.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.itm.common.utility/itmAzureMIKeyvaultUtility/jars/itmAzureMIKeyvaultUtility-48.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/local/com.lightbend.cloudflow/cloudflow-runner_2.12/2.0.24-NIGHTLY20210302-27-efe3bc45/jars/cloudflow-runner_2.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/local/com.lightbend.cloudflow/cloudflow-blueprint_2.12/2.0.24-NIGHTLY20210302-27-efe3bc45/jars/cloudflow-blueprint_2.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/local/com.lightbend.cloudflow/cloudflow-localrunner_2.12/2.0.24-NIGHTLY20210302-27-efe3bc45/jars/cloudflow-localrunner_2.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/local/com.lightbend.cloudflow/cloudflow-runner-config_2.12/2.0.24-NIGHTLY20210302-27-efe3bc45/jars/cloudflow-runner-config_2.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.fasterxml.jackson.module/jackson-module-scala_2.12/bundles/jackson-module-scala_2.12-2.11.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.fasterxml.jackson.core/jackson-core/bundles/jackson-core-2.11.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.fasterxml.jackson.core/jackson-annotations/bundles/jackson-annotations-2.11.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.fasterxml.jackson.core/jackson-databind/bundles/jackson-databind-2.11.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.fasterxml.jackson.module/jackson-module-paranamer/bundles/jackson-module-paranamer-2.11.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.thoughtworks.paranamer/paranamer/bundles/paranamer-2.8.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/local/com.lightbend.cloudflow/cloudflow-flink_2.12/2.0.24-NIGHTLY20210302-27-efe3bc45/jars/cloudflow-flink_2.12.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-scala_2.12/jars/flink-scala_2.12-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-core/jars/flink-core-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-annotations/jars/flink-annotations-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/force-shading/jars/force-shading-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-metrics-core/jars/flink-metrics-core-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/org/apache/flink/flink-shaded-asm-7/7.1-9.0/flink-shaded-asm-7-7.1-9.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/com/esotericsoftware/kryo/kryo/2.24.0/kryo-2.24.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/com/esotericsoftware/minlog/minlog/1.2/minlog-1.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/org/apache/flink/flink-shaded-guava/18.0-9.0/flink-shaded-guava-18.0-9.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-java/jars/flink-java-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/org/apache/commons/commons-math3/3.5/commons-math3-3.5.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-streaming-scala_2.12/jars/flink-streaming-scala_2.12-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-streaming-java_2.12/jars/flink-streaming-java_2.12-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-runtime_2.12/jars/flink-runtime_2.12-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-queryable-state-client-java/jars/flink-queryable-state-client-java-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-shaded-netty/jars/flink-shaded-netty-4.1.39.Final-9.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-hadoop-fs/jars/flink-hadoop-fs-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/commons-io/commons-io/jars/commons-io-2.4.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/org/apache/flink/flink-shaded-jackson/2.10.1-9.0/flink-shaded-jackson-2.10.1-9.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.m2/repository/commons-cli/commons-cli/1.3.1/commons-cli-1.3.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.javassist/javassist/bundles/javassist-3.24.0-GA.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.typesafe.akka/akka-slf4j_2.12/jars/akka-slf4j_2.12-2.5.21.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.clapper/grizzled-slf4j_2.12/jars/grizzled-slf4j_2.12-1.3.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.scopt/scopt_2.12/jars/scopt_2.12-3.5.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.twitter/chill_2.12/jars/chill_2.12-0.7.6.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.twitter/chill-java/jars/chill-java-0.7.6.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.lz4/lz4-java/jars/lz4-java-1.5.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-clients_2.12/jars/flink-clients_2.12-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-optimizer_2.12/jars/flink-optimizer_2.12-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-connector-kafka_2.12/jars/flink-connector-kafka_2.12-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-connector-kafka-base_2.12/jars/flink-connector-kafka-base_2.12-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.kafka/kafka-clients/jars/kafka-clients-2.2.0.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.github.luben/zstd-jni/jars/zstd-jni-1.3.8-1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.xerial.snappy/snappy-java/bundles/snappy-java-1.1.7.2.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-avro/jars/flink-avro-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-runtime-web_2.12/jars/flink-runtime-web_2.12-1.10.3.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.apache.flink/flink-state-processor-api_2.12/jars/flink-state-processor-api_2.12-1.9.1.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.slf4j/slf4j-log4j12/jars/slf4j-log4j12-1.7.30.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/log4j/log4j/bundles/log4j-1.2.17.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/com.sksamuel.scapegoat/scalac-scapegoat-plugin_2.12/jars/scalac-scapegoat-plugin_2.12-1.3.9.jar
file:/Users/Francisco.Lopez-Sancho@ey.com/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12/bundles/scala-xml_2.12-1.2.0.jar
```


### Does this PR introduce any user-facing change?
no


### How was this patch tested?
rebuilding `sbt-plugin` and executing `runLocal`
