### PR TITLE
Testkit sink write

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -316,8 +316,7 @@ lazy val cloudflowAkkaTestkit =
       crossScalaVersions := Vector(Dependencies.Scala212, Dependencies.Scala213),
       scalafmtOnCompile := true,
       javacOptions ++= Seq("-Xlint:deprecation", "-Xlint:unchecked"),
-     (sourceGenerators in Test) += (avroScalaGenerateSpecific in Test).taskValue
-    )
+      (sourceGenerators in Test) += (avroScalaGenerateSpecific in Test).taskValue)
 
 lazy val cloudflowAkkaUtil =
   Project(id = "cloudflow-akka-util", base = file("cloudflow-akka-util"))

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -295,32 +295,34 @@ lazy val cloudflowStreamlets =
       crossScalaVersions := Vector(Dependencies.Scala212, Dependencies.Scala213),
       scalafmtOnCompile := true)
 
-lazy val cloudflowAkkastream =
+lazy val cloudflowAkka =
   Project(id = "cloudflow-akka", base = file("cloudflow-akka"))
     .enablePlugins(GenJavadocPlugin, JavaFormatterPlugin, ScalafmtPlugin)
     .dependsOn(cloudflowStreamlets)
-    .settings(Dependencies.cloudflowAkkastream)
+    .settings(Dependencies.cloudflowAkka)
     .settings(
       scalaVersion := Dependencies.Scala212,
       crossScalaVersions := Vector(Dependencies.Scala212, Dependencies.Scala213),
       javacOptions += "-Xlint:deprecation",
       scalafmtOnCompile := true)
 
-lazy val cloudflowAkkastreamTestkit =
+lazy val cloudflowAkkaTestkit =
   Project(id = "cloudflow-akka-testkit", base = file("cloudflow-akka-testkit"))
     .enablePlugins(GenJavadocPlugin, JavaFormatterPlugin, ScalafmtPlugin)
-    .dependsOn(cloudflowAkkastream)
-    .settings(Dependencies.cloudflowAkkastreamTestkit)
+    .dependsOn(cloudflowAkka)
+    .settings(Dependencies.cloudflowAkkaTestkit)
     .settings(
       scalaVersion := Dependencies.Scala212,
       crossScalaVersions := Vector(Dependencies.Scala212, Dependencies.Scala213),
       scalafmtOnCompile := true,
-      javacOptions ++= Seq("-Xlint:deprecation", "-Xlint:unchecked"))
+      javacOptions ++= Seq("-Xlint:deprecation", "-Xlint:unchecked"),
+     (sourceGenerators in Test) += (avroScalaGenerateSpecific in Test).taskValue
+    )
 
-lazy val cloudflowAkkastreamUtil =
+lazy val cloudflowAkkaUtil =
   Project(id = "cloudflow-akka-util", base = file("cloudflow-akka-util"))
     .enablePlugins(GenJavadocPlugin, JavaFormatterPlugin, ScalafmtPlugin)
-    .dependsOn(cloudflowAkkastream, (cloudflowAkkastreamTestkit % "test->test").classpathDependency)
+    .dependsOn(cloudflowAkka, (cloudflowAkkaTestkit % "test->test").classpathDependency)
     .settings(Dependencies.cloudflowAkkaUtil)
     .settings(
       scalaVersion := Dependencies.Scala212,
@@ -329,11 +331,11 @@ lazy val cloudflowAkkastreamUtil =
       javacOptions += "-Xlint:deprecation",
       (Test / sourceGenerators) += (Test / avroScalaGenerateSpecific).taskValue)
 
-lazy val cloudflowAkkastreamTests =
+lazy val cloudflowAkkaTests =
   Project(id = "cloudflow-akka-tests", base = file("cloudflow-akka-tests"))
     .enablePlugins(JavaFormatterPlugin, ScalafmtPlugin)
-    .dependsOn(cloudflowAkkastream, (cloudflowAkkastreamTestkit % "test->test").classpathDependency)
-    .settings(Dependencies.cloudflowAkkastreamTests)
+    .dependsOn(cloudflowAkka, (cloudflowAkkaTestkit % "test->test").classpathDependency)
+    .settings(Dependencies.cloudflowAkkaTests)
     .settings(
       scalaVersion := Dependencies.Scala212,
       crossScalaVersions := Vector(Dependencies.Scala212, Dependencies.Scala213),
@@ -495,9 +497,9 @@ lazy val root = Project(id = "root", base = file("."))
     },
     ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(
         cloudflowStreamlets,
-        cloudflowAkkastream,
-        cloudflowAkkastreamUtil,
-        cloudflowAkkastreamTestkit,
+        cloudflowAkka,
+        cloudflowAkkaUtil,
+        cloudflowAkkaTestkit,
         cloudflowSpark,
         cloudflowSparkTestkit),
     JavaUnidoc / unidoc / unidocProjectFilter := (ScalaUnidoc / unidoc / unidocProjectFilter).value)
@@ -514,10 +516,10 @@ lazy val root = Project(id = "root", base = file("."))
     cloudflowSbtPlugin,
     cloudflowRunnerConfig,
     cloudflowStreamlets,
-    cloudflowAkkastream,
-    cloudflowAkkastreamTestkit,
-    cloudflowAkkastreamUtil,
-    cloudflowAkkastreamTests,
+    cloudflowAkka,
+    cloudflowAkkaTestkit,
+    cloudflowAkkaUtil,
+    cloudflowAkkaTests,
     cloudflowFlink,
     cloudflowFlinkTestkit,
     cloudflowFlinkTests,

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/TestContext.scala
@@ -174,7 +174,7 @@ private[testkit] case class TestContext(
   def sinkRef[T](outlet: CodecOutlet[T]): WritableSinkRef[T] =
     new WritableSinkRef[T] {
       lazy val sink = writeSink.contramap[(T, Committable)] {
-        case (t, c) => (t, Promise[T]().success(t), TestCommittableOffset())
+        case (t, c) => (t, Promise.successful(t), TestCommittableOffset())
       }
       val writeSink: Sink[(T, Promise[T], Committable), NotUsed] = {
         val flow = Flow[(T, Promise[T], Committable)]

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/javadsl/AkkaStreamletTestKit.scala
@@ -36,7 +36,7 @@ object AkkaStreamletTestKit {
 }
 
 /**
- * Java testkit for testing akkastreams streamlets.
+ * Java testkit for testing akka streamlets.
  *
  * API:
  *

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/package.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/package.scala
@@ -39,7 +39,7 @@ package testkit {
     private[testkit] def sink: Sink[PartitionedValue[T], Future[Done]]
 
     private[testkit] def toPartitionedValue(element: T): PartitionedValue[T] = {
-      PartitionedValue(outlet.partitioner(element), element, Promise[T]().complete(Try(element)))
+      PartitionedValue(outlet.partitioner(element), element, Promise.successful(element))
     }
 
     private[testkit] def toPartitionedValue(element: T, promise: Promise[T]): PartitionedValue[T] =

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/package.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/package.scala
@@ -17,7 +17,8 @@
 package cloudflow.akkastream
 
 package testkit {
-  import scala.concurrent.Future
+  import scala.util.Try
+  import scala.concurrent.{ Future, Promise }
   import akka.{ Done, NotUsed }
   import akka.stream.scaladsl._
   import cloudflow.streamlets.CodecOutlet
@@ -33,18 +34,22 @@ package testkit {
   trait OutletTap[T] {
     def outlet: CodecOutlet[T]
     def portName: String = outlet.name
-
+    private[testkit] def flow: Flow[PartitionedValue[T], PartitionedValue[T], NotUsed]
     // This is for internal usage so using a scaladsl Source is no problem
     private[testkit] def sink: Sink[PartitionedValue[T], Future[Done]]
 
-    private[testkit] def toPartitionedValue(element: T): PartitionedValue[T] =
-      PartitionedValue(outlet.partitioner(element), element)
+    private[testkit] def toPartitionedValue(element: T): PartitionedValue[T] = {
+      PartitionedValue(outlet.partitioner(element), element, Promise[T]().complete(Try(element)))
+    }
+
+    private[testkit] def toPartitionedValue(element: T, promise: Promise[T]): PartitionedValue[T] =
+      PartitionedValue(outlet.partitioner(element), element, promise)
   }
 
   /**
    * A representation of a key-value pair that is not bound to the Scala or Java DSLs
    */
-  case class PartitionedValue[T](key: String, value: T) {
+  private[testkit] case class PartitionedValue[T](key: String, value: T, promise: Promise[T]) {
     def getKey(): String = key
     def getValue(): T = value
   }

--- a/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/OutletTap.scala
+++ b/core/cloudflow-akka-testkit/src/main/scala/cloudflow/akkastream/testkit/scaladsl/OutletTap.scala
@@ -29,25 +29,29 @@ import cloudflow.akkastream.testkit.PartitionedValue
 case class Failed(e: Throwable)
 
 case class SinkOutletTap[T](outlet: CodecOutlet[T], val snk: Sink[(String, T), NotUsed]) extends OutletTap[T] {
-  private[testkit] val sink: Sink[PartitionedValue[T], Future[Done]] =
+  private[testkit] val flow: Flow[PartitionedValue[T], PartitionedValue[T], NotUsed] =
     Flow[PartitionedValue[T]]
       .alsoTo(
         Flow[PartitionedValue[T]]
           .map(pv => (pv.key, pv.value))
           .to(snk))
-      .toMat(Sink.ignore)(Keep.right)
+
+  private[testkit] val sink: Sink[PartitionedValue[T], Future[Done]] =
+    flow.toMat(Sink.ignore)(Keep.right)
 }
 
 case class ProbeOutletTap[T](outlet: CodecOutlet[T])(implicit system: ActorSystem) extends OutletTap[T] {
   val probe = new TestKit(system)
 
-  // This will emit Tuple2 elements to the test actor (partitioning key -> data)
-  // for easy usage in Scala-based tests
-  private[testkit] val sink: Sink[PartitionedValue[T], Future[Done]] =
+  private[testkit] val flow: Flow[PartitionedValue[T], PartitionedValue[T], NotUsed] =
     Flow[PartitionedValue[T]]
       .alsoTo(
         Flow[PartitionedValue[T]]
           .map(pv => (pv.key, pv.value))
           .to(Sink.actorRef[Tuple2[String, T]](probe.testActor, Completed, Failed)))
-      .toMat(Sink.ignore)(Keep.right)
+
+  // This will emit Tuple2 elements to the test actor (partitioning key -> data)
+  // for easy usage in Scala-based tests
+  private[testkit] val sink: Sink[PartitionedValue[T], Future[Done]] =
+    flow.toMat(Sink.ignore)(Keep.right)
 }

--- a/core/cloudflow-akka-testkit/src/test/avro/TestData.avsc
+++ b/core/cloudflow-akka-testkit/src/test/avro/TestData.avsc
@@ -1,0 +1,13 @@
+{
+    "namespace": "cloudflow.akkastream.testdata",
+    "type": "record",
+    "name": "TestData",
+    "fields":[
+         {
+            "name": "id", "type": "int"
+         },
+         {
+            "name": "name", "type": "string"
+         }
+    ]
+}

--- a/core/cloudflow-akka-testkit/src/test/scala/cloudflow/akkastream/testkit/TestSinkRefSpec.scala
+++ b/core/cloudflow-akka-testkit/src/test/scala/cloudflow/akkastream/testkit/TestSinkRefSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudflow.akkastream.testkit
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{ RunnableGraph, Source }
+import akka.testkit.TestKit
+import cloudflow.akkastream.{ AkkaStreamlet, AkkaStreamletLogic }
+import cloudflow.akkastream.scaladsl.RunnableGraphStreamletLogic
+import cloudflow.streamlets.StreamletShape
+import cloudflow.akkastream.testdata.TestData
+import cloudflow.akkastream.testkit.scaladsl._
+import cloudflow.streamlets.avro.{ AvroInlet, AvroOutlet }
+import org.scalatest._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.must.Matchers
+import scala.concurrent.Future
+
+class TestSinkRefSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+  private implicit val system = ActorSystem("CloudflowAkkaTestkitErrorReproducerSpec")
+
+  override def afterAll: Unit =
+    TestKit.shutdownActorSystem(system)
+
+  object TestFixture {
+    val msgs = List.tabulate(10)(i => TestData(i, i.toString))
+
+    class TestStreamlet extends AkkaStreamlet {
+      val in = AvroInlet[TestData]("in")
+      val out = AvroOutlet[TestData]("out")
+
+      override val shape: StreamletShape = StreamletShape(in).withOutlets(out)
+
+      override protected def createLogic(): AkkaStreamletLogic = new RunnableGraphStreamletLogic() {
+        override def runnableGraph(): RunnableGraph[_] = {
+          val snk = sinkRef(out)
+          sourceWithCommittableContext(in)
+            .mapAsync(parallelism = 1) { element =>
+              snk.write(element)
+            }
+            .to(committableSink)
+        }
+      }
+    }
+  }
+
+  import TestFixture._
+
+  "Cloudflow Akka TestKit" should {
+    "emit a dedicated completed messages after each message emitted via sinkRef.write, but should not" in {
+      val testkit = AkkaStreamletTestKit(system)
+      val s = new TestStreamlet()
+      val in = testkit.inletFromSource(s.in, Source(msgs))
+      val out = testkit.outletAsTap(s.out)
+
+      testkit.run(s, List(in), List(out), () => {
+        val results = out.probe.receiveN(msgs.size)
+
+        val resultWithoutIndex = results.asInstanceOf[Seq[(_, TestData)]].map(_._2)
+        resultWithoutIndex must contain allElementsOf msgs
+      })
+    }
+
+    (0 until 300).foreach { i =>
+      s"maintain the order in which messages are emitted via sinkRef.write (run #$i), but should not" in {
+        val testkit = AkkaStreamletTestKit(system)
+        val s = new TestStreamlet()
+        val in = testkit.inletFromSource(s.in, Source(msgs))
+        val out = testkit.outletAsTap(s.out)
+
+        testkit.run(s, List(in), List(out), () => {
+          val got = out.probe
+            .receiveN(msgs.size)
+            .map {
+              case (_, m: TestData) => m
+            }
+          got mustEqual msgs
+        })
+      }
+    }
+  }
+
+}

--- a/core/cloudflow-akka-testkit/src/test/scala/cloudflow/akkastream/testkit/TestSinkRefSpec.scala
+++ b/core/cloudflow-akka-testkit/src/test/scala/cloudflow/akkastream/testkit/TestSinkRefSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2021 Lightbend Inc. <https://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/HttpServerSpec.scala
+++ b/core/cloudflow-akka-util/src/test/scala/cloudflow/akkastream/util/scaladsl/HttpServerSpec.scala
@@ -83,7 +83,6 @@ class HttpServerSpec
       response.status mustEqual StatusCodes.Accepted
       response.entity.discardBytes()
       out.probe.expectMsg(("1", data))
-      out.probe.expectMsg(Completed)
     }
 
     "reject POST requests without an entity when using the default route" in {
@@ -102,7 +101,6 @@ class HttpServerSpec
       response.entity.discardBytes()
       response.status mustEqual StatusCodes.OK
       out.probe.expectMsg(("42", data))
-      out.probe.expectMsg(Completed)
 
       val badData = Data(1, "a")
       val badRequest = Put(s"http://127.0.0.1:$port", badData)

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
     val log4jOverSlf4j = "org.slf4j" % "log4j-over-slf4j" % "1.7.30"
 
     val scalatest = "org.scalatest" %% "scalatest" % Versions.scalaTest
-
+    val scalatestMustMatchers = "org.scalatest" %% "scalatest-mustmatchers" % Versions.scalaTest
     // These two dependencies are required to be present at runtime by fabric8, specifically its pod file read methods.
     // Reference:
     // https://github.com/fabric8io/kubernetes-client/blob/0c4513ff30ac9229426f1481a46fde2eb54933d9/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java#L451
@@ -208,7 +208,7 @@ object Dependencies {
         Compile.ficus,
         Compile.scalatest % Test)
 
-  val cloudflowAkkastream =
+  val cloudflowAkka =
     libraryDependencies ++= Seq(
         Compile.akkaActor,
         Compile.akkaStream,
@@ -228,7 +228,7 @@ object Dependencies {
         Compile.sprayJson,
         Compile.ficus)
 
-  val cloudflowAkkastreamTestkit =
+  val cloudflowAkkaTestkit =
     libraryDependencies ++= Seq(
         Compile.akkaSlf4j,
         Compile.akkaStream,
@@ -238,6 +238,8 @@ object Dependencies {
         Compile.akkaStreamTestkit,
         Compile.akkaTestkit,
         Compile.scalatest,
+        Compile.scalatestMustMatchers % "test",
+        Compile.scalatest % Test,
         TestDeps.scalatestJunit)
 
   val cloudflowAkkaUtil =
@@ -252,7 +254,7 @@ object Dependencies {
         Compile.scalatest % Test,
         TestDeps.scalatestJunit)
 
-  val cloudflowAkkastreamTests =
+  val cloudflowAkkaTests =
     libraryDependencies ++= Vector(
         TestDeps.akkaHttpTestkit,
         Compile.akkaHttpSprayJson % Test,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Fixes https://github.com/lightbend/cloudflow/issues/1054
https://github.com/lightbend/cloudflow/issues/1033

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
See referenced issues.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
A `testkit` `sinkRef.write` does not cause a `Completed` message anymore. The `Completed`  message is only sent when the stream has completed. Internally, every `sinkRef.write` returns a `Future` that is completed when the element is written to the Sink.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The test that showed the issue is added to the repo, thanks @thomasschoeftner !