### PR TITLE
Make it possible to deploy an application to different namespaces

### DIFF
--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ConfigurationExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ConfigurationExecution.scala
@@ -17,7 +17,7 @@ final case class ConfigurationExecution(c: Configuration, client: KubeClient, lo
     logger.info("Executing command Configuration")
     for {
       _ <- validateProtocolVersion(client)
-      res <- client.getAppInputSecret(c.cloudflowApp)
+      res <- client.getAppInputSecret(c.cloudflowApp, c.namespace.getOrElse(c.cloudflowApp))
       config <- Try { ConfigFactory.parseString(res) }.recover {
         case ex => throw CliException("Failed to parse the current configuration", ex)
       }

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ListExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ListExecution.scala
@@ -17,7 +17,7 @@ final case class ListExecution(l: List, client: KubeClient, logger: CliLogger)
     logger.info("Executing command List")
     for {
       _ <- validateProtocolVersion(client)
-      res <- client.listCloudflowApps()
+      res <- client.listCloudflowApps(l.namespace)
     } yield {
       ListResult(res)
     }

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ScaleExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ScaleExecution.scala
@@ -18,13 +18,14 @@ final case class ScaleExecution(s: Scale, client: KubeClient, logger: CliLogger)
     logger.info("Executing command Status")
     for {
       _ <- validateProtocolVersion(client)
+      namespace = s.namespace.getOrElse(s.cloudflowApp)
 
-      currentAppCrOpt <- client.readCloudflowApp(s.cloudflowApp)
+      currentAppCrOpt <- client.readCloudflowApp(s.cloudflowApp, namespace)
 
       currentAppCr = currentAppCrOpt.getOrElse(throw CliException(s"Application ${s.cloudflowApp} not found"))
       applicationCr <- updateReplicas(currentAppCr, s.scales)
 
-      _ <- client.updateCloudflowApp(applicationCr)
+      _ <- client.updateCloudflowApp(applicationCr, namespace)
     } yield {
       ScaleResult()
     }

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/StatusExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/StatusExecution.scala
@@ -17,7 +17,7 @@ final case class StatusExecution(s: Status, client: KubeClient, logger: CliLogge
     logger.info("Executing command Status")
     for {
       _ <- validateProtocolVersion(client)
-      res <- client.getCloudflowAppStatus(s.cloudflowApp)
+      res <- client.getCloudflowAppStatus(s.cloudflowApp, s.namespace.getOrElse(s.cloudflowApp))
     } yield {
       StatusResult(res)
     }

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/UndeployExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/UndeployExecution.scala
@@ -17,7 +17,7 @@ final case class UndeployExecution(u: Undeploy, client: KubeClient, logger: CliL
     logger.info("Executing command Undeploy")
     for {
       _ <- validateProtocolVersion(client)
-      _ <- client.deleteCloudflowApp(u.cloudflowApp)
+      _ <- client.deleteCloudflowApp(u.cloudflowApp, u.namespace.getOrElse(u.cloudflowApp))
     } yield {
       UndeployResult()
     }

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/UpdateCredentialsExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/UpdateCredentialsExecution.scala
@@ -17,9 +17,10 @@ final case class UpdateCredentialsExecution(u: UpdateCredentials, client: KubeCl
     logger.info("Executing command UpdateCredentials")
     for {
       _ <- validateProtocolVersion(client)
-      _ <- client.createNamespace(u.cloudflowApp)
+      namespace = u.namespace.getOrElse(u.cloudflowApp)
+      _ <- client.createNamespace(namespace)
       _ <- client.createImagePullSecret(
-        namespace = u.cloudflowApp,
+        namespace = namespace,
         dockerRegistryURL = u.dockerRegistry,
         dockerUsername = u.username,
         dockerPassword = u.password)

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/kubeclient/KubeClient.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/kubeclient/KubeClient.scala
@@ -42,36 +42,40 @@ trait KubeClient {
       dockerUsername: String,
       dockerPassword: String): Try[Unit]
 
-  def getAppInputSecret(name: String): Try[String]
+  def getAppInputSecret(name: String, namespace: String): Try[String]
 
   def getOperatorProtocolVersion(): Try[String]
 
   // C
-  def createCloudflowApp(spec: App.Spec): Try[String]
+  def createCloudflowApp(spec: App.Spec, namespace: String): Try[String]
 
-  def createMicroservicesApp(cfSpec: App.Spec, specs: Map[String, Option[AkkaMicroserviceSpec]]): Try[String]
+  def createMicroservicesApp(
+      cfSpec: App.Spec,
+      namespace: String,
+      specs: Map[String, Option[AkkaMicroserviceSpec]]): Try[String]
 
-  def uidCloudflowApp(name: String): Try[String]
+  def uidCloudflowApp(name: String, namespace: String): Try[String]
 
   def configureCloudflowApp(
       name: String,
+      namespace: String,
       uid: String,
       appConfig: String,
       loggingContent: Option[String],
       configs: Map[App.Deployment, Map[String, String]]): Try[Unit]
 
   // R
-  def readCloudflowApp(name: String): Try[Option[App.Cr]]
+  def readCloudflowApp(name: String, namespace: String): Try[Option[App.Cr]]
 
   // U
-  def updateCloudflowApp(app: App.Cr): Try[App.Cr]
+  def updateCloudflowApp(app: App.Cr, namespace: String): Try[App.Cr]
 
   // D
-  def deleteCloudflowApp(app: String): Try[Unit]
+  def deleteCloudflowApp(app: String, namespace: String): Try[Unit]
 
-  def listCloudflowApps(): Try[List[models.CRSummary]]
+  def listCloudflowApps(namespace: Option[String]): Try[List[models.CRSummary]]
 
-  def getCloudflowAppStatus(app: String): Try[models.ApplicationStatus]
+  def getCloudflowAppStatus(app: String, namespace: String): Try[models.ApplicationStatus]
 
   def getPvcs(namespace: String): Try[List[String]]
 

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/kubeclient/KubeClientFabric8.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/kubeclient/KubeClientFabric8.scala
@@ -157,11 +157,15 @@ class KubeClientFabric8(
 
   import ModelConversions._
 
-  def listCloudflowApps() = withApplicationClient { cloudflowApps =>
+  def listCloudflowApps(namespace: Option[String]) = withApplicationClient { cloudflowApps =>
     logger.trace("Running the Fabric8 list command")
     Try {
-      val res = cloudflowApps
-        .inAnyNamespace()
+      val apps =
+        namespace match {
+          case Some(ns) => cloudflowApps.inNamespace(ns)
+          case _        => cloudflowApps.inAnyNamespace()
+        }
+      val res = apps
         .list()
         .getItems
         .asScala
@@ -172,33 +176,34 @@ class KubeClientFabric8(
     }
   }
 
-  def getCloudflowAppStatus(appName: String): Try[models.ApplicationStatus] = withApplicationClient { cloudflowApps =>
-    Try {
-      val app = cloudflowApps
-        .inAnyNamespace()
-        .list()
-        .getItems()
-        .asScala
-        .find(_.getMetadata.getName == appName)
-        .getOrElse(throw CliException(s"""Cloudflow application "${appName}" not found"""))
+  def getCloudflowAppStatus(appName: String, namespace: String): Try[models.ApplicationStatus] = withApplicationClient {
+    cloudflowApps =>
+      Try {
+        val app = cloudflowApps
+          .inNamespace(namespace)
+          .list()
+          .getItems()
+          .asScala
+          .find(_.getMetadata.getName == appName)
+          .getOrElse(throw CliException(s"""Cloudflow application "${appName}" not found"""))
 
-      val appStatus: String = Try(app.status.appStatus).toOption.getOrElse("Unknown")
+        val appStatus: String = Try(app.status.appStatus).toOption.getOrElse("Unknown")
 
-      val res = models.ApplicationStatus(
-        summary = getCRSummary(app),
-        status = appStatus,
-        // FIXME, remove in a breaking CRD change, the endpoint statuses are not updated anymore.
-        endpointsStatuses = Try(app.status.endpointStatuses).toOption
-          .filterNot(_ == null)
-          .map(_.map(getEndpointStatus))
-          .getOrElse(Seq.empty),
-        streamletsStatuses = Try(app.status.streamletStatuses).toOption
-          .filterNot(_ == null)
-          .map(_.map(getStreamletStatus))
-          .getOrElse(Seq.empty))
-      logger.trace(s"Fabric8 status command successful")
-      res
-    }
+        val res = models.ApplicationStatus(
+          summary = getCRSummary(app),
+          status = appStatus,
+          // FIXME, remove in a breaking CRD change, the endpoint statuses are not updated anymore.
+          endpointsStatuses = Try(app.status.endpointStatuses).toOption
+            .filterNot(_ == null)
+            .map(_.map(getEndpointStatus))
+            .getOrElse(Seq.empty),
+          streamletsStatuses = Try(app.status.streamletStatuses).toOption
+            .filterNot(_ == null)
+            .map(_.map(getStreamletStatus))
+            .getOrElse(Seq.empty))
+        logger.trace(s"Fabric8 status command successful")
+        res
+      }
   }
 
   def getOperatorProtocolVersion(): Try[String] = withClient { client =>
@@ -282,6 +287,7 @@ class KubeClientFabric8(
       def secret(config: String) =
         new SecretBuilder().withNewMetadata
           .withName(KubeClient.ImagePullSecretName)
+          .withNamespace(namespace)
           .withLabels(cloudflowLabels(namespace))
           .endMetadata
           .withType("kubernetes.io/dockerconfigjson")
@@ -339,11 +345,11 @@ class KubeClientFabric8(
       .build()
   }
 
-  def getAppInputSecret(name: String): Try[String] = withClient { client =>
+  def getAppInputSecret(name: String, namespace: String): Try[String] = withClient { client =>
     Try {
       val data =
         client.secrets
-          .inNamespace(name)
+          .inNamespace(namespace)
           .list()
           .getItems
           .asScala
@@ -356,31 +362,34 @@ class KubeClientFabric8(
     }
   }
 
-  def createAppInputSecret(name: String, appConfig: String, ownerReference: OwnerReference) = withClient { client =>
-    Try {
-      lazy val secret =
-        new SecretBuilder().withNewMetadata
-          .withName(appInputSecretName(name))
-          .withLabels(
-            (cloudflowLabels(name).asScala ++
-            Map(
-              "com.lightbend.cloudflow/created-at" -> System.currentTimeMillis().toString,
-              "com.lightbend.cloudflow/config-format" -> "input")).asJava)
-          .withOwnerReferences(ownerReference)
-          .endMetadata
-          .addToStringData(appInputSecretConfKey, appConfig)
-          .build()
+  def createAppInputSecret(name: String, namespace: String, appConfig: String, ownerReference: OwnerReference) =
+    withClient { client =>
+      Try {
+        lazy val secret =
+          new SecretBuilder().withNewMetadata
+            .withName(appInputSecretName(name))
+            .withNamespace(namespace)
+            .withLabels(
+              (cloudflowLabels(name).asScala ++
+              Map(
+                "com.lightbend.cloudflow/created-at" -> System.currentTimeMillis().toString,
+                "com.lightbend.cloudflow/config-format" -> "input")).asJava)
+            .withOwnerReferences(ownerReference)
+            .endMetadata
+            .addToStringData(appInputSecretConfKey, appConfig)
+            .build()
 
-      client.secrets
-        .inNamespace(name)
-        .withName(appInputSecretName(name))
-        .createOrReplace(secret)
+        client.secrets
+          .inNamespace(namespace)
+          .withName(appInputSecretName(name))
+          .createOrReplace(secret)
+      }
     }
-  }
 
   private def createStreamletSecret(
       ownerReference: OwnerReference,
       name: String,
+      namespace: String,
       secretName: String,
       streamletName: String,
       configs: Map[String, String]): Try[Unit] = {
@@ -389,6 +398,7 @@ class KubeClientFabric8(
         lazy val secret =
           new SecretBuilder().withNewMetadata
             .withName(secretName)
+            .withNamespace(namespace)
             .withLabels((cloudflowLabels(name).asScala ++
             Map(
               "com.lightbend.cloudflow/created-at" -> System.currentTimeMillis().toString,
@@ -400,7 +410,7 @@ class KubeClientFabric8(
             .build()
 
         client.secrets
-          .inNamespace(name)
+          .inNamespace(namespace)
           .withName(secretName)
           .createOrReplace(secret)
       }
@@ -409,6 +419,7 @@ class KubeClientFabric8(
 
   private def createStreamletsConfigSecrets(
       name: String,
+      namespace: String,
       secrets: Map[App.Deployment, Map[String, String]],
       ownerReference: OwnerReference): Try[Unit] = {
     secrets.foldLeft[Try[Unit]](Success(())) {
@@ -419,6 +430,7 @@ class KubeClientFabric8(
             createStreamletSecret(
               ownerReference = ownerReference,
               name = name,
+              namespace = namespace,
               secretName = deployment.secretName,
               streamletName = deployment.streamletName,
               configs = configs)
@@ -426,21 +438,21 @@ class KubeClientFabric8(
     }
   }
 
-  def handleLoggingSecret(name: String, content: Option[String], ownerReference: OwnerReference) = withClient {
-    client =>
+  def handleLoggingSecret(name: String, namespace: String, content: Option[String], ownerReference: OwnerReference) =
+    withClient { client =>
       Try {
         content match {
           case None =>
             val current = client
               .secrets()
-              .inNamespace(name)
+              .inNamespace(namespace)
               .withName(LoggingSecretName)
               .get()
 
             if (current != null) {
               client
                 .secrets()
-                .inNamespace(name)
+                .inNamespace(namespace)
                 .withName(LoggingSecretName)
                 .delete()
             }
@@ -448,6 +460,7 @@ class KubeClientFabric8(
             lazy val secret =
               new SecretBuilder().withNewMetadata
                 .withName(LoggingSecretName)
+                .withNamespace(namespace)
                 .withLabels(
                   (cloudflowLabels(name).asScala ++
                   Map(
@@ -460,45 +473,47 @@ class KubeClientFabric8(
 
             client
               .secrets()
-              .inNamespace(name)
+              .inNamespace(namespace)
               .withName(LoggingSecretName)
               .createOrReplace(secret)
         }
       }
-  }
+    }
 
   private val CreatedByCliAnnotation = {
     Map("com.lightbend.cloudflow/created-by-cli-version" -> BuildInfo.version).asJava
   }
 
-  private def createCloudflowServiceAccount(appId: String, ownerReference: OwnerReference) = withClient { client =>
-    Try {
+  private def createCloudflowServiceAccount(appId: String, namespace: String, ownerReference: OwnerReference) =
+    withClient { client =>
+      Try {
 
-      val imagePullSecret = new LocalObjectReferenceBuilder()
-        .withName(ImagePullSecretName)
-        .build()
+        val imagePullSecret = new LocalObjectReferenceBuilder()
+          .withName(ImagePullSecretName)
+          .build()
 
-      val serviceAccount = new ServiceAccountBuilder()
-        .withNewMetadata()
-        .withName(CloudflowAppServiceAccountName)
-        .withNamespace(appId)
-        .withLabels(cloudflowLabels(appId))
-        .withOwnerReferences(ownerReference)
-        .endMetadata()
-        .withImagePullSecrets(imagePullSecret)
-        .withAutomountServiceAccountToken(true)
-        .build()
+        val serviceAccount = new ServiceAccountBuilder()
+          .withNewMetadata()
+          .withName(CloudflowAppServiceAccountName)
+          .withNamespace(namespace)
+          .withLabels(cloudflowLabels(appId))
+          .withOwnerReferences(ownerReference)
+          .endMetadata()
+          .withImagePullSecrets(imagePullSecret)
+          .withAutomountServiceAccountToken(true)
+          .build()
 
-      client
-        .serviceAccounts()
-        .inNamespace(appId)
-        .createOrReplace(serviceAccount)
+        client
+          .serviceAccounts()
+          .inNamespace(namespace)
+          .createOrReplace(serviceAccount)
+      }
     }
-  }
 
-  private def getFullCloudflowApp(spec: App.Spec): App.Cr = {
+  private def getFullCloudflowApp(spec: App.Spec, namespace: String): App.Cr = {
     val metadata = new ObjectMetaBuilder()
       .withName(spec.appId)
+      .withNamespace(namespace)
       .withLabels(cloudflowLabels(spec.appId))
       .withAnnotations(CreatedByCliAnnotation)
       .build()
@@ -514,15 +529,15 @@ class KubeClientFabric8(
     App.Cr(spec = spec, metadata = metadata, status = status)
   }
 
-  private def createCFApp(spec: App.Spec): Try[String] =
+  private def createCFApp(spec: App.Spec, namespace: String): Try[String] =
     withApplicationClient { cloudflowApps =>
       for {
         uid <- Try {
-          val app = getFullCloudflowApp(spec)
+          val app = getFullCloudflowApp(spec, namespace)
 
           val crd =
             cloudflowApps
-              .inNamespace(spec.appId)
+              .inNamespace(namespace)
               .withName(spec.appId)
               .createOrReplace(app)
 
@@ -533,15 +548,18 @@ class KubeClientFabric8(
       }
     }
 
-  def createCloudflowApp(spec: App.Spec): Try[String] =
+  def createCloudflowApp(spec: App.Spec, namespace: String): Try[String] =
     for {
-      uid <- createCFApp(spec)
-      _ <- createCloudflowServiceAccount(spec.appId, getOwnerReference(spec.appId, uid))
+      uid <- createCFApp(spec, namespace)
+      _ <- createCloudflowServiceAccount(spec.appId, namespace, getOwnerReference(spec.appId, uid))
     } yield { uid }
 
-  def createMicroservicesApp(cfSpec: App.Spec, specs: Map[String, Option[AkkaMicroserviceSpec]]): Try[String] = {
+  def createMicroservicesApp(
+      cfSpec: App.Spec,
+      namespace: String,
+      specs: Map[String, Option[AkkaMicroserviceSpec]]): Try[String] = {
     for {
-      uid <- createCFApp(cfSpec)
+      uid <- createCFApp(cfSpec, namespace)
       _ <- {
         withClient { client =>
           val microservices = client.customResources(
@@ -559,6 +577,7 @@ class KubeClientFabric8(
                     case Some(s) =>
                       val metadata = new ObjectMetaBuilder()
                         .withName(name)
+                        .withNamespace(namespace)
                         .withLabels(cloudflowLabels(name))
                         .withAnnotations(CreatedByCliAnnotation)
                         .withOwnerReferences(getOwnerReference(cfSpec.appId, uid))
@@ -568,7 +587,7 @@ class KubeClientFabric8(
 
                       val crd =
                         microservices
-                          .inNamespace(cfSpec.appId)
+                          .inNamespace(namespace)
                           .withName(name)
                           .createOrReplace(app)
 
@@ -581,11 +600,11 @@ class KubeClientFabric8(
     } yield { uid }
   }
 
-  def uidCloudflowApp(name: String): Try[String] = {
+  def uidCloudflowApp(name: String, namespace: String): Try[String] = {
     withApplicationClient { cloudflowApps =>
       Try {
         val current = cloudflowApps
-          .inNamespace(name)
+          .inNamespace(namespace)
           .withName(name)
           .get()
 
@@ -600,22 +619,23 @@ class KubeClientFabric8(
 
   def configureCloudflowApp(
       appName: String,
+      namespace: String,
       appUid: String,
       appConfig: String,
       loggingContent: Option[String],
       configs: Map[App.Deployment, Map[String, String]]) = {
     val ownerReference = getOwnerReference(appName, appUid)
     for {
-      _ <- handleLoggingSecret(appName, loggingContent, ownerReference)
-      _ <- createStreamletsConfigSecrets(appName, configs, ownerReference)
-      _ <- createAppInputSecret(appName, appConfig, ownerReference)
+      _ <- handleLoggingSecret(appName, namespace, loggingContent, ownerReference)
+      _ <- createStreamletsConfigSecrets(appName, namespace, configs, ownerReference)
+      _ <- createAppInputSecret(appName, namespace, appConfig, ownerReference)
     } yield { () }
   }
 
-  def updateCloudflowApp(app: App.Cr): Try[App.Cr] = withApplicationClient { cloudflowApps =>
+  def updateCloudflowApp(app: App.Cr, namespace: String): Try[App.Cr] = withApplicationClient { cloudflowApps =>
     Try {
       cloudflowApps
-        .inNamespace(app.spec.appId)
+        .inNamespace(namespace)
         .withName(app.spec.appId)
         // NOTE: Patch doesn't work
         //.patch(app)
@@ -623,10 +643,10 @@ class KubeClientFabric8(
     }
   }
 
-  def deleteCloudflowApp(appName: String): Try[Unit] = withApplicationClient { cloudflowApps =>
+  def deleteCloudflowApp(appName: String, namespace: String): Try[Unit] = withApplicationClient { cloudflowApps =>
     Try {
       val app = cloudflowApps
-        .inAnyNamespace()
+        .inNamespace(namespace)
         .list()
         .getItems()
         .asScala
@@ -634,7 +654,7 @@ class KubeClientFabric8(
         .getOrElse(throw CliException(s"""Cloudflow application "${appName}" not found"""))
 
       cloudflowApps
-        .inAnyNamespace()
+        .inNamespace(namespace)
         .delete(app)
     }
   }
@@ -682,11 +702,11 @@ class KubeClientFabric8(
     }
   }
 
-  def readCloudflowApp(name: String): Try[Option[App.Cr]] = withApplicationClient { cloudflowApps =>
+  def readCloudflowApp(name: String, namespace: String): Try[Option[App.Cr]] = withApplicationClient { cloudflowApps =>
     Try {
       Option(
         cloudflowApps
-          .inNamespace(name)
+          .inNamespace(namespace)
           .withName(name)
           .get())
     }

--- a/core/cloudflow-cli/src/test/scala/akka/cli/cloudflow/CliWorkflowSpec.scala
+++ b/core/cloudflow-cli/src/test/scala/akka/cli/cloudflow/CliWorkflowSpec.scala
@@ -38,9 +38,9 @@ class CliWorkflowSpec extends AnyFlatSpec with Matchers with TryValues {
       providedApplication: Option[App.Cr] = None,
       providedInputSecret: String = "")(config: Option[File], logger: CliLogger) = {
     new KubeClient {
-      def listCloudflowApps(): Try[List[models.CRSummary]] =
+      def listCloudflowApps(namespace: Option[String]): Try[List[models.CRSummary]] =
         Success(listResult)
-      def getCloudflowAppStatus(app: String) =
+      def getCloudflowAppStatus(app: String, namespace: String) =
         Success(statusResult)
       def createImagePullSecret(
           namespace: String,
@@ -51,22 +51,26 @@ class CliWorkflowSpec extends AnyFlatSpec with Matchers with TryValues {
       def sparkAppVersion(): Try[String] = Success(sparkVersion)
       def flinkAppVersion(): Try[String] = Success(flinkVersion)
       def getOperatorProtocolVersion(): Try[String] = Success(protocolVersion)
-      def createCloudflowApp(spec: App.Spec) = Success("1")
-      def uidCloudflowApp(name: String) = Success("1")
-      def createMicroservicesApp(cfSpec: App.Spec, specs: Map[String, Option[AkkaMicroserviceSpec]]): Try[String] =
+      def createCloudflowApp(spec: App.Spec, namespace: String) = Success("1")
+      def uidCloudflowApp(name: String, namespace: String) = Success("1")
+      def createMicroservicesApp(
+          cfSpec: App.Spec,
+          namespace: String,
+          specs: Map[String, Option[AkkaMicroserviceSpec]]): Try[String] =
         Success("1")
       def configureCloudflowApp(
           name: String,
+          namespace: String,
           appUid: String,
           appConfig: String,
           loggingContent: Option[String],
           configs: Map[App.Deployment, Map[String, String]]): Try[Unit] = Success(())
-      def deleteCloudflowApp(app: String) = Success(())
+      def deleteCloudflowApp(app: String, namespace: String) = Success(())
       def getPvcs(namespace: String) = Success(providedPvcs)
       def getKafkaClusters(namespace: Option[String]) = Success(providedKafkaClusters)
-      def readCloudflowApp(name: String): Try[Option[App.Cr]] = Success(providedApplication)
-      def updateCloudflowApp(app: App.Cr): Try[App.Cr] = Success(app)
-      def getAppInputSecret(name: String): Try[String] = Success(providedInputSecret)
+      def readCloudflowApp(name: String, namespace: String): Try[Option[App.Cr]] = Success(providedApplication)
+      def updateCloudflowApp(app: App.Cr, namespace: String): Try[App.Cr] = Success(app)
+      def getAppInputSecret(name: String, namespace: String): Try[String] = Success(providedInputSecret)
     }
   }
 
@@ -309,7 +313,7 @@ class CliWorkflowSpec extends AnyFlatSpec with Matchers with TryValues {
 
     // Act
     val res =
-      cli.run(commands.Scale("skiss-knife", Map("non-existent" -> 5)))
+      cli.run(commands.Scale("skiss-knife", scales = Map("non-existent" -> 5)))
 
     // Assert
     res.isFailure shouldBe true
@@ -323,7 +327,7 @@ class CliWorkflowSpec extends AnyFlatSpec with Matchers with TryValues {
 
     // Act
     val res =
-      cli.run(commands.Scale("skiss-knife", Map("akka-process" -> 5)))
+      cli.run(commands.Scale("skiss-knife", scales = Map("akka-process" -> 5)))
 
     // Assert
     res.isSuccess shouldBe true

--- a/core/cloudflow-cli/src/test/scala/akka/cli/cloudflow/OptionsParserSpec.scala
+++ b/core/cloudflow-cli/src/test/scala/akka/cli/cloudflow/OptionsParserSpec.scala
@@ -27,12 +27,13 @@ class OptionsParserSpec extends AnyFlatSpec with Matchers {
     res.isDefined shouldBe true
     res.get.command.isDefined shouldBe true
     res.get.command.get shouldBe a[Version]
+    res.get.command.get.namespace shouldBe None
     res.get.logLevel shouldBe Some("info")
   }
 
   it should "parse command options" in {
     // Arrange
-    val input = Array("list", "-o", "c")
+    val input = Array("list", "-o", "c", "-n", "my-ns")
 
     // Act
     val res = OptionsParser(input)
@@ -41,6 +42,7 @@ class OptionsParserSpec extends AnyFlatSpec with Matchers {
     res.isDefined shouldBe true
     res.get.command.isDefined shouldBe true
     res.get.command.get shouldBe a[List]
+    res.get.command.get.namespace shouldBe Some("my-ns")
     res.get.command.get.output shouldBe format.Classic
   }
 

--- a/core/cloudflow-it/src/it/scala/ItResources.scala
+++ b/core/cloudflow-it/src/it/scala/ItResources.scala
@@ -42,4 +42,6 @@ trait ItResources {
   val interval = (2 * mult).seconds
   val appName = "swiss-knife"
   val namespace = new NamespaceBuilder().withMetadata(new ObjectMetaBuilder().withName(appName).build()).build()
+  val alternativeNamespace =
+    new NamespaceBuilder().withMetadata(new ObjectMetaBuilder().withName("my-ns").build()).build()
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a CLI option to deploy a Cloudflow application to a specific namespace

### Why are the changes needed?
To be able to deploy the same application to different namespaces in the same cluster

### Does this PR introduce any user-facing change?
Yes an additional command line flag

### How was this patch tested?
Integration tests with a minimal deployment
