### PR TITLE
fix: bumping up version

### DIFF
--- a/docs/shared-content-source/docs/modules/administration/pages/how-to-install-and-use-strimzi.adoc
+++ b/docs/shared-content-source/docs/modules/administration/pages/how-to-install-and-use-strimzi.adoc
@@ -90,7 +90,7 @@ spec:
       deleteClaim: false
       size: 100Gi
       type: persistent-claim
-    version: 2.7.1
+    version: 3.0.0
   zookeeper:
     livenessProbe:
       initialDelaySeconds: 15


### PR DESCRIPTION
As per documentation https://github.com/strimzi/strimzi-kafka-operator/releases with the new release, the Kafka CR doesn't work any more with version 2.7.1. Deploy a CR with that version raises an exception that states that 2.7.1 is not supported anymore and you need to choose among 2.8.0, 2.8.1, and 3.0.0.
I have chosen 3.0.0 only to be the latest, for no other reason.


