### PR TITLE
Fix yq syntax for java/scala docs generation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -114,7 +114,7 @@ list-todos: html
 # Generate the ScalaDoc and the JavaDoc, for the old versions
 all_javascaladocs:
 	@echo "Building old java and scala docs"
-	(yq e '.content.sources[0].branches.*' docs-source/site.yml | xargs -n1 ./build-javascaladocs.sh)
+	(yq e '.content.sources[0].branches.[]' docs-source/site.yml | xargs -n1 ./build-javascaladocs.sh)
 
 print-site:
 	# The result directory with the contents of this build:


### PR DESCRIPTION
Thanks to @marcospereira , here I cherry-pick the bug noticed in:
https://github.com/lightbend/cloudflow/pull/1088#discussion_r690848061
