### PR TITLE
Avoid querying all namespaces when validating Cloudflow protocol version

### DIFF
--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ConfigurationExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ConfigurationExecution.scala
@@ -16,7 +16,7 @@ final case class ConfigurationExecution(c: Configuration, client: KubeClient, lo
   def run(): Try[ConfigurationResult] = {
     logger.info("Executing command Configuration")
     for {
-      _ <- validateProtocolVersion(client)
+      _ <- validateProtocolVersion(client, c.namespace)
       res <- client.getAppInputSecret(c.cloudflowApp, c.namespace.getOrElse(c.cloudflowApp))
       config <- Try { ConfigFactory.parseString(res) }.recover {
         case ex => throw CliException("Failed to parse the current configuration", ex)

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ConfigureExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ConfigureExecution.scala
@@ -17,7 +17,7 @@ final case class ConfigureExecution(c: Configure, client: KubeClient, logger: Cl
   def run(): Try[ConfigureResult] = {
     logger.info("Executing command Configure")
     for {
-      _ <- validateProtocolVersion(client)
+      _ <- validateProtocolVersion(client, c.namespace)
       namespace = c.namespace.getOrElse(c.cloudflowApp)
 
       currentCr <- client.readCloudflowApp(c.cloudflowApp, namespace).map {

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/DeployExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/DeployExecution.scala
@@ -150,7 +150,7 @@ final case class DeployExecution(d: Deploy, client: KubeClient, logger: CliLogge
         if (d.microservices) {
           Success("")
         } else {
-          validateProtocolVersion(client)
+          validateProtocolVersion(client, d.namespace)
         }
       }
 

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ListExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ListExecution.scala
@@ -16,7 +16,7 @@ final case class ListExecution(l: List, client: KubeClient, logger: CliLogger)
   def run(): Try[ListResult] = {
     logger.info("Executing command List")
     for {
-      _ <- validateProtocolVersion(client)
+      _ <- validateProtocolVersion(client, l.namespace)
       res <- client.listCloudflowApps(l.namespace)
     } yield {
       ListResult(res)

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ScaleExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/ScaleExecution.scala
@@ -17,7 +17,7 @@ final case class ScaleExecution(s: Scale, client: KubeClient, logger: CliLogger)
   def run(): Try[ScaleResult] = {
     logger.info("Executing command Status")
     for {
-      _ <- validateProtocolVersion(client)
+      _ <- validateProtocolVersion(client, s.namespace)
       namespace = s.namespace.getOrElse(s.cloudflowApp)
 
       currentAppCrOpt <- client.readCloudflowApp(s.cloudflowApp, namespace)

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/StatusExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/StatusExecution.scala
@@ -16,7 +16,7 @@ final case class StatusExecution(s: Status, client: KubeClient, logger: CliLogge
   def run(): Try[StatusResult] = {
     logger.info("Executing command Status")
     for {
-      _ <- validateProtocolVersion(client)
+      _ <- validateProtocolVersion(client, s.namespace)
       res <- client.getCloudflowAppStatus(s.cloudflowApp, s.namespace.getOrElse(s.cloudflowApp))
     } yield {
       StatusResult(res)

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/UndeployExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/UndeployExecution.scala
@@ -16,7 +16,7 @@ final case class UndeployExecution(u: Undeploy, client: KubeClient, logger: CliL
   def run(): Try[UndeployResult] = {
     logger.info("Executing command Undeploy")
     for {
-      _ <- validateProtocolVersion(client)
+      _ <- validateProtocolVersion(client, u.namespace)
       _ <- client.deleteCloudflowApp(u.cloudflowApp, u.namespace.getOrElse(u.cloudflowApp))
     } yield {
       UndeployResult()

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/UpdateCredentialsExecution.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/UpdateCredentialsExecution.scala
@@ -16,7 +16,7 @@ final case class UpdateCredentialsExecution(u: UpdateCredentials, client: KubeCl
   def run(): Try[UpdateCredentialsResult] = {
     logger.info("Executing command UpdateCredentials")
     for {
-      _ <- validateProtocolVersion(client)
+      _ <- validateProtocolVersion(client, u.namespace)
       namespace = u.namespace.getOrElse(u.cloudflowApp)
       _ <- client.createNamespace(namespace)
       _ <- client.createImagePullSecret(

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/WithProtocolVersion.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/execution/WithProtocolVersion.scala
@@ -11,9 +11,9 @@ import scala.util.{ Failure, Success, Try }
 
 trait WithProtocolVersion {
 
-  def validateProtocolVersion(client: KubeClient): Try[String] = {
+  def validateProtocolVersion(client: KubeClient, namespace: Option[String]): Try[String] = {
     (for {
-      version <- client.getOperatorProtocolVersion()
+      version <- client.getOperatorProtocolVersion(namespace)
     } yield {
       version match {
         case v if v == Cli.ProtocolVersion =>

--- a/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/kubeclient/KubeClient.scala
+++ b/core/cloudflow-cli/src/main/scala/akka/cli/cloudflow/kubeclient/KubeClient.scala
@@ -44,7 +44,7 @@ trait KubeClient {
 
   def getAppInputSecret(name: String, namespace: String): Try[String]
 
-  def getOperatorProtocolVersion(): Try[String]
+  def getOperatorProtocolVersion(namespace: Option[String]): Try[String]
 
   // C
   def createCloudflowApp(spec: App.Spec, namespace: String): Try[String]

--- a/core/cloudflow-cli/src/test/scala/akka/cli/cloudflow/CliWorkflowSpec.scala
+++ b/core/cloudflow-cli/src/test/scala/akka/cli/cloudflow/CliWorkflowSpec.scala
@@ -50,10 +50,10 @@ class CliWorkflowSpec extends AnyFlatSpec with Matchers with TryValues {
       def createNamespace(name: String): Try[Unit] = Success(())
       def sparkAppVersion(): Try[String] = Success(sparkVersion)
       def flinkAppVersion(): Try[String] = Success(flinkVersion)
-      def getOperatorProtocolVersion(): Try[String] = Success(protocolVersion)
       def createCloudflowApp(spec: App.Spec, namespace: String) = Success("1")
       def uidCloudflowApp(name: String, namespace: String) = Success("1")
       def createMicroservicesApp(
+      override def getOperatorProtocolVersion(namespace: Option[String]): Try[String] = Success(protocolVersion)
           cfSpec: App.Spec,
           namespace: String,
           specs: Map[String, Option[AkkaMicroserviceSpec]]): Try[String] =

--- a/core/cloudflow-cli/src/test/scala/akka/cli/cloudflow/CliWorkflowSpec.scala
+++ b/core/cloudflow-cli/src/test/scala/akka/cli/cloudflow/CliWorkflowSpec.scala
@@ -20,10 +20,10 @@ class CliWorkflowSpec extends AnyFlatSpec with Matchers with TryValues {
 
   val crFile = new File("./cloudflow-cli/src/test/resources/swiss-knife.json")
   val crFileWithKafkaCluster = new File("./cloudflow-cli/src/test/resources/swiss-knife-with-kafka-cluster.json")
-  val testingCRSummary = models.CRSummary("foo", "bar", "0.0.1", "now")
+  val testingCRSummary: models.CRSummary = models.CRSummary("foo", "bar", "0.0.1", "now")
 
   val listResult = List(testingCRSummary)
-  val statusResult = ApplicationStatus(testingCRSummary, "MOCK", List(), List())
+  val statusResult: ApplicationStatus = ApplicationStatus(testingCRSummary, "MOCK", List(), List())
 
   val defaultPvcMounts = List("cloudflow-spark", "cloudflow-flink")
 
@@ -36,41 +36,42 @@ class CliWorkflowSpec extends AnyFlatSpec with Matchers with TryValues {
       providedPvcs: List[String] = defaultPvcMounts,
       providedKafkaClusters: Map[String, String] = defaultProvidedKafkaClusters,
       providedApplication: Option[App.Cr] = None,
-      providedInputSecret: String = "")(config: Option[File], logger: CliLogger) = {
+      providedInputSecret: String = "")(config: Option[File], logger: CliLogger): KubeClient = {
     new KubeClient {
-      def listCloudflowApps(namespace: Option[String]): Try[List[models.CRSummary]] =
+      override def listCloudflowApps(namespace: Option[String]): Try[List[models.CRSummary]] =
         Success(listResult)
-      def getCloudflowAppStatus(app: String, namespace: String) =
+      override def getCloudflowAppStatus(app: String, namespace: String): Try[ApplicationStatus] =
         Success(statusResult)
-      def createImagePullSecret(
+      override def createImagePullSecret(
           namespace: String,
           dockerRegistryURL: String,
           dockerUsername: String,
           dockerPassword: String): Try[Unit] = Success(())
-      def createNamespace(name: String): Try[Unit] = Success(())
-      def sparkAppVersion(): Try[String] = Success(sparkVersion)
-      def flinkAppVersion(): Try[String] = Success(flinkVersion)
-      def createCloudflowApp(spec: App.Spec, namespace: String) = Success("1")
-      def uidCloudflowApp(name: String, namespace: String) = Success("1")
-      def createMicroservicesApp(
+      override def createNamespace(name: String): Try[Unit] = Success(())
+      override def sparkAppVersion(): Try[String] = Success(sparkVersion)
+      override def flinkAppVersion(): Try[String] = Success(flinkVersion)
       override def getOperatorProtocolVersion(namespace: Option[String]): Try[String] = Success(protocolVersion)
+      override def createCloudflowApp(spec: App.Spec, namespace: String): Try[String] = Success("1")
+      override def uidCloudflowApp(name: String, namespace: String): Try[String] = Success("1")
+      override def createMicroservicesApp(
           cfSpec: App.Spec,
           namespace: String,
           specs: Map[String, Option[AkkaMicroserviceSpec]]): Try[String] =
         Success("1")
-      def configureCloudflowApp(
+      override def configureCloudflowApp(
           name: String,
           namespace: String,
           appUid: String,
           appConfig: String,
           loggingContent: Option[String],
           configs: Map[App.Deployment, Map[String, String]]): Try[Unit] = Success(())
-      def deleteCloudflowApp(app: String, namespace: String) = Success(())
-      def getPvcs(namespace: String) = Success(providedPvcs)
-      def getKafkaClusters(namespace: Option[String]) = Success(providedKafkaClusters)
-      def readCloudflowApp(name: String, namespace: String): Try[Option[App.Cr]] = Success(providedApplication)
-      def updateCloudflowApp(app: App.Cr, namespace: String): Try[App.Cr] = Success(app)
-      def getAppInputSecret(name: String, namespace: String): Try[String] = Success(providedInputSecret)
+      override def deleteCloudflowApp(app: String, namespace: String): Try[Unit] = Success(())
+      override def getPvcs(namespace: String): Try[List[String]] = Success(providedPvcs)
+      override def getKafkaClusters(namespace: Option[String]): Try[Map[String, String]] =
+        Success(providedKafkaClusters)
+      override def readCloudflowApp(name: String, namespace: String): Try[Option[App.Cr]] = Success(providedApplication)
+      override def updateCloudflowApp(app: App.Cr, namespace: String): Try[App.Cr] = Success(app)
+      override def getAppInputSecret(name: String, namespace: String): Try[String] = Success(providedInputSecret)
     }
   }
 

--- a/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
+++ b/core/cloudflow-spark/src/main/scala/cloudflow/spark/SparkStreamlet.scala
@@ -85,8 +85,8 @@ trait SparkStreamlet extends Streamlet[SparkStreamletContext] with Serializable 
     val completionFuture = completionPromise.future
 
     // these values are candidates to move to the configuration system
-    val InitialDelay = 2 seconds
-    val MonitorFrequency = 5 seconds
+    val InitialDelay = 2.seconds
+    val MonitorFrequency = 5.seconds
     implicit val system: ActorSystem = ActorSystem("spark_streamlet", context.config)
 
     val streamletQueryExecution = createLogic.buildStreamingQueries


### PR DESCRIPTION
### Status

Needs some (automated) tests.

### What changes were proposed in this pull request?

The Cloudflow CLI is currently querying all namespaces (using `inAnyNamespace`) to validate the protocol version. This changes it to first query for the namespace specified by `-n`/`--namespace` parameter, and if it is not present, then query all namespaces. Also, if no protocol version is found, it runs the query using `inAnyNamespace` to maintain some sort of compatibility with the existing behavior.


### Why are the changes needed?

In environments where users cannot query all namespaces, the CLI fails to run operations since it fails to run the query.


### Does this PR introduce any user-facing change?

I don't think so.
