### PR TITLE
Deprecate Flink and Spark support.

### DIFF
--- a/core/cloudflow-flink-testkit/src/main/scala/cloudflow/flink/testkit/FlinkSource.scala
+++ b/core/cloudflow-flink-testkit/src/main/scala/cloudflow/flink/testkit/FlinkSource.scala
@@ -21,6 +21,7 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import scala.collection.JavaConverters._
 
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 object FlinkSource {
   case class CollectionSourceFunction[T](data: Seq[T]) extends SourceFunction[T] {
     def cancel(): Unit = {}

--- a/core/cloudflow-flink-testkit/src/main/scala/cloudflow/flink/testkit/FlinkTestkit.scala
+++ b/core/cloudflow-flink-testkit/src/main/scala/cloudflow/flink/testkit/FlinkTestkit.scala
@@ -88,6 +88,7 @@ import cloudflow.streamlets._
  * }
  * }}
  */
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 abstract class FlinkTestkit {
 
   val testTimeout = 10.seconds

--- a/core/cloudflow-flink-testkit/src/main/scala/cloudflow/flink/testkit/TestFlinkStreamletContext.scala
+++ b/core/cloudflow-flink-testkit/src/main/scala/cloudflow/flink/testkit/TestFlinkStreamletContext.scala
@@ -28,6 +28,7 @@ import cloudflow.streamlets._
 /**
  * An implementation of `FlinkStreamletContext` for unit testing.
  */
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 class TestFlinkStreamletContext(
     override val streamletRef: String,
     env: StreamExecutionEnvironment,
@@ -71,8 +72,10 @@ class TestFlinkStreamletContext(
         s"Bad test context, could not find destination for outlet ${outlet.name}"))
 }
 
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 object TestFlinkStreamletContext {
   val result = new java.util.concurrent.ConcurrentLinkedQueue[String]()
 }
 
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 case class TestContextException(portName: String, msg: String) extends RuntimeException(msg)

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkKafkaCodecSerde.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkKafkaCodecSerde.scala
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.connectors.kafka._
 import cloudflow.streamlets.{ CodecInlet, CodecOutlet, RoundRobinPartitioner }
 import org.apache.flink.api.java.typeutils.TypeExtractor
 
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 private[flink] class FlinkKafkaCodecSerializationSchema[T: TypeInformation](outlet: CodecOutlet[T], topic: String)
     extends KafkaSerializationSchema[T] {
   override def serialize(value: T, timestamp: java.lang.Long): ProducerRecord[Array[Byte], Array[Byte]] =
@@ -34,6 +35,7 @@ private[flink] class FlinkKafkaCodecSerializationSchema[T: TypeInformation](outl
     }
 }
 
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 private[flink] class FlinkKafkaCodecDeserializationSchema() extends KafkaDeserializationSchema[Array[Byte]] {
   override def deserialize(record: ConsumerRecord[Array[Byte], Array[Byte]]): Array[Byte] = record.value
   override def isEndOfStream(value: Array[Byte]): Boolean = false

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamlet.scala
@@ -68,6 +68,7 @@ import org.apache.flink.core.fs.FileSystem
  *  }
  * }}}
  */
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 abstract class FlinkStreamlet extends Streamlet[FlinkStreamletContext] with Serializable {
   final override val runtime = FlinkStreamletRuntime
 
@@ -426,6 +427,7 @@ abstract class FlinkStreamletLogic(implicit val context: FlinkStreamletContext)
 
 }
 
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 case object FlinkStreamletRuntime extends StreamletRuntime {
   override val name: String = "flink"
 }

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContext.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContext.scala
@@ -25,6 +25,7 @@ import cloudflow.streamlets._
 /**
  * Runtime context for [[FlinkStreamlet]]s
  */
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 abstract case class FlinkStreamletContext(
     private[cloudflow] override val streamletDefinition: StreamletDefinition,
     @transient env: StreamExecutionEnvironment)

--- a/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContextImpl.scala
+++ b/core/cloudflow-flink/src/main/scala/cloudflow/flink/FlinkStreamletContextImpl.scala
@@ -32,6 +32,7 @@ import scala.util._
 /**
  * An implementation of `FlinkStreamletContext`
  */
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 class FlinkStreamletContextImpl(
     private[cloudflow] override val streamletDefinition: StreamletDefinition,
     @transient env: StreamExecutionEnvironment,

--- a/core/cloudflow-sbt-plugin/src/main/scala/cloudflow/sbt/CloudflowFlinkPlugin.scala
+++ b/core/cloudflow-sbt-plugin/src/main/scala/cloudflow/sbt/CloudflowFlinkPlugin.scala
@@ -26,6 +26,7 @@ import com.typesafe.sbt.packager.Keys._
 import cloudflow.sbt.CloudflowKeys._
 import CloudflowBasePlugin._
 
+@deprecated("Use contrib-sbt-flink library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 object CloudflowFlinkPlugin extends AutoPlugin {
 
   override def requires = CloudflowBasePlugin

--- a/core/cloudflow-sbt-plugin/src/main/scala/cloudflow/sbt/CloudflowSparkPlugin.scala
+++ b/core/cloudflow-sbt-plugin/src/main/scala/cloudflow/sbt/CloudflowSparkPlugin.scala
@@ -27,6 +27,7 @@ import com.typesafe.sbt.packager.Keys._
 import cloudflow.sbt.CloudflowKeys._
 import CloudflowBasePlugin._
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 object CloudflowSparkPlugin extends AutoPlugin {
 
   override def requires = CloudflowBasePlugin

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkScalaTestSupport.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkScalaTestSupport.scala
@@ -21,6 +21,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec._
 import org.scalatest.matchers.must._
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 trait SparkScalaTestSupport extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   val session: SparkSession = SparkSession

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkStreamletTestkit.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/SparkStreamletTestkit.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.streaming.StreamingQueryListener.{
 
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 object ConfigParameterValue {
   def apply(configParameter: ConfigParameter, value: String): ConfigParameterValue =
     ConfigParameterValue(configParameter.key, value)
@@ -43,6 +44,7 @@ object ConfigParameterValue {
   def create(configParameter: ConfigParameter, value: String): ConfigParameterValue =
     ConfigParameterValue(configParameter.key, value)
 }
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 final case class ConfigParameterValue private (configParameterKey: String, value: String)
 
 /**
@@ -102,6 +104,7 @@ final case class ConfigParameterValue private (configParameterKey: String, value
  * Note: Every test is executed against a `SparkSession` which gets created and removed as part of the test
  * lifecycle methods.
  */
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 final case class SparkStreamletTestkit(
     session: SparkSession,
     config: Config = ConfigFactory.empty,
@@ -225,20 +228,24 @@ final case class SparkStreamletTestkit(
   }
 }
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 case class SparkInletTap[T: Encoder](portName: String, instream: MemoryStream[T]) {
   // add data to memory stream
   def addData(data: Seq[T]) = instream.addData(data)
 }
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 case class SparkOutletTap[T: Encoder](portName: String, queryName: String) {
   // get results from memory sink
   def asCollection(session: SparkSession): Seq[T] = session.sql(s"select * from $queryName").as[T].collect()
 }
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 case class ExecutionReport(totalRows: Long, totalQueries: Int, failures: Seq[String]) {
   override def toString: String =
     s"total rows: [$totalRows], total queries: [$totalQueries], failures: [${failures.mkString(",")}]"
 }
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 class QueryExecutionMonitor() extends StreamingQueryListener {
   @volatile var status: Map[UUID, QueryState] = Map()
   @volatile var dataRows: Map[UUID, Long] = Map()

--- a/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
+++ b/core/cloudflow-spark-testkit/src/main/scala/cloudflow/spark/testkit/TestSparkStreamletContext.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.catalyst.InternalRow
  *              a `MemorySink`.
  *
  */
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 class TestSparkStreamletContext(
     override val streamletRef: String,
     session: SparkSession,
@@ -105,4 +106,5 @@ class TestSparkStreamletContext(
 
 }
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 case class TestContextException(portName: String, msg: String) extends RuntimeException(msg)

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -62,6 +62,7 @@ import cloudflow.streamlets._
  *  }
  * }}}
  */
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable {
   final override val runtime = SparkStreamletRuntime
   val StopTimeout = 30.seconds
@@ -216,6 +217,7 @@ trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable 
  *  }
  * }}}
  */
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 abstract class SparkStreamletLogic(implicit val context: SparkStreamletContext)
     extends StreamletLogic[SparkStreamletContext] {
 
@@ -266,15 +268,17 @@ abstract class SparkStreamletLogic(implicit val context: SparkStreamletContext)
 
 }
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 case object SparkStreamletRuntime extends StreamletRuntime {
   override val name: String = "spark"
 }
 
-// Allows the management of an executing Streamlet instance
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 case class StreamletQueryExecution(queries: Vector[StreamingQuery]) {
   final def stop(): Unit = queries.foreach(_.stop)
 }
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 object StreamletQueryExecution {
   def apply(singleQuery: StreamingQuery): StreamletQueryExecution = StreamletQueryExecution(Vector(singleQuery))
   def apply(oneQuery: StreamingQuery, moreQueries: StreamingQuery*): StreamletQueryExecution =

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamletContext.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamletContext.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.streaming.{ OutputMode, StreamingQuery, Trigger }
 import cloudflow.streamlets.{ CodecInlet, CodecOutlet }
 import cloudflow.streamlets._
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 abstract case class SparkStreamletContext(
     private[cloudflow] override val streamletDefinition: StreamletDefinition,
     session: SparkSession)

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/kafka/SparkStreamletContextImpl.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/kafka/SparkStreamletContextImpl.scala
@@ -28,6 +28,7 @@ import cloudflow.streamlets._
 import scala.reflect.runtime.universe._
 import scala.util.{ Failure, Success }
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 class SparkStreamletContextImpl(
     private[cloudflow] override val streamletDefinition: StreamletDefinition,
     session: SparkSession,
@@ -131,4 +132,5 @@ class SparkStreamletContextImpl(
   }
 }
 
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 case class EncodedKV(key: Array[Byte], value: Array[Byte])

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/sql/SQLImplicits.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/sql/SQLImplicits.scala
@@ -45,6 +45,7 @@ import scala.reflect.runtime.universe.TypeTag
  *
  * @since 1.6.0
  */
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 object SQLImplicits extends LowPrioritySQLImplicits {
 
   /**
@@ -236,6 +237,7 @@ object SQLImplicits extends LowPrioritySQLImplicits {
  * Reasons for including specific implicits:
  * newProductEncoder - to disambiguate for `List`s which are both `Seq` and `Product`
  */
+@deprecated("Use contrib-sbt-spark library instead, see https://github.com/lightbend/cloudflow-contrib", "2.2.0")
 trait LowPrioritySQLImplicits {
 
   /** @since 1.6.0 */

--- a/docs/shared-content-source/docs/modules/administration/pages/installing-flink-operator.adoc
+++ b/docs/shared-content-source/docs/modules/administration/pages/installing-flink-operator.adoc
@@ -2,6 +2,8 @@
 
 include::ROOT:partial$include.adoc[]
 
+NOTE: Integration with the Lyft Flink Operator has been deprecated since 2.2.0, and will be removed in version 3.x. Flink integration has moved to the https://github.com/lightbend/cloudflow-contrib[Cloudflow-contrib project]. Please see https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/index.html[the Cloudflow-contrib getting started guide] for instructions on how to use Flink Native Kubernetes integration. The documentation that follows describes the deprecated feature.
+
 NOTE: See xref:installation-prerequisites.adoc#_storage_requirements_for_use_with_spark_or_flink[Storage requirements (for use with Spark or Flink)] to setup Storage Requirements for Flink applications.
 
 If you plan to write applications that utilize Flink you will need to install the Lyft Flink operator before deploying your Cloudflow application.

--- a/docs/shared-content-source/docs/modules/administration/pages/installing-spark-operator.adoc
+++ b/docs/shared-content-source/docs/modules/administration/pages/installing-spark-operator.adoc
@@ -2,6 +2,8 @@
 
 include::ROOT:partial$include.adoc[]
 
+NOTE: Integration with the Spark Operator has been deprecated since 2.2.0, and will be removed in version 3.x. Spark integration has moved to the https://github.com/lightbend/cloudflow-contrib[Cloudflow-contrib project]. Please see https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/index.html[the Cloudflow-contrib getting started guide] for instructions on how to use Spark Native Kubernetes integration. The documentation that follows describes the deprecated feature.
+
 NOTE: See xref:installation-prerequisites.adoc#_storage_requirements_for_use_with_spark_or_flink[Storage requirements (for use with Spark or Flink)] to setup Storage Requirements for Spark applications.
 
 If you plan to write applications that utilize Spark, you will need to install the Spark operator before deploying your Cloudflow application.

--- a/docs/shared-content-source/docs/modules/develop/pages/build-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/build-flink-streamlets.adoc
@@ -3,6 +3,8 @@
 
 include::ROOT:partial$include.adoc[]
 
+NOTE: Integration with the Lyft Flink Operator has been deprecated since 2.2.0, and will be removed in version 3.x. Flink integration has moved to the https://github.com/lightbend/cloudflow-contrib[Cloudflow-contrib project]. Please see https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/index.html[the Cloudflow-contrib getting started guide] for instructions on how to use Flink Native Kubernetes integration. The documentation that follows describes the deprecated feature. The FlinkStreamlet API has not changed in cloudflow-contrib, though you do need to use a different dependency and add the `CloudflowNativeFlinkPlugin`, which is described in the https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/flink-native.html#_building_flink_native_streamlets[Cloudflow contrib documentation for building Flink native streamlets].
+
 The following sections describe how you can create a Flink streamlet.
 As mentioned in xref:use-flink-streamlets.adoc[Using Flink streamlets], a Flink streamlet is defined by the following features:
 

--- a/docs/shared-content-source/docs/modules/develop/pages/build-spark-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/build-spark-streamlets.adoc
@@ -2,6 +2,8 @@
 
 include::ROOT:partial$include.adoc[]
 
+NOTE: Integration with the Spark Operator has been deprecated since 2.2.0, and will be removed in version 3.x. Spark integration has moved to the https://github.com/lightbend/cloudflow-contrib[Cloudflow-contrib project]. Please see https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/index.html[the Cloudflow-contrib getting started guide] for instructions on how to use Spark Native Kubernetes integration. The documentation that follows describes the deprecated feature. The SparkStreamlet API has not changed in cloudflow-contrib, though you do need to use a different dependency and add the `CloudflowNativeSparkPlugin`, which is described in the https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/spark-native.html[Cloudflow contrib documentation for building Spark native streamlets].
+
 The following sections describe how you can create a Spark streamlet.
 As mentioned in xref:use-spark-streamlets.adoc[Using Spark streamlets], a Spark streamlet is defined by the following features:
 

--- a/docs/shared-content-source/docs/modules/develop/pages/test-flink-streamlet.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/test-flink-streamlet.adoc
@@ -2,6 +2,8 @@
 
 include::ROOT:partial$include.adoc[]
 
+NOTE: Integration with the Lyft Flink Operator has been deprecated since 2.2.0, and will be removed in version 3.x. Flink integration has moved to the https://github.com/lightbend/cloudflow-contrib[Cloudflow-contrib project]. Please see https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/index.html[the Cloudflow-contrib getting started guide] for instructions on how to use Flink Native Kubernetes integration. The documentation that follows describes the deprecated feature. The FlinkStreamlet API has not changed in cloudflow-contrib, though you do need to use a different dependency and add the `CloudflowNativeFlinkPlugin`, which is described in the https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/flink-native.html#_building_flink_native_streamlets[Cloudflow contrib documentation for building Flink native streamlets].
+
 A `testkit` is provided to make it easier to write unit tests for Flink streamlets. The unit tests are meant to facilitate local testing of streamlets. `FlinkTestkit` offers APIs to write unit tests for Flink streamlets in both Scala and Java.
 
 == Basic flow of `testkit` APIs in Scala

--- a/docs/shared-content-source/docs/modules/develop/pages/test-spark-streamlet.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/test-spark-streamlet.adoc
@@ -2,6 +2,8 @@
 
 include::ROOT:partial$include.adoc[]
 
+NOTE: Integration with the Spark Operator has been deprecated since 2.2.0, and will be removed in version 3.x. Spark integration has moved to the https://github.com/lightbend/cloudflow-contrib[Cloudflow-contrib project]. Please see https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/index.html[the Cloudflow-contrib getting started guide] for instructions on how to use Spark Native Kubernetes integration. The documentation that follows describes the deprecated feature. The SparkStreamlet API has not changed in cloudflow-contrib, though you do need to use a different dependency and add the `CloudflowNativeSparkPlugin`, which is described in the https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/spark-native.html[Cloudflow contrib documentation for building Spark native streamlets].
+
 A `testkit` is provided to make it easier to write unit tests for Spark streamlets. The unit tests are meant to facilitate local testing of streamlets.
 
 == Basic flow of `testkit` APIs

--- a/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-flink-streamlets.adoc
@@ -2,6 +2,9 @@
 
 include::ROOT:partial$include.adoc[]
 
+NOTE: Integration with the Lyft Flink Operator has been deprecated since 2.2.0, and will be removed in version 3.x. Flink integration has moved to the https://github.com/lightbend/cloudflow-contrib[Cloudflow-contrib project]. Please see https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/index.html[the Cloudflow-contrib getting started guide] for instructions on how to use Flink Native Kubernetes integration. The documentation that follows describes the deprecated feature. The FlinkStreamlet API has not changed in cloudflow-contrib, though you do need to use a different dependency and add the `CloudflowNativeFlinkPlugin`, which is described in the https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/flink-native.html#_building_flink_native_streamlets[Cloudflow contrib documentation for building Flink native streamlets].
+
+
 A Flink streamlet has the following responsibilities:
 
 * It needs to capture your stream processing logic.

--- a/docs/shared-content-source/docs/modules/develop/pages/use-spark-streamlets.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/use-spark-streamlets.adoc
@@ -2,6 +2,8 @@
 
 include::ROOT:partial$include.adoc[]
 
+NOTE: Integration with the Spark Operator has been deprecated since 2.2.0, and will be removed in version 3.x. Spark integration has moved to the https://github.com/lightbend/cloudflow-contrib[Cloudflow-contrib project]. Please see https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/index.html[the Cloudflow-contrib getting started guide] for instructions on how to use Spark Native Kubernetes integration. The documentation that follows describes the deprecated feature. The SparkStreamlet API has not changed in cloudflow-contrib, though you do need to use a different dependency and add the `CloudflowNativeSparkPlugin`, which is described in the https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/spark-native.html[Cloudflow contrib documentation for building Spark native streamlets].
+
 A Spark streamlet has the following responsibilities:
 
 * It needs to capture your stream processing logic.


### PR DESCRIPTION
Native Flink and Spark support in cloudflow-contrib should be used.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/main/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Flink and Spark support are deprecated. Flink and Spark support will be removed in a future Cloudflow 3.x release. 

You can start using the [cloudflow-contrib](https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/index.html) project, which provides [Flink Native Kubernetes](https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/flink-native.html) and [Spark Native Kubernetes](https://lightbend.github.io/cloudflow-contrib/docs/0.1.1/get-started/spark-native.html) integration instead.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We needed a more robust and production capable integration with Flink and Spark than we had to date. We wanted to allow our users to completely manage Flink and Spark and still create interconnected Cloudflow applications. We also wanted our users to be able to take advantage of Native Kubernetes integration in Flink 1.13. To that end we came up with cloudflow-contrib which allows Flink and Spark to be set up in a way that meets the demands of the customers.


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, Flink and Spark support is deprecated. 
CloudflowFlinkPlugin, CloudflowSparkPlugin, Cloudflow Spark and Flink API's and test kits are deprecated. You should use the plugins, API's and test kits in cloudflow-contrib instead.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
tests green, only deprecated items.