### PR TITLE
Refactoring AkkaStreamletContextImpl to consolidate duplicated code

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -25,3 +25,7 @@ cloudflow-cli/src/graal
 cloudflow-it/src/it/resources/swiss-knife.json
 cloudflow-it/generated-spark-values.yaml
 /project/metals.sbt
+
+project/.boot/
+project/.ivy/
+project/.sbtboot/

--- a/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
+++ b/core/cloudflow-akka-tests/src/test/scala/cloudflow/akkastream/scaladsl/AkkaStreamletConsumerGroupSpec.scala
@@ -47,6 +47,8 @@ import AkkaStreamletConsumerGroupSpec._
 class AkkaStreamletConsumerGroupSpec extends TestcontainersKafkaSpec(ActorSystem("test", config)) {
   import system.dispatcher
 
+  val factory = new AkkaStreamletContextFactory(system)
+
   implicit override val patienceConfig = PatienceConfig(timeout = Span(10, Seconds), interval = Span(20, Millis))
 
   "Akka streamlet instances" should {
@@ -142,7 +144,7 @@ class AkkaStreamletConsumerGroupSpec extends TestcontainersKafkaSpec(ActorSystem
 
     def run(testData: List[Data], outlet: String): StreamletExecution = {
       val gen = new Generator(testData)
-      val context = new AkkaStreamletContextImpl(definition(outlet), system)
+      val context = factory.newContext(definition(outlet))
       gen.setContext(context)
       gen.run(context)
     }
@@ -176,7 +178,7 @@ class AkkaStreamletConsumerGroupSpec extends TestcontainersKafkaSpec(ActorSystem
 
     def run(streamletRef: String, receiver: TestReceiver, genOutlet: String): StreamletExecution = {
       val streamletDef = definition(streamletRef, genOutlet)
-      val context = new AkkaStreamletContextImpl(streamletDef, system)
+      val context = factory.newContext(streamletDef)
       receiver.setContext(context)
       receiver.run(context)
     }

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextFactory.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/AkkaStreamletContextFactory.scala
@@ -1,0 +1,11 @@
+package cloudflow.akkastream
+
+import akka.actor.ActorSystem
+import cloudflow.streamlets._
+
+class AkkaStreamletContextFactory(system: ActorSystem) extends StreamletContextFactory[AkkaStreamletContext] {
+
+  def newContext(definition: StreamletDefinition): AkkaStreamletContext = {
+    new AkkaStreamletContextImpl(definition, system)
+  }
+}

--- a/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
+++ b/core/cloudflow-akka/src/main/scala/cloudflow/akkastream/KafkaSinkRef.scala
@@ -28,7 +28,6 @@ import akka.stream._
 import akka.stream.scaladsl._
 
 import org.apache.kafka.clients.producer.{ Callback, RecordMetadata }
-import org.apache.kafka.common.serialization._
 
 import cloudflow.streamlets._
 
@@ -41,9 +40,9 @@ final class KafkaSinkRef[T](
     completionPromise: Promise[Dun])
     extends WritableSinkRef[T]
     with ProducerHelper {
-  private val producerSettings = ProducerSettings(system, new ByteArraySerializer, new ByteArraySerializer)
-    .withBootstrapServers(bootstrapServers)
-    .withProperties(topic.kafkaProducerProperties)
+
+  private val producerSettings: ProducerSettings[Array[Byte], Array[Byte]] =
+    producerSettings(topic, bootstrapServers)(system)
   private val producer = producerSettings.createKafkaProducer()
 
   def sink: Sink[(T, Committable), NotUsed] = {

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/Streamlet.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/Streamlet.scala
@@ -28,6 +28,8 @@ abstract class Streamlet[Context <: StreamletContext] {
 
   @transient @volatile private var ctx: Context = _
 
+  //def factory: StreamletContextFactory
+
   /**
    * Returns the [[StreamletContext]] in which this streamlet is run. It can only be accessed when the streamlet is run.
    */

--- a/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletContextFactory.scala
+++ b/core/cloudflow-streamlets/src/main/scala/cloudflow/streamlets/StreamletContextFactory.scala
@@ -1,0 +1,7 @@
+package cloudflow.streamlets
+
+trait StreamletContextFactory[Context <: StreamletContext] {
+
+  def newContext(definition: StreamletDefinition): Context
+
+}

--- a/core/project/Dependencies.scala
+++ b/core/project/Dependencies.scala
@@ -91,7 +91,7 @@ object Dependencies {
     val ficus = "com.iheart" %% "ficus" % "1.5.2"
 
     val kubeActions = "com.lightbend.akka" %% "kube-actions" % "0.1.1"
-    val kafkaClient = "org.apache.kafka" % "kafka-clients" % "3.1.0"
+    val kafkaClient = "org.apache.kafka" % "kafka-clients" % "3.1.1"
 
     val classgraph = "io.github.classgraph" % "classgraph" % "4.8.147"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactoring `AkkaStreamletContextImpl` to consolidate duplicated code and hide the constructor in a factory (`StreamletContextFactory`)

See `makeConsumerSettings`, `withGroupId` so far.
This is work in progress: submitted to verify it would be agreeable to accept such a change.

### Why are the changes needed?
Looking to add support for `committablePartitionedShardedSource`  as mentioned 
* https://cloudflow.zulipchat.com/#narrow/stream/263236-cloudflow/topic/hybrid.20runtime/near/285558740 and
* https://cloudflow.zulipchat.com/#narrow/stream/263236-cloudflow/topic/hybrid.20runtime/near/287714133

### Does this PR introduce any user-facing change?
Not yet.
Yes, `AkkaStreamlet` users will be able to leverage `committablePartitionedShardedSource`.

### How was this patch tested?
Doing just cleanup refactorings first, no extra testing should be required.
`#todo` Not yet implemented but will add tests specific for streamlets running sticky to partitions.
