### PR TITLE
Version is not needed

### DIFF
--- a/docs/shared-content-source/docs/modules/administration/pages/how-to-install-and-use-strimzi.adoc
+++ b/docs/shared-content-source/docs/modules/administration/pages/how-to-install-and-use-strimzi.adoc
@@ -90,7 +90,6 @@ spec:
       deleteClaim: false
       size: 100Gi
       type: persistent-claim
-    version: 3.0.0
   zookeeper:
     livenessProbe:
       initialDelaySeconds: 15


### PR DESCRIPTION
I removed it from our Makefile. Also here now, no version sets it to the latest.
I'm assuming that if this CR changes drastically in the future versions we'll have a clear message indicating some field is not allowed or some other is required.

