### PR TITLE
Support for ConfigMap volumes

### DIFF
--- a/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/runner/Runner.scala
+++ b/core/cloudflow-operator/src/main/scala/cloudflow/operator/action/runner/Runner.scala
@@ -442,6 +442,21 @@ object PodsConfig {
                   .withReadOnly(pvc.readOnly)
                   .build())
               .build()
+          case cm: CloudflowConfig.ConfigMapVolume =>
+            new VolumeBuilder()
+              .withName(name)
+              .withConfigMap(
+                new ConfigMapVolumeSourceBuilder()
+                  .withName(cm.name)
+                  .withOptional(cm.optional)
+                  .withItems(cm.items
+                    .map {
+                      case (k, item) => new KeyToPathBuilder().withKey(k).withPath(item.path).build()
+                    }
+                    .toList
+                    .asJava)
+                  .build())
+              .build()
           case unknown =>
             logger.error(s"Found unknown $unknown volume type skipping")
             throw new Exception(s"Unknown volume $unknown")

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/runner/AkkaRunnerSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/runner/AkkaRunnerSpec.scala
@@ -105,7 +105,7 @@ class AkkaRunnerSpec
       crd.getSpec.getTemplate.getMetadata.getLabels.get("key2") mustBe "value2"
     }
 
-    "read from config custom annotaions and add them to the pod spec" in {
+    "read from config custom annotations and add them to the pod spec" in {
 
       val crd =
         akkaRunner.resource(
@@ -196,6 +196,76 @@ class AkkaRunnerSpec
         .map(v => (v.getName, v.getSecret.getSecretName)) must contain allElementsOf List(
         ("foo", "mysecret"),
         ("bar", "yoursecret"))
+
+      crd.getSpec.getTemplate.getSpec.getContainers.asScala.head.getVolumeMounts.asScala.map(vm =>
+        (vm.getName, vm.getMountPath, vm.getReadOnly)) must contain allElementsOf List(
+        ("foo", "/etc/my/file", true),
+        ("bar", "/etc/mc/fly", false))
+
+    }
+
+    "read from config custom config maps and mount them" in {
+
+      val crd = akkaRunner.resource(
+        deployment = deployment,
+        app = app,
+        configSecret = getSecret("""
+                                   |kubernetes.pods.pod {
+                                   |   volumes {
+                                   |     foo {
+                                   |       config-map {
+                                   |         name = myconfigmap
+                                   |       }
+                                   |     },
+                                   |     bar {
+                                   |       config-map {
+                                   |         name = yourconfigmap
+                                   |         optional = true
+                                   |         items {
+                                   |           barkey1 {
+                                   |            path = barpath1
+                                   |           }
+                                   |           barkey2 {
+                                   |             path = barpath2
+                                   |           }
+                                   |         }
+                                   |       }
+                                   |     }
+                                   |   }
+                                   |   containers.container {
+                                   |     volume-mounts {
+                                   |       foo {
+                                   |         mount-path = "/etc/my/file"
+                                   |         read-only = true
+                                   |       },
+                                   |       bar {
+                                   |         mount-path = "/etc/mc/fly"
+                                   |         read-only =  false
+                                   |       }
+                                   |     }
+                                   |   }
+                                   |}
+                """.stripMargin))
+
+      val configMapVols = crd.getSpec.getTemplate.getSpec.getVolumes.asScala.collect {
+        case v if v.getConfigMap != null => v -> v.getConfigMap
+      }
+
+      configMapVols
+        .map { case (v, cm) => (v.getName, cm.getName, cm.getOptional) } must contain allElementsOf List(
+        ("foo", "myconfigmap", false),
+        ("bar", "yourconfigmap", true))
+
+      configMapVols
+        .collectFirst {
+          case (v, cm) if v.getName == "bar" => cm
+        }
+        .value
+        .getItems
+        .asScala
+        .map(i => (i.getKey, i.getPath)) must contain allElementsOf List(
+        ("barkey1", "barpath1"),
+        ("barkey2", "barpath2"))
 
       crd.getSpec.getTemplate.getSpec.getContainers.asScala.head.getVolumeMounts.asScala.map(vm =>
         (vm.getName, vm.getMountPath, vm.getReadOnly)) must contain allElementsOf List(

--- a/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/runner/AkkaRunnerSpec.scala
+++ b/core/cloudflow-operator/src/test/scala/cloudflow/operator/action/runner/AkkaRunnerSpec.scala
@@ -222,8 +222,8 @@ class AkkaRunnerSpec
                                    |         name = yourconfigmap
                                    |         optional = true
                                    |         items {
-                                   |           barkey1 {
-                                   |            path = barpath1
+                                   |           "app.conf" {
+                                   |             path = my-app.conf
                                    |           }
                                    |           barkey2 {
                                    |             path = barpath2
@@ -264,7 +264,7 @@ class AkkaRunnerSpec
         .getItems
         .asScala
         .map(i => (i.getKey, i.getPath)) must contain allElementsOf List(
-        ("barkey1", "barpath1"),
+        ("app.conf", "my-app.conf"),
         ("barkey2", "barpath2"))
 
       crd.getSpec.getTemplate.getSpec.getContainers.asScala.head.getVolumeMounts.asScala.map(vm =>

--- a/docs/shared-content-source/docs/modules/develop/pages/cloudflow-configuration-kubernetes.adoc
+++ b/docs/shared-content-source/docs/modules/develop/pages/cloudflow-configuration-kubernetes.adoc
@@ -137,7 +137,7 @@ It is only possible to add container ports to Akka Streamlets, the Flink and Spa
 === Volumes and Volume-Mounts
 ==== **Mounting Secrets**
 
-It possible to add a `volume` that contains a secret, and mount it into the container with `volume-mounts`. Bear in mind that each `kubernetes.pods.pod.containers.container.volume-mounts` name must match a `kubernetes.pods.pod.volumes` name in the config. 
+It's possible to add a `volume` that contains a secret, and mount it into the container with `volume-mounts`. Bear in mind that each `kubernetes.pods.pod.containers.container.volume-mounts` name must match a `kubernetes.pods.pod.volumes` name in the config.
 
 Here's a sample, and further explanation, of how to configure two secrets to be mounted on a container. 
 
@@ -181,6 +181,70 @@ As each `volume-mounts` name must match a `volumes` name, `volume-mounts.foo` ma
 |===
 | resource  | key
 | `volumes` | `kubernetes.pods.pod.volumes.[name].secret.name = [secret-name]`
+| `volume-mounts` | `pod.containers.container.volume-mounts.[name].mount-path = [some-path]`
+| `volume-mounts` | `pod.containers.container.volume-mounts.[name].read-only = [true or false]`
+|===
+
+
+==== **Mounting Config Maps**
+
+Mounting a config map works similar to mounting a secret.
+
+Here's a sample, and further explanation, of how to configure two config map's to be mounted on all the deployed containers of `my-streamlet`.
+
+[source, hocon]
+----
+cloudflow.streamlets.my-streamlet {
+  kubernetes.pods.pod {
+   volumes {
+      foo {
+        config-map {
+          name = myconfigmap1
+        }
+      }
+      bar {
+        config-map {
+          name = myconfigmap2
+          optional = true
+          items {
+            "app.conf" = {
+              path = my-app.conf
+            }
+            key2 = {
+              path = mypath2
+            }
+          }
+        }
+      }
+    }
+    containers.container {
+      volume-mounts {
+        foo {
+          mount-path = "/mnt/folderA"
+          read-only = true
+        }
+        bar {
+          mount-path = "/mnt/folderB"
+          read-only = true
+        }
+      }
+    }
+  }
+}
+----
+
+This configuration will mount all entries of `myconfigmap1` into each `my-streamlet` container under the path `/mnt/folderA/myconfigmap1` as read-only, while for `myconfigmap2` only 2 items/files be mounted at the paths `/mnt/folderB/myconfigmap2/my-app.conf` and `/mnt/folderB/myconfigmap2/mypath2`.
+This configuration also specifies `myconfigmap2` to be an https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/[`optional`] volume by using `optional = true`, while `myconfigmap1`, as per default, is a required volume.
+
+As each `volume-mounts` name must match a `volumes` name, `volume-mounts.foo` matches `volumes.foo` and `volume-mounts.bar` matches `volumes.bar`.
+
+.Configuration available to mount config maps
+[%autowidth]
+|===
+| resource  | key
+| `volumes` | `kubernetes.pods.pod.volumes.[name].config-map.name = [pvc-name]`
+| `volumes` | `kubernetes.pods.pod.volumes.[name].config-map.optional = [true or false]`
+| `volumes` | `kubernetes.pods.pod.volumes.[name].config-map.items.[key].path = [some-path]`
 | `volume-mounts` | `pod.containers.container.volume-mounts.[name].mount-path = [some-path]`
 | `volume-mounts` | `pod.containers.container.volume-mounts.[name].read-only = [true or false]`
 |===


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/lightbend/cloudflow/blob/main/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, open it as a 'Draft'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Adds support for using k8s `ConfigMap` for k8s `Volume`s. Atm only `Secret` and `Pvc` are possible.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
See: zulip thread: [Why is logging conf stored in a secret instead of ConfigMap](https://cloudflow.zulipchat.com/#narrow/stream/263236-cloudflow/topic/Why.20is.20logging.20conf.20stored.20in.20a.20secret.20instead.20of.20ConfigMap.3F)

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, it adds a new config feature.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Only tested via unit tests.

### Documentation

I did not adjust the documentation yet cos I first want to get some feedback on the PR if this feature makes sense in the way I am proposing it.

### Open questions

1. I did not test the writing of the `CloudflowConfig` yet and I am pretty sure this will not work at the moment cos `exportWriter` most likey does not treat the `ConfigMapVolumeKeyToPath` correctly. I did only see very few tests for writing the `CloudflowConfig`, thats why I am wondering if its even necessary?