### PR TITLE
Install the CRD before the helm charts and remove the CRD creation from the operator

### DIFF
--- a/core/cloudflow-it/Makefile
+++ b/core/cloudflow-it/Makefile
@@ -46,6 +46,8 @@ prepare-cluster:
 		https://github.com/lightbend/flink-operator/releases/download/v0.8.2/flink-operator-0.8.2.tgz \
 		--set operatorVersion="v0.5.0" \
 		--namespace cloudflow)
+	@echo '****** Installing Cloudflow CRD'
+	kubectl apply -f ../cloudflow-crd/kubernetes/cloudflow-crd.yaml
 	@echo '****** Installing Cloudflow Operator'
 	helm repo add cloudflow-helm-charts https://lightbend.github.io/cloudflow-helm-charts/ | true
 	helm repo update

--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/Main.scala
@@ -144,13 +144,9 @@ object Main extends {
       case Some(crd) if crd.getSpec.getVersion == App.GroupVersion =>
         system.log.info(s"CRD found at version ${App.GroupVersion}")
       case _ =>
-        client
-          .apiextensions()
-          .v1beta1()
-          .customResourceDefinitions()
-          .inNamespace(settings.podNamespace)
-          .withName(App.ResourceName)
-          .create(App.Crd)
+        system.log.error(
+          s"Cloudflow CRD not found, please install it: 'kubectl apply -f https://raw.githubusercontent.com/lightbend/cloudflow/v${BuildInfo.version}/core/cloudflow-crd/kubernetes/cloudflow-crd.yaml'")
+        throw new Exception("Cloudflow CRD not found")
     }
   }
 

--- a/docs/shared-content-source/docs/modules/administration/pages/installing-cloudflow.adoc
+++ b/docs/shared-content-source/docs/modules/administration/pages/installing-cloudflow.adoc
@@ -9,7 +9,12 @@ It also shows how to install Kafka, Spark, and Flink operators that integrate wi
 In this guide, we will use Helm to install Cloudflow.
 Please see xref:get-started:prepare-development-environment.adoc#_download_and_install_the_cloudflow_cli[Preparing a development environment] for how to download and install the Cloudflow CLI. 
 
-The first step is to create the namespace, if it does not exist yet, to install Cloudflow into:
+The first step is to create the Cloudflow CRD in the cluster:
+
+[subs="attributes+"]
+  kubectl apply -f https://raw.githubusercontent.com/lightbend/cloudflow/v{cloudflow-version}/core/cloudflow-crd/kubernetes/cloudflow-crd.yaml
+
+next the namespace, if it does not exist yet, to install Cloudflow into:
 
   kubectl create ns cloudflow
 


### PR DESCRIPTION
From this PR:
https://github.com/lightbend/cloudflow-helm-charts/pull/22/files#diff-08bec0d8da17f5482f6840b57e144767f8250cafd31b80a37e13e494d2236b71R71-R78

the Cloudflow operator cannot create anymore the CRD.
Here we fix the integration tests, document how to install the CRD, and remove the creation of it from the operator with a specific error message.