### PR TITLE
removing version so it sets it to latest

### DIFF
--- a/core/cloudflow-it/kafka-cluster.yaml
+++ b/core/cloudflow-it/kafka-cluster.yaml
@@ -34,7 +34,6 @@ spec:
       deleteClaim: false
       size: 1Gi
       type: persistent-claim
-    version: 2.7.1
   zookeeper:
     livenessProbe:
       initialDelaySeconds: 15


### PR DESCRIPTION
I tested it with `preparing-cluster`. The created default version was 3.0.0 in this case.