### PR TITLE
bump: Akka-gRPC to 2.0.0

### DIFF
--- a/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/GrpcServerLogic.scala
+++ b/core/cloudflow-akka-util/src/main/scala/cloudflow/akkastream/util/javadsl/GrpcServerLogic.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletionStage
 import java.util.{ List => JList }
 
 import akka.annotation.ApiMayChange
-import akka.japi.Function
+import akka.japi.function.Function
 import akka.grpc.javadsl.ServiceHandler
 import akka.http.javadsl.model.{ HttpRequest, HttpResponse }
 import akka.http.javadsl.model.StatusCodes.OK

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/AppCrSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/AppCrSpec.scala
@@ -71,8 +71,9 @@ class AppCrSpec
 
       val newApp = mkApp(verifiedBlueprint)
       val cr = App.Cr(spec = newApp, metadata = null)
-      val customResource =
-        Serialization.jsonMapper().readValue(Serialization.jsonMapper().writeValueAsString(cr), classOf[App.Cr])
+      val mapper = Serialization.jsonMapper()
+      val str = mapper.writeValueAsString(cr)
+      val customResource = mapper.readValue(str, classOf[App.Cr])
       customResource.spec mustBe cr.spec
     }
 

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val Scala213 = "2.13.3" // Scala 2.13.4 breaks scopt when using "--help"
 
   object Versions {
-    val akka = "2.6.13"
+    val akka = "2.6.15"
     val akkaHttp = "10.2.4"
-    val akkaGrpc = "1.0.2"
+    val akkaGrpc = "2.0.0"
     val alpakkaKafka = "2.0.5"
     val akkaMgmt = "1.0.8"
     val flink = "1.10.3"

--- a/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/build.sbt
@@ -37,22 +37,6 @@ lazy val step2 = appModule("step2")
       Test / fork := true
     )
 
-// [info] * org.scala-lang:scala-library:2.12.11
-// [info] * org.apache.avro:avro:1.8.2
-// [info] * com.google.protobuf:protobuf-java:3.11.4
-// [info] * com.lightbend.akka.grpc:akka-grpc-runtime_2.12:1.0.2
-// [info] * com.lightbend.akka.grpc:akka-grpc-runtime_2.12:1.0.2
-// [info] * io.grpc:grpc-stub:1.32.1
-// [info] * com.lightbend.akka.grpc:akka-grpc-runtime_2.12:1.0.2
-// [info] * com.twitter:bijection-avro_2.12:0.9.7
-// [info] * org.apache.avro:avro:1.8.2
-// [info] * com.lightbend.cloudflow:cloudflow-runner_2.12:2.1.2
-// [info] * com.lightbend.cloudflow:cloudflow-localrunner_2.12:2.1.2
-// [info] * com.lightbend.cloudflow:cloudflow-flink_2.12:2.1.2
-// [info] * com.lightbend.cloudflow:cloudflow-flink-testkit_2.12:2.1.2:test
-// [info] * org.scalatest:scalatest:3.0.8:test
-// [info] * junit:junit:4.12:test
-
 lazy val step3 = appModule("step3")
     .enablePlugins(CloudflowFlinkPlugin)
     .settings(

--- a/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-flink-streamlets-java/build.sbt
@@ -37,9 +37,26 @@ lazy val step2 = appModule("step2")
       Test / fork := true
     )
 
+// [info] * org.scala-lang:scala-library:2.12.11
+// [info] * org.apache.avro:avro:1.8.2
+// [info] * com.google.protobuf:protobuf-java:3.11.4
+// [info] * com.lightbend.akka.grpc:akka-grpc-runtime_2.12:1.0.2
+// [info] * com.lightbend.akka.grpc:akka-grpc-runtime_2.12:1.0.2
+// [info] * io.grpc:grpc-stub:1.32.1
+// [info] * com.lightbend.akka.grpc:akka-grpc-runtime_2.12:1.0.2
+// [info] * com.twitter:bijection-avro_2.12:0.9.7
+// [info] * org.apache.avro:avro:1.8.2
+// [info] * com.lightbend.cloudflow:cloudflow-runner_2.12:2.1.2
+// [info] * com.lightbend.cloudflow:cloudflow-localrunner_2.12:2.1.2
+// [info] * com.lightbend.cloudflow:cloudflow-flink_2.12:2.1.2
+// [info] * com.lightbend.cloudflow:cloudflow-flink-testkit_2.12:2.1.2:test
+// [info] * org.scalatest:scalatest:3.0.8:test
+// [info] * junit:junit:4.12:test
+
 lazy val step3 = appModule("step3")
     .enablePlugins(CloudflowFlinkPlugin)
     .settings(
+      dependencyOverrides += "com.lightbend.akka.grpc" %% "akka-grpc-runtime" % "1.0.3",
       Test / parallelExecution := false,
       Test / fork := true
     )

--- a/examples/snippets/modules/ROOT/examples/build-flink-streamlets-scala/build.sbt
+++ b/examples/snippets/modules/ROOT/examples/build-flink-streamlets-scala/build.sbt
@@ -40,6 +40,7 @@ lazy val step2 = appModule("step2")
 lazy val step3 = appModule("step3")
     .enablePlugins(CloudflowFlinkPlugin)
     .settings(
+      dependencyOverrides += "com.lightbend.akka.grpc" %% "akka-grpc-runtime" % "1.0.3",
       Test / parallelExecution := false,
       Test / fork := true
     )


### PR DESCRIPTION
Note that this is going to be incompatible with previous versions, we need at least to bump `minor` after we merge.